### PR TITLE
Fix BPF compile on kernel 6.14+ and process snapshot crashes

### DIFF
--- a/src/tracer/prober/prober.c
+++ b/src/tracer/prober/prober.c
@@ -20,13 +20,6 @@
 #define BPF_NO_KFUNC_PROTO
 #include <linux/ptrace.h>
 
-/* Kernel version compatibility: BPF kfunc declarations were restructured
- * in kernel 6.14+, requiring empty struct placeholders */
-// #if LINUX_VERSION_CODE >= KERNEL_VERSION(6,14,0)
-// #define BPF_NO_KFUNC_PROTO
-// struct bpf_wq {};
-// #endif
-
 /* ============================================================================
  * KERNEL VERSION COMPATIBILITY
  * ============================================================================
@@ -34,9 +27,37 @@
  * kernel versions by providing missing definitions.
  */
 
-/* bpf_timer struct was introduced in kernel 5.17 */
+/* ----------------------------------------------------------------------------
+ * BPF "special field" type compatibility
+ * ----------------------------------------------------------------------------
+ * <linux/bpf.h> defines btf_field_type_size() / btf_field_type_align() as
+ * static inline functions that apply sizeof()/__alignof__() to a family of
+ * special-field structs: bpf_timer, bpf_wq, bpf_task_work, bpf_list_head,
+ * bpf_list_node, bpf_rb_root, bpf_rb_node, bpf_refcount.
+ *
+ * That header is pulled into this BPF program transitively
+ * (net/sock.h -> linux/security.h -> linux/bpf.h). Depending on the kernel,
+ * some of these structs are only *forward-declared* in the headers BCC sees,
+ * so sizeof()/__alignof__() fail with "invalid application ... to an
+ * incomplete type". The program never instantiates these structs, so an empty
+ * placeholder is enough to complete the type for the compiler.
+ *
+ * We can only declare the ones the headers leave incomplete: defining a
+ * placeholder for a struct the headers already define fully is a redefinition
+ * error, and there is no preprocessor test for "is this type complete?".
+ * Hence the per-version guards below.
+ *
+ * MAINTENANCE: if a future kernel fails to compile with
+ *   "invalid application of 'sizeof' to an incomplete type 'struct bpf_<X>'"
+ * add `struct bpf_<X> {};` here under the matching version guard. The
+ * authoritative list lives in btf_field_type_size() in <linux/bpf.h>.
+ */
 #if LINUX_VERSION_CODE < KERNEL_VERSION(5, 17, 0)
-struct bpf_timer {};
+struct bpf_timer {};       /* bpf_timer field, forward-declared from 5.17 on */
+#endif
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
+struct bpf_wq {};          /* workqueue field, added in 6.14 */
+struct bpf_task_work {};   /* task_work field, added in 6.14 */
 #endif
 
 /* BPF atomic load/store instructions - fallback definitions */
@@ -54,11 +75,6 @@ struct bpf_timer {};
 
 #ifndef BPF_F_BROADCAST
 #define BPF_F_BROADCAST (1ULL << 3)  /**< Broadcast flag for BPF maps */
-#endif
-
-/* bpf_task_work struct introduced in kernel 6.14 */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
-struct bpf_task_work {};
 #endif
 
 /* ============================================================================

--- a/src/tracer/snappers/ProcessSnapper.py
+++ b/src/tracer/snappers/ProcessSnapper.py
@@ -96,7 +96,7 @@ class ProcessSnapper:
                 name = proc.info['name'] or ''
                 working_set_size = proc.info['memory_info'].rss / 1024 
                 virtual_mem = proc.info['memory_info'].vms / 1024
-                cmdline = ' '.join(proc.info['cmdline'])
+                cmdline = ' '.join(proc.info['cmdline'] or [])
                 if self.anonymous:
                     cmdline = simple_hash(cmdline, length=12)
                 create_time = float(proc.info['create_time'])
@@ -112,10 +112,10 @@ class ProcessSnapper:
                 self.wm.append_process_log(out)
             except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess) as e:
                 # Expected errors while iterating over system processes; skip this process.
-                logger.debug(f"Skipping process {getattr(proc, 'pid', 'unknown')} due to psutil error: {e}")
+                logger("info", f"Skipping process {getattr(proc, 'pid', 'unknown')} due to psutil error: {e}")
             except Exception as e:
                 # Log unexpected errors to avoid silently hiding issues in the snapshot loop.
-                logger.warning("Unexpected error while collecting process snapshot data", exc_info=True)
+                logger("warning", f"Unexpected error while collecting process snapshot data: {e}")
         
         # Check one final time before flushing
         if not self.running:


### PR DESCRIPTION
## Summary

`iotrc.py` failed to start on kernel 6.14+ (reproduced on 6.17) and, once running, crashed the process snapshotter on every run. This fixes all three root causes.

## What changed & why

**1. BPF compilation failure (the blocker)** — On 6.14+, `<linux/bpf.h>` applies `sizeof()`/`__alignof__()` to `struct bpf_wq` and `struct bpf_task_work` inside `btf_field_type_size()`/`btf_field_type_align()`, but BCC only sees them forward-declared. The probe failed to compile with `invalid application of 'sizeof' to an incomplete type` and the tool reported the device as incompatible. Added empty placeholder structs (the program never instantiates them, so completing the type is sufficient).

While here, consolidated the three scattered, version-gated placeholder snippets into **one documented compat block** that:
- names the canonical kernel source (`btf_field_type_size()` in `<linux/bpf.h>`),
- explains why the whole struct family can't simply be blanket-defined (redefinition errors; no preprocessor "is-complete" test), and
- states the exact rule for extending it on future kernels.

**2. `TypeError: can only join an iterable`** in `ProcessSnapper._take_snapshot` — `psutil` returns `None` for `cmdline` on kernel threads / zombies, so `' '.join(None)` crashed the snapshot. Guarded with `or []`.

**3. Broken error handler** in the same loop — the `except` blocks called `logger.debug(...)`/`logger.warning(...)`, but `logger` is a plain function (`logger(scale, msg)`), not a `logging.Logger`, so the handler itself raised `AttributeError` and masked the real error. Switched to the correct call form.

## Testing

`sudo python3 iotrc.py --no-upload` on kernel 6.17.0-35-generic:
- before: exits immediately with BPF compile error + incompatible-device message
- after: compiles, attaches probes, reaches `[INFO] IO Tracer is running`, completes `Process Snapshot: completed and flushed`, and exits cleanly on stop — no tracebacks

## Reviewer notes

- The per-kernel placeholder approach is inherent to how the kernel header is written; there is no single root-level fix (detailed in the code comment). The new comment makes the next kernel bump a mechanical one-line edit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)