### PR TITLE
Enrich fs trace with completion and provenance metadata

### DIFF
--- a/docs/TRACE_FORMAT.md
+++ b/docs/TRACE_FORMAT.md
@@ -34,8 +34,10 @@ Each subdirectory contains CSV files that are automatically compressed to `.csv.
 ### CSV Header
 
 ```csv
-timestamp,operation,pid,command,filename,size,inode,flags,offset,tid
+timestamp,operation,pid,command,filename,size,inode,flags,offset,tid,mmap_prot,mmap_flags,address,cmdline,return_value,errno,bytes_completed,duration_ns,device,ppid,container_id,fs_type
 ```
+
+`return_value`, `errno`, `bytes_completed`, and `duration_ns` are populated for `READ`/`WRITE`; `device`, `ppid`, `container_id`, and `fs_type` are populated for `READ`/`WRITE`/`OPEN`. All are empty for operations that do not carry them.
 
 For operations captured and examples, see [VFS_EVENTS.md](traces/VFS_EVENTS.md).
 

--- a/docs/traces/VFS_EVENTS.md
+++ b/docs/traces/VFS_EVENTS.md
@@ -6,8 +6,8 @@
 - `do_sys_openat2` (entry) — Captures the user-provided filename string before kernel resolution
 - `do_sys_openat2` (return) — Captures the allocated file descriptor after a successful open
 - `vfs_open` — File open operations (inode and flags)
-- `vfs_read` — File read operations
-- `vfs_write` — File write operations
+- `vfs_read` (entry + return) — File read operations; the return probe records bytes read / errno and latency
+- `vfs_write` (entry + return) — File write operations; the return probe records bytes written / errno and latency
 - `vfs_fsync` / `vfs_fsync_range` — File sync operations
 - `vfs_unlink` — File deletion operations
 - `vfs_getattr` — File attribute queries
@@ -172,6 +172,16 @@ The path captured is relative to the mount namespace of the probed process. In c
 | 12 | mmap_flags | `string` | MMAP mapping flags (`MAP_*`, pipe-separated); empty for non-MMAP operations |
 | 13 | address | `string` | Mapping start address as hex (`0x...`) for `MMAP` and `MUNMAP`; for `MREMAP` formatted as `old_address -> new_address`; empty for other operations |
 | 14 | cmdline | `string` | Full command line (`argv` joined by spaces) of the process that triggered the event; empty if unresolvable (see below) |
+| 15 | return_value | `s64` | Raw syscall return value for `READ`/`WRITE` (bytes moved if `>= 0`, negative `errno` on failure); empty for other operations |
+| 16 | errno | `string` | Error name (e.g. `EAGAIN`) when a `READ`/`WRITE` failed (`return_value < 0`); empty on success or for other operations |
+| 17 | bytes_completed | `u64` | Bytes actually read/written for `READ`/`WRITE` (`return_value` when `>= 0`); empty on failure or for other operations |
+| 18 | duration_ns | `u64` | Operation duration in nanoseconds (entry → return) for `READ`/`WRITE`; empty for other operations |
+| 19 | device | `string` | Backing device of the file as `major:minor` (from `super_block->s_dev`); populated for `READ`/`WRITE`/`OPEN`; empty otherwise |
+| 20 | ppid | `u32` | Parent process ID (`real_parent->tgid`); populated for `READ`/`WRITE`/`OPEN`; empty otherwise |
+| 21 | container_id | `u64` | cgroup v2 id of the process (container identifier); populated for `READ`/`WRITE`/`OPEN`; empty otherwise |
+| 22 | fs_type | `string` | Source filesystem name derived from the superblock magic (e.g. `EXT2/3/4`, `XFS`, `BTRFS`, `OVERLAYFS`, `NFS`), letting physical-disk I/O be distinguished from network/overlay sources; populated for `READ`/`WRITE`/`OPEN`; empty otherwise |
+
+> **Note on filesystem classification (`fs_type`) and sockets:** virtual/pseudo filesystems (procfs, sysfs, tmpfs, cgroupfs, debugfs, …) and sockets/pipes are filtered out at the eBPF layer by `is_regular_file()`, so they never appear as fs-trace rows. Their *absence* is the signal that an access was virtual/socket I/O rather than physical filesystem I/O. The `fs_type` column then names the concrete backing filesystem of the events that do appear, so physical-disk filesystems (`EXT2/3/4`, `XFS`, `BTRFS`, …) can be told apart from network (`NFS`, `CIFS`) and container-overlay (`OVERLAYFS`) sources.
 
 ## `cmdline` Field
 

--- a/src/tracer/FlagMapper.py
+++ b/src/tracer/FlagMapper.py
@@ -746,3 +746,56 @@ class FlagMapper:
             if flags & flag:
                 result.append(name)
         return "|".join(result) if result else ""
+
+    # =====================================================================
+    # VFS completion / provenance mappings
+    # =====================================================================
+
+    # Common errno values (magnitude) seen on VFS read/write failures.
+    errno_map = {
+        1: "EPERM", 2: "ENOENT", 4: "EINTR", 5: "EIO", 9: "EBADF",
+        11: "EAGAIN", 12: "ENOMEM", 13: "EACCES", 14: "EFAULT", 16: "EBUSY",
+        21: "EISDIR", 22: "EINVAL", 24: "EMFILE", 27: "EFBIG", 28: "ENOSPC",
+        32: "EPIPE", 36: "ENAMETOOLONG", 40: "ELOOP", 75: "EOVERFLOW",
+        122: "EDQUOT",
+    }
+
+    # Superblock magic -> filesystem name. Used to classify the source of an
+    # I/O event (physical disk fs vs network fs vs container overlay, etc.).
+    fs_type_map = {
+        0xEF53: "EXT2/3/4",
+        0x58465342: "XFS",
+        0x9123683E: "BTRFS",
+        0xF2F52010: "F2FS",
+        0x4D44: "FAT",
+        0x2011BAB0: "EXFAT",
+        0x5346544E: "NTFS",
+        0x73717368: "SQUASHFS",
+        0x9660: "ISOFS",
+        0x52654973: "REISERFS",
+        0x3434: "NILFS",
+        0x6969: "NFS",
+        0xFF534D42: "CIFS",
+        0x65735546: "FUSE",
+        0x794C7630: "OVERLAYFS",
+        0x01021994: "TMPFS",
+        0x858458F6: "RAMFS",
+        0x9FA0: "PROCFS",
+        0x62656572: "SYSFS",
+        0x1373: "DEVFS",
+    }
+
+    @classmethod
+    def format_errno(cls, code):
+        """Map an errno magnitude to its name. Returns '' for 0."""
+        if not code:
+            return ""
+        code = abs(int(code))
+        return cls.errno_map.get(code, f"ERRNO({code})")
+
+    @classmethod
+    def format_fs_type(cls, magic):
+        """Map a superblock magic number to a filesystem name."""
+        if not magic:
+            return ""
+        return cls.fs_type_map.get(int(magic), f"FS(0x{int(magic):x})")

--- a/src/tracer/IOTracer.py
+++ b/src/tracer/IOTracer.py
@@ -299,12 +299,47 @@ class IOTracer:
                 # CLOSE events buffered after PROCESS_EXIT can still resolve it.
                 self.mmap_regions.pop(event.pid, None)
 
+        # Completion metadata — READ/WRITE carry the syscall return value, errno,
+        # completed byte count, and duration (filled by the kretprobes).
+        return_value = ""
+        errno_val = ""
+        bytes_completed = ""
+        duration_ns = ""
+        if op_name in ("READ", "WRITE"):
+            ret = event.ret_val
+            return_value = str(ret)
+            if ret < 0:
+                errno_val = self.flag_mapper.format_errno(-ret)
+            else:
+                bytes_completed = str(ret)
+            duration_ns = str(event.latency_ns) if event.latency_ns else ""
+
+        # Provenance metadata — populated for READ/WRITE/OPEN.
+        dev_val = self._format_dev(event.dev) if getattr(event, "dev", 0) else ""
+        ppid_val = event.ppid if getattr(event, "ppid", 0) else ""
+        container_id = event.cgroup_id if getattr(event, "cgroup_id", 0) else ""
+        fs_type_val = (
+            self.flag_mapper.format_fs_type(event.fs_magic)
+            if getattr(event, "fs_magic", 0) else ""
+        )
+
         output = format_csv_row(
             timestamp, op_name, event.pid, comm, filename, size_val, inode_val,
             flags_val, offset_val, tid_val, mmap_prot_val, mmap_flags_val,
-            address_val, cmdline
+            address_val, cmdline,
+            return_value, errno_val, bytes_completed, duration_ns,
+            dev_val, ppid_val, container_id, fs_type_val
         )
         self.writer.append_fs_log(output)
+
+    @staticmethod
+    def _format_dev(dev: int) -> str:
+        """Decode a dev_t (super_block->s_dev) into 'major:minor'."""
+        if not dev:
+            return ""
+        major = (dev >> 20) & 0xfff
+        minor = dev & 0xfffff
+        return f"{major}:{minor}"
 
     def _track_mmap_region(self, pid: int, start: int, length: int, filename: str) -> None:
         """Track file-backed mappings so later munmap events can recover filenames."""

--- a/src/tracer/KernelProbeTracker.py
+++ b/src/tracer/KernelProbeTracker.py
@@ -167,6 +167,10 @@ class KernelProbeTracker:
             # VFS (Virtual File System) probes
             self.add_kprobe("vfs_read", "trace_vfs_read")
             self.add_kprobe("vfs_write", "trace_vfs_write")
+            # Return probes complete READ/WRITE events with the syscall return
+            # value (bytes moved / errno) and the operation latency.
+            self.add_kretprobe("vfs_read", "trace_vfs_read_ret")
+            self.add_kretprobe("vfs_write", "trace_vfs_write_ret")
             # Capture the user-provided filename before the kernel resolves it.
             # Must be registered BEFORE vfs_open so the path is staged in time.
             # Uses the same fallback chain as the kretprobe.

--- a/src/tracer/prober/prober.c
+++ b/src/tracer/prober/prober.c
@@ -232,6 +232,14 @@ struct data_t {
   u32 mmap_flags;                 /**< mmap mapping flags (MAP_*) for MMAP events */
   u64 old_addr;                   /**< mremap: old mapping start address (0 for other ops) */
   u64 old_size;                   /**< mremap: old mapping length (0 for other ops) */
+  /* Completion metadata (populated by the READ/WRITE return probes) */
+  s64 ret_val;                    /**< Syscall return value: bytes moved on success, -errno on failure (READ/WRITE) */
+  u64 latency_ns;                 /**< Operation duration in ns from entry to return (READ/WRITE) */
+  /* Provenance metadata (populated for READ/WRITE/OPEN) */
+  u32 dev;                        /**< Backing device id (super_block->s_dev, major:minor encoded) */
+  u32 ppid;                       /**< Parent process ID (real_parent->tgid) */
+  u64 cgroup_id;                  /**< cgroup v2 id — container identifier */
+  u32 fs_magic;                   /**< Superblock magic for filesystem-type classification */
 };
 
 /**
@@ -572,6 +580,10 @@ BPF_HASH(open_staging, u64, struct data_t, 4096);
 /* Staged MMAP event from do_mmap entry, completed by the do_mmap kretprobe. */
 BPF_HASH(mmap_staging, u64, struct data_t, 4096);
 
+/* Staged READ/WRITE event from the vfs_read/vfs_write entry probe, completed by
+ * the matching kretprobe which fills in the return value and latency. */
+BPF_HASH(rw_staging, u64, struct data_t, 10240);
+
 /* Staged mremap args from sys_mremap entry, consumed by the kretprobe. */
 BPF_HASH(mremap_staging, u64, struct mremap_args, 4096);
 
@@ -610,6 +622,48 @@ static u64 get_file_inode(struct file *file) {
     inode = file->f_path.dentry->d_inode->i_ino;
   }
   return inode;
+}
+
+/**
+ * @brief Get the parent process ID (tgid of real_parent) of the current task.
+ *
+ * @return Parent PID, or 0 if it cannot be read.
+ */
+static __always_inline u32 get_ppid(void) {
+  struct task_struct *task = (struct task_struct *)bpf_get_current_task();
+  struct task_struct *parent = NULL;
+  u32 ppid = 0;
+  if (task) {
+    bpf_probe_read_kernel(&parent, sizeof(parent), &task->real_parent);
+    if (parent) {
+      bpf_probe_read_kernel(&ppid, sizeof(ppid), &parent->tgid);
+    }
+  }
+  return ppid;
+}
+
+/**
+ * @brief Read the backing device id and filesystem magic from a file's
+ *        superblock, used to record the mount/device and to classify the
+ *        filesystem source (physical vs network vs overlay, etc.).
+ *
+ * @param file     Kernel file structure
+ * @param dev      Out: super_block->s_dev (major:minor encoded); untouched on failure
+ * @param fs_magic Out: super_block->s_magic; untouched on failure
+ */
+static __always_inline void get_file_source(struct file *file, u32 *dev,
+                                            u32 *fs_magic) {
+  if (!file) return;
+  struct dentry *dentry = NULL;
+  bpf_probe_read_kernel(&dentry, sizeof(dentry), &file->f_path.dentry);
+  if (!dentry) return;
+  struct super_block *sb = NULL;
+  bpf_probe_read_kernel(&sb, sizeof(sb), &dentry->d_sb);
+  if (!sb) return;
+  bpf_probe_read_kernel(dev, sizeof(*dev), &sb->s_dev);
+  unsigned long magic = 0;
+  bpf_probe_read_kernel(&magic, sizeof(magic), &sb->s_magic);
+  *fs_magic = (u32)magic;
 }
 
 /**
@@ -894,8 +948,39 @@ int trace_vfs_read(struct pt_regs *ctx, struct file *file, char __user *buf,
   // We capture 0 to indicate it needs user-space correlation
   data.fd = 0;
 
-  events.perf_submit(ctx, &data, sizeof(data));
+  // Provenance metadata: parent PID, container (cgroup) id, backing
+  // device, and filesystem magic for source classification.
+  data.ppid = get_ppid();
+  data.cgroup_id = bpf_get_current_cgroup_id();
+  get_file_source(file, &data.dev, &data.fs_magic);
 
+  // Defer submission to the kretprobe, which records the return value
+  // (bytes read or negative errno) and the operation latency.
+  rw_staging.update(&pid_tgid, &data);
+
+  return 0;
+}
+
+/**
+ * @brief Trace vfs_read() return — record bytes read / errno and latency.
+ *
+ * Completes the event staged by trace_vfs_read() with the syscall return
+ * value and the entry-to-return duration, then submits it.
+ *
+ * @param ctx  BPF context (return value via PT_REGS_RC)
+ * @return     0
+ */
+int trace_vfs_read_ret(struct pt_regs *ctx) {
+  u64 pid_tgid = bpf_get_current_pid_tgid();
+  struct data_t *data = rw_staging.lookup(&pid_tgid);
+  if (!data) {
+    return 0;
+  }
+  long ret = PT_REGS_RC(ctx);
+  data->ret_val = (s64)ret;
+  data->latency_ns = bpf_ktime_get_ns() - data->ts;
+  events.perf_submit(ctx, data, sizeof(*data));
+  rw_staging.delete(&pid_tgid);
   return 0;
 }
 
@@ -941,11 +1026,42 @@ int trace_vfs_write(struct pt_regs *ctx, struct file *file,
   if (pos) {
     bpf_probe_read_kernel(&data.offset, sizeof(data.offset), pos);
   }
-  
+
   data.fd = 0;
 
-  events.perf_submit(ctx, &data, sizeof(data));
+  // Provenance metadata: parent PID, container (cgroup) id, backing
+  // device, and filesystem magic for source classification.
+  data.ppid = get_ppid();
+  data.cgroup_id = bpf_get_current_cgroup_id();
+  get_file_source(file, &data.dev, &data.fs_magic);
 
+  // Defer submission to the kretprobe, which records the return value
+  // (bytes written or negative errno) and the operation latency.
+  rw_staging.update(&pid_tgid, &data);
+
+  return 0;
+}
+
+/**
+ * @brief Trace vfs_write() return — record bytes written / errno and latency.
+ *
+ * Completes the event staged by trace_vfs_write() with the syscall return
+ * value and the entry-to-return duration, then submits it.
+ *
+ * @param ctx  BPF context (return value via PT_REGS_RC)
+ * @return     0
+ */
+int trace_vfs_write_ret(struct pt_regs *ctx) {
+  u64 pid_tgid = bpf_get_current_pid_tgid();
+  struct data_t *data = rw_staging.lookup(&pid_tgid);
+  if (!data) {
+    return 0;
+  }
+  long ret = PT_REGS_RC(ctx);
+  data->ret_val = (s64)ret;
+  data->latency_ns = bpf_ktime_get_ns() - data->ts;
+  events.perf_submit(ctx, data, sizeof(*data));
+  rw_staging.delete(&pid_tgid);
   return 0;
 }
 
@@ -1031,6 +1147,12 @@ int trace_vfs_open(struct pt_regs *ctx, const struct path *path,
   data.op = OP_OPEN;
   data.size = 0;
   bpf_probe_read_kernel(&data.flags, sizeof(data.flags), &file->f_flags);
+
+  // Provenance metadata: parent PID, container (cgroup) id, backing
+  // device, and filesystem magic for source classification.
+  data.ppid = get_ppid();
+  data.cgroup_id = bpf_get_current_cgroup_id();
+  get_file_source(file, &data.dev, &data.fs_magic);
 
   // Prefer the full path captured from the syscall entry (trace_do_sys_openat2_entry).
   // This is the string the caller passed — for library loads and most file opens


### PR DESCRIPTION
## Summary

Addresses the fs-trace feedback by enriching the VFS event stream with completion and provenance metadata. Eight new CSV columns are appended (existing columns keep their positions).

### 1. Syscall return value, errno, completed bytes, duration — `READ`/`WRITE`
`vfs_read` / `vfs_write` are now traced with **entry + return probe pairs**. The entry probe stages the event per-thread in a new `rw_staging` map; the kretprobe fills in:
- `return_value` — raw syscall return (bytes on success, `-errno` on failure)
- `errno` — decoded error name when `return_value < 0`
- `bytes_completed` — actual bytes moved (`return_value` when `>= 0`)
- `duration_ns` — entry→return latency

(The existing `size` column continues to report the *requested* byte count.)

### 2. Absolute path, mount/device, thread ID, parent PID, container ID
- Absolute path (`filename`) and thread ID (`tid`) were already present.
- Added `device` (`super_block->s_dev` as `major:minor`), `ppid` (`real_parent->tgid`), and `container_id` (cgroup v2 id), populated for `READ`/`WRITE`/`OPEN`.

### 3. Distinguish virtual filesystems and sockets from physical I/O
- Added `fs_type`, derived from the superblock magic (`EXT2/3/4`, `XFS`, `BTRFS`, `OVERLAYFS`, `NFS`, `CIFS`, …).
- Virtual/pseudo filesystems (procfs, sysfs, tmpfs, cgroupfs, …) and sockets/pipes remain filtered out by `is_regular_file()`, so their *absence* already signals non-physical I/O; `fs_type` then names the concrete backing filesystem of the events that do appear, separating physical-disk I/O from network/overlay sources. (Per discussion, kept the existing filtering rather than re-introducing socket/virtual events.)

### 4. Filter/sample monitoring sources (htop)
Out of scope per discussion — not included.

## Changes
- `prober.c`: new `data_t` fields; `rw_staging` map; `get_ppid()` / `get_file_source()` helpers; `vfs_read`/`vfs_write` converted to entry+return with `trace_vfs_read_ret` / `trace_vfs_write_ret`; OPEN enriched with provenance.
- `KernelProbeTracker.py`: register the two kretprobes.
- `FlagMapper.py`: `format_errno`, `format_fs_type` (+ maps).
- `IOTracer.py`: render the 8 new columns; `_format_dev` helper.
- `docs`: VFS_EVENTS.md field table + probe list; TRACE_FORMAT.md header (also corrected its previously-stale VFS column list).

## Verification
- All Python compiles.
- `prober.c` brace/paren balance preserved (same brace delta as before; parens balanced).
- ⚠️ **The eBPF program could not be BCC-compiled or run in this sandbox** (no kernel headers/BCC). The entry/return staging, map-pointer `perf_submit`, and `bpf_get_current_cgroup_id()` follow patterns already used in the codebase, but this needs a real `bcc` build + run to validate the verifier accepts it and the new columns populate as expected.

## Scope note
`return/errno/bytes/duration` are READ/WRITE-only and `device/ppid/container_id/fs_type` are READ/WRITE/OPEN-only (per the agreed scope); other operations emit these columns empty. Extending provenance to the remaining ops is a straightforward follow-up if wanted.

https://claude.ai/code/session_01FwemkGDyJhq3QNQLjzie4w

---
_Generated by [Claude Code](https://claude.ai/code/session_01FwemkGDyJhq3QNQLjzie4w)_