### PR TITLE
Capture io_uring SQE fields and mirror async I/O into the fs trace

### DIFF
--- a/docs/traces/IO_URING_EVENTS.md
+++ b/docs/traces/IO_URING_EVENTS.md
@@ -4,11 +4,24 @@
 
 **Kernel Probes Attached:**
 - `__io_uring_enter` / `__sys_io_uring_enter` — io_uring_enter syscall
+- `io_prep_rw` (or per-op `io_prep_read{,v,_fixed}` / `io_prep_write{,v,_fixed}`) — SQE field capture
 - `io_queue_sqe` / `io_submit_sqe` — SQE submission
 - `io_req_complete_post` / `io_req_complete` — Completion
 - `io_wq_submit_work` — Async worker execution
 
 > **Note:** The `io_uring:io_uring_submit_sqe` and `io_uring:io_uring_complete` tracepoints are disabled by default due to incompatible struct field layouts across kernel versions. The kprobe-based implementations above provide cross-kernel compatibility.
+
+### SQE field capture and file correlation
+
+The SUBMIT kprobe on `io_queue_sqe` only receives the internal `struct io_kiocb`, whose layout is **not** ABI-stable across kernel releases, so reading `opcode`/`fd`/`len`/`offset`/`user_data` from it directly is unreliable. Instead these fields are captured at request-**prep** time:
+
+- `trace_io_uring_prep_rw` attaches to the read/write prep handler (`io_prep_rw`), which is dispatched through the opcode table (`def->prep`) and therefore is not inlined. It receives the **UAPI `struct io_uring_sqe`** (PARM2), whose leading field offsets are stable for all io_uring kernels. A minimal mirror (`io_uring_sqe_min`) reads `opcode`, `flags`, `ioprio`, `fd`, `off`, `len`, `user_data` and `buf_index`.
+- The same probe reads `req->file` (the first member of `struct io_kiocb` on modern kernels) and, when it is a regular file on a real filesystem, records the backing **inode**, **device** and **superblock magic** via the same helpers used by the VFS probes.
+- These values are staged in the `io_uring_submit_map` (keyed by the `io_kiocb` pointer) and consumed by the SUBMIT, COMPLETE and WORKER probes.
+
+If the prep symbol is unavailable on a given kernel, the SUBMIT probe falls back to reading `req->file` directly for inode/device/fs, and the SQE-only fields (`opcode`, `len`, `offset`, `user_data`) simply remain empty — graceful degradation rather than failure.
+
+> **Note:** This captures SQE fields for the read/write opcode families (the bulk of filesystem I/O). Other opcodes (e.g. `OPENAT`, `STATX`) are not prepped through `io_prep_rw`, so their `opcode`/`fd`/`len`/`offset` columns may be empty.
 
 ## Data Captured
 
@@ -52,6 +65,12 @@
 | 36 | CQ Tail | `u32` | Completion queue tail (optional) |
 | 37 | SQ Depth | `u32` | SQ backlog (sq_tail - sq_head) |
 | 38 | CQ Depth | `u32` | CQ backlog (cq_tail - cq_head) |
+| 39 | Inode | `u64` | Backing file inode for file-backed ops; empty otherwise |
+| 40 | Filename | `string` | Resolved file path (from the inode→path cache populated by OPEN events); empty if unresolved |
+| 41 | Device | `string` | Backing device as `major:minor` (from `super_block->s_dev`); empty otherwise |
+| 42 | FS Type | `string` | Source filesystem name from the superblock magic (e.g. `EXT2/3/4`, `XFS`, `BTRFS`); empty otherwise |
+
+> Columns 39–42 are appended to the original 38-column schema, so parsers that read only the first 38 fields are unaffected.
 
 ## Event Types
 
@@ -140,6 +159,16 @@ SUBMIT and COMPLETE events share the same `Req Ptr`, enabling latency calculatio
 ```
 latency_ns = complete_ts_ns - submit_ts_ns
 ```
+
+## Mirroring into the fs/VFS trace
+
+io_uring read/write operations call `->read_iter`/`->write_iter` directly and **never pass through `vfs_read`/`vfs_write`**, so they are invisible to the VFS probes. To make async I/O visible alongside syscall I/O, each completed io_uring read/write is also emitted into the main **fs/VFS trace** (`fs/fs_*.csv`) using the standard VFS 22-column schema:
+
+- **Mirrored opcodes:** `READV`, `READ_FIXED`, `READ` → `READ`; `WRITEV`, `WRITE_FIXED`, `WRITE` → `WRITE`.
+- **Trigger:** COMPLETE events only (so `bytes_completed`/`duration_ns` are known), and only when a backing inode was resolved.
+- **Columns:** filename/inode/device/fs_type come from the prep-time file capture; `size` is the SQE length, `bytes_completed`/`errno` from the CQE result, `duration_ns` from the submit→complete latency. The generic `flags` column carries the decoded **SQE flags** (`FIXED_FILE|ASYNC|IO_LINK…`) in place of the open-file `O_*` flags, which are not available on the io_uring path.
+
+`fsync` is intentionally **not** mirrored: io_uring `FSYNC` calls `vfs_fsync` internally and is therefore already captured by the VFS fsync probe — mirroring it would double-count. The full async-specific detail (req_ptr, user_data, worker, queue depths) always remains in the dedicated io_uring CSV.
 
 ## Analysis Use Cases
 

--- a/docs/traces/VFS_EVENTS.md
+++ b/docs/traces/VFS_EVENTS.md
@@ -22,6 +22,8 @@
 - `vfs_fallocate` — File space pre-allocation operations
 - `do_sendfile` / `__do_sendfile` — Efficient file-to-file transfer operations
 
+> **io_uring-origin rows:** `READ`/`WRITE` operations issued via io_uring bypass `vfs_read`/`vfs_write` (they call `->read_iter`/`->write_iter` directly), so they are mirrored into this trace from the io_uring instrumentation rather than captured by a VFS probe. They use the same schema; their `flags` column carries io_uring SQE flags (`FIXED_FILE|ASYNC|…`) instead of `O_*` flags, and `ppid`/`container_id` are empty. See [IO_URING_EVENTS.md](IO_URING_EVENTS.md#mirroring-into-the-fsvfs-trace). Each such row also has a full-detail counterpart in the io_uring CSV.
+
 ## Filename Resolution
 
 The `filename` field contains the best available path for the file at event time. Full absolute paths are resolved entirely inside the kernel at probe time before the process can exit, so even output from short-lived processes (e.g. `cat`, `ls`) contains correct paths.

--- a/src/tracer/IOTracer.py
+++ b/src/tracer/IOTracer.py
@@ -786,6 +786,31 @@ class IOTracer:
         sq_depth = str(e.sq_depth) if e.sq_depth else ""
         cq_depth = str(e.cq_depth) if e.cq_depth else ""
 
+        # File correlation — the prep probe records the backing file's inode,
+        # device and filesystem for file-backed ops. Resolve the path from the
+        # inode→path cache populated by OPEN events (same strategy as VFS events)
+        # so io_uring I/O carries the same file identity as the fs trace.
+        inode_val = e.inode if getattr(e, "inode", 0) else ""
+        dev_val = self._format_dev(e.dev) if getattr(e, "dev", 0) else ""
+        fs_type_val = (
+            self.flag_mapper.format_fs_type(e.fs_magic)
+            if getattr(e, "fs_magic", 0) else ""
+        )
+        filename = ""
+        if getattr(e, "inode", 0):
+            cached = self.path_resolver.inode_to_path.get(e.inode)
+            if cached:
+                filename = cached
+            if self.anonymous and filename:
+                filename = hash_filename_in_path(Path(filename))
+
+        # Surface io_uring file READ/WRITE in the main fs/VFS trace stream so
+        # async I/O appears alongside syscall reads/writes. Mirror only on
+        # COMPLETE (result/latency known) and only read/write opcodes, which
+        # bypass vfs_read/vfs_write and would otherwise be invisible there.
+        if e.event_type == 2:
+            self._mirror_io_uring_to_fs(e, comm, filename, ts, dev_val, fs_type_val)
+
         # Build CSV row matching the unified schema from the guide
         output = format_csv_row(
             ts.strftime("%Y-%m-%d %H:%M:%S.%f"),
@@ -826,8 +851,75 @@ class IOTracer:
             cq_tail,
             sq_depth,
             cq_depth,
+            inode_val,
+            filename,
+            dev_val,
+            fs_type_val,
         )
         self.writer.append_io_uring_log(output)
+
+    def _mirror_io_uring_to_fs(self, e, comm, filename, ts, dev_val, fs_type_val):
+        """
+        Emit an fs/VFS-shaped row for a completed io_uring file READ/WRITE.
+
+        io_uring read/write operations call ``->read_iter``/``->write_iter``
+        directly and never pass through ``vfs_read``/``vfs_write``, so they are
+        invisible to the VFS probes. To make async I/O visible alongside
+        syscall I/O, this mirrors COMPLETE events for the read/write opcode
+        families into the fs log using the same 22-column schema as
+        ``_print_event``.
+
+        fsync is intentionally not mirrored: io_uring FSYNC calls ``vfs_fsync``
+        internally and is therefore already captured by the VFS fsync probe;
+        mirroring it would double-count.
+
+        Args:
+            e: The io_uring perf event.
+            comm: Decoded process name.
+            filename: Resolved file path (may be empty).
+            ts: Event datetime (matches the fs-log timestamp format).
+            dev_val: Pre-formatted ``major:minor`` device string.
+            fs_type_val: Pre-formatted filesystem name.
+        """
+        # IORING_OP_* read/write opcode families → unified fs operation name.
+        op_map = {
+            1: "READ",   # READV
+            4: "READ",   # READ_FIXED
+            22: "READ",  # READ
+            2: "WRITE",  # WRITEV
+            5: "WRITE",  # WRITE_FIXED
+            23: "WRITE", # WRITE
+        }
+        op_name = op_map.get(e.opcode)
+        if not op_name or not getattr(e, "inode", 0):
+            return
+
+        ret = e.result
+        return_value = str(ret)
+        errno_val = ""
+        bytes_completed = ""
+        if ret < 0:
+            errno_val = self.flag_mapper.format_errno(-ret)
+        else:
+            bytes_completed = str(ret)
+        duration_ns = str(e.latency_ns) if e.latency_ns else ""
+
+        offset_val = e.offset if e.offset else ""
+        tid_val = e.tid if e.tid else ""
+        size_val = e.len if e.len else 0
+        # io_uring rows carry the SQE flags (FIXED_FILE|ASYNC|IO_LINK…) in the
+        # generic flags column in place of the open-file O_* flags, which are
+        # not available on the io_uring path.
+        flags_val = self.flag_mapper.format_io_uring_sqe_flags(e.sqe_flags)
+        cmdline = self._read_cmdline_cached(e.pid)
+
+        output = format_csv_row(
+            ts, op_name, e.pid, comm, filename, size_val, e.inode,
+            flags_val, offset_val, tid_val, "", "", "", cmdline,
+            return_value, errno_val, bytes_completed, duration_ns,
+            dev_val, "", "", fs_type_val
+        )
+        self.writer.append_fs_log(output)
 
     def _cleanup(self, signum, frame):
         self.running = False

--- a/src/tracer/KernelProbeTracker.py
+++ b/src/tracer/KernelProbeTracker.py
@@ -387,6 +387,33 @@ class KernelProbeTracker:
                 if self.developer_mode:
                     logger("warning", "io_uring_enter probe not available - ENTER events disabled")
 
+            # io_uring SQE field capture (opcode/fd/len/offset/user_data + backing
+            # file). The SUBMIT kprobe on io_queue_sqe only has the io_kiocb, whose
+            # layout is not ABI-stable; the read/write prep handler receives the
+            # UAPI io_uring_sqe (stable offsets) and the io_kiocb, so we capture the
+            # SQE fields there and stage them for the SUBMIT/COMPLETE probes. The
+            # shared helper io_prep_rw covers all rw opcodes; fall back to the
+            # per-op prep handlers when it is inlined/renamed on a given kernel.
+            prep_attached = False
+            for sym in (b'io_prep_rw', b'__io_prep_rw'):
+                if BPF.get_kprobe_functions(sym):
+                    self.add_kprobe(sym.decode(), "trace_io_uring_prep_rw")
+                    prep_attached = True
+                    if self.developer_mode:
+                        logger("info", f"io_uring SQE capture enabled via {sym.decode()}")
+                    break
+            if not prep_attached:
+                for sym in (b'io_prep_readv', b'io_prep_writev',
+                            b'io_prep_read', b'io_prep_write',
+                            b'io_prep_read_fixed', b'io_prep_write_fixed'):
+                    if BPF.get_kprobe_functions(sym):
+                        self.add_kprobe(sym.decode(), "trace_io_uring_prep_rw")
+                        prep_attached = True
+                if self.developer_mode and prep_attached:
+                    logger("info", "io_uring SQE capture enabled via per-op prep handlers")
+            if not prep_attached and self.developer_mode:
+                logger("warning", "io_uring SQE prep probe not available - opcode/fd/len/offset may be empty")
+
             # io_uring SQE submission probe (kprobe fallback for SUBMIT events)
             # Note: TRACEPOINT_PROBE(io_uring, io_uring_submit_sqe) in BPF is preferred
             if BPF.get_kprobe_functions(b'io_queue_sqe'):

--- a/src/tracer/prober/prober.c
+++ b/src/tracer/prober/prober.c
@@ -3703,7 +3703,14 @@ int trace_io_uring_prep_rw(struct pt_regs *ctx, void *req, void *sqe) {
   }
 
   struct io_uring_sqe_min s = {};
-  bpf_probe_read_kernel(&s, sizeof(s), sqe);
+  /* The SQE normally lives in kernel-allocated ring memory (mmapped to
+   * userspace), so a kernel read works. With IORING_SETUP_NO_MMAP (6.5+) the
+   * ring is allocated in application memory and the pointer is a user address,
+   * for which the kernel read fails — fall back to a user read so the SQE
+   * fields are still captured. */
+  if (bpf_probe_read_kernel(&s, sizeof(s), sqe) != 0) {
+    bpf_probe_read_user(&s, sizeof(s), sqe);
+  }
 
   struct io_uring_submit_ctx submit_ctx = {};
   submit_ctx.opcode    = s.opcode;

--- a/src/tracer/prober/prober.c
+++ b/src/tracer/prober/prober.c
@@ -501,6 +501,12 @@ struct io_uring_event_data {
   u32 worker_cpu;               /**< io-wq worker CPU */
   u8 is_async;                  /**< 1 if executed by io-wq worker */
   
+  /* File correlation — populated for file-backed ops from req->file so that
+   * io_uring I/O can be joined with the fs/VFS trace by inode/device. */
+  u64 inode;                    /**< Backing file inode (0 if not a file op) */
+  u32 dev;                      /**< Backing device id (super_block->s_dev) */
+  u32 fs_magic;                 /**< Superblock magic for fs-type classification */
+
   /* Ring state (optional) */
   u32 sq_head;
   u32 sq_tail;
@@ -518,6 +524,12 @@ struct io_uring_submit_ctx {
   s32 fd;                     /**< Target FD */
   u32 len;                    /**< I/O length */
   u64 offset;                 /**< File offset */
+  u8 sqe_flags;               /**< SQE flags (IOSQE_*) */
+  u16 ioprio;                 /**< I/O priority */
+  u16 buf_index;              /**< Fixed-buffer index */
+  u64 inode;                  /**< Backing file inode (file ops) */
+  u32 dev;                    /**< Backing device id */
+  u32 fs_magic;               /**< Superblock magic */
 };
 
 /**
@@ -3632,10 +3644,104 @@ int trace_io_uring_enter(struct pt_regs *ctx, unsigned int fd,
 }
 
 /**
+ * @brief ABI-stable subset of the io_uring SQE (uapi/linux/io_uring.h).
+ *
+ * struct io_uring_sqe is a UAPI structure whose leading field offsets are
+ * stable across every kernel that supports io_uring. We mirror that prefix so
+ * the prep probe can read the opcode/fd/len/offset/user_data directly from the
+ * SQE — values that the internal struct io_kiocb does NOT expose at stable
+ * offsets (its layout changes substantially between releases). The trailing
+ * fields of the real SQE are not needed and are intentionally omitted.
+ */
+struct io_uring_sqe_min {
+  u8  opcode;     /* 0  : IORING_OP_* */
+  u8  flags;      /* 1  : IOSQE_* */
+  u16 ioprio;     /* 2  : I/O priority */
+  s32 fd;         /* 4  : target file descriptor */
+  u64 off;        /* 8  : off / addr2 union */
+  u64 addr;       /* 16 : addr / splice_off_in union */
+  u32 len;        /* 24 : I/O length in bytes */
+  u32 op_flags;   /* 28 : rw_flags / fsync_flags / ... union */
+  u64 user_data;  /* 32 : caller correlation token */
+  u16 buf_index;  /* 40 : buf_index / buf_group union */
+};
+
+/**
+ * @brief Capture io_uring SQE fields at request-prep time.
+ *
+ * Attached to the read/write prep handler, which is invoked through the opcode
+ * dispatch table (def->prep) and therefore is not inlined away. It receives the
+ * io_kiocb request and the UAPI SQE:
+ *
+ *   int io_prep_rw(struct io_kiocb *req, const struct io_uring_sqe *sqe)
+ *
+ * Reading the SQE (stable ABI offsets) yields the opcode, fd, length, offset,
+ * priority and user_data. The req->file pointer — the first member of io_kiocb
+ * on modern kernels — yields the backing file's inode/device/filesystem so the
+ * io_uring I/O can be joined with the fs/VFS trace. Results are staged in
+ * io_uring_submit_map keyed by the req pointer and consumed by the SUBMIT and
+ * COMPLETE probes. If the prep symbol is unavailable on a given kernel these
+ * fields simply stay empty (graceful degradation).
+ *
+ * @param ctx BPF context
+ * @param req io_kiocb request structure pointer (PARM1)
+ * @param sqe UAPI io_uring_sqe pointer (PARM2)
+ * @return    0
+ */
+int trace_io_uring_prep_rw(struct pt_regs *ctx, void *req, void *sqe) {
+  u64 pid_tgid = bpf_get_current_pid_tgid();
+  u32 pid = pid_tgid >> 32;
+
+  u32 config_key = 0;
+  u32 *tracer_pid = tracer_config.lookup(&config_key);
+  if (tracer_pid && pid == *tracer_pid) {
+    return 0;
+  }
+
+  if (!req || !sqe) {
+    return 0;
+  }
+
+  struct io_uring_sqe_min s = {};
+  bpf_probe_read_kernel(&s, sizeof(s), sqe);
+
+  struct io_uring_submit_ctx submit_ctx = {};
+  submit_ctx.opcode    = s.opcode;
+  submit_ctx.sqe_flags = s.flags;
+  submit_ctx.ioprio    = s.ioprio;
+  submit_ctx.fd        = s.fd;
+  submit_ctx.offset    = s.off;
+  submit_ctx.len       = s.len;
+  submit_ctx.user_data = s.user_data;
+  submit_ctx.buf_index = s.buf_index;
+
+  /* req->file is the first member of struct io_kiocb on modern kernels. Pull
+   * the backing file identity when it is a regular file on a real filesystem;
+   * is_regular_file() filters sockets/pipes/pseudo-fs and bad reads. */
+  struct file *file = NULL;
+  bpf_probe_read_kernel(&file, sizeof(file), req);
+  if (is_regular_file(file)) {
+    submit_ctx.inode = get_file_inode(file);
+    get_file_source(file, &submit_ctx.dev, &submit_ctx.fs_magic);
+  }
+
+  u64 req_ptr = (u64)req;
+  io_uring_submit_map.update(&req_ptr, &submit_ctx);
+  return 0;
+}
+
+/**
  * @brief Trace io_uring SQE submission (via io_submit_sqes or io_queue_sqe)
  *
  * Captures individual SQE submissions with operation details.
  * Stores submit timestamp for latency calculation on completion.
+ *
+ * The opcode/fd/len/offset/user_data are read from the SQE by the prep probe
+ * (trace_io_uring_prep_rw) and staged in io_uring_submit_map before this probe
+ * runs. We reuse that staged context and stamp the submission timestamp so the
+ * completion probe can compute latency. When no prep data exists (a non-rw op,
+ * or a kernel without the prep symbol) we still recover the backing file from
+ * req->file on a best-effort basis.
  *
  * @param ctx BPF context
  * @param req io_kiocb request structure pointer
@@ -3654,30 +3760,23 @@ int trace_io_uring_submit(struct pt_regs *ctx, void *req) {
   u64 ts = bpf_ktime_get_ns();
   u64 req_ptr = (u64)req;
 
-  /* Read io_kiocb fields - structure offsets may vary by kernel version */
-  /* These are common fields that exist in most kernel versions */
-  u8 opcode = 0;
-  u64 user_data = 0;
-  s32 fd = -1;
-  u32 len = 0;
-  u64 offset = 0;
-  u8 flags = 0;
-
-  /* 
-   * Note: io_kiocb structure layout varies significantly across kernel versions.
-   * We read from known stable offsets. For production use, consider using
-   * tracepoints when available (io_uring:io_uring_submit_sqe).
-   */
-  
-  /* Store submission context for correlation on completion */
+  /* Reuse the SQE context staged by the prep probe; fall back to reading the
+   * backing file directly when this request was not prepped through the rw
+   * handler (e.g. fsync/openat ops, or a kernel without the prep symbol). */
   struct io_uring_submit_ctx submit_ctx = {};
+  struct io_uring_submit_ctx *staged = io_uring_submit_map.lookup(&req_ptr);
+  if (staged) {
+    submit_ctx = *staged;
+  } else {
+    submit_ctx.fd = -1;
+    struct file *file = NULL;
+    bpf_probe_read_kernel(&file, sizeof(file), req);
+    if (is_regular_file(file)) {
+      submit_ctx.inode = get_file_inode(file);
+      get_file_source(file, &submit_ctx.dev, &submit_ctx.fs_magic);
+    }
+  }
   submit_ctx.submit_ts_ns = ts;
-  submit_ctx.user_data = user_data;
-  submit_ctx.opcode = opcode;
-  submit_ctx.fd = fd;
-  submit_ctx.len = len;
-  submit_ctx.offset = offset;
-  
   io_uring_submit_map.update(&req_ptr, &submit_ctx);
 
   struct io_uring_event_data e = {};
@@ -3688,12 +3787,17 @@ int trace_io_uring_submit(struct pt_regs *ctx, void *req) {
   bpf_get_current_comm(&e.comm, sizeof(e.comm));
   e.cpu = bpf_get_smp_processor_id();
   e.req_ptr = req_ptr;
-  e.user_data = user_data;
-  e.opcode = opcode;
-  e.fd = fd;
-  e.len = len;
-  e.offset = offset;
-  e.sqe_flags = flags;
+  e.user_data = submit_ctx.user_data;
+  e.opcode = submit_ctx.opcode;
+  e.fd = submit_ctx.fd;
+  e.len = submit_ctx.len;
+  e.offset = submit_ctx.offset;
+  e.sqe_flags = submit_ctx.sqe_flags;
+  e.ioprio = submit_ctx.ioprio;
+  e.buf_index = submit_ctx.buf_index;
+  e.inode = submit_ctx.inode;
+  e.dev = submit_ctx.dev;
+  e.fs_magic = submit_ctx.fs_magic;
   e.submit_ts_ns = ts;
 
   io_uring_events.perf_submit(ctx, &e, sizeof(e));
@@ -3745,13 +3849,21 @@ int trace_io_uring_complete(struct pt_regs *ctx, void *req, s32 result) {
   struct io_uring_submit_ctx *submit_ctx = io_uring_submit_map.lookup(&req_ptr);
   if (submit_ctx) {
     e.submit_ts_ns = submit_ctx->submit_ts_ns;
-    e.latency_ns = ts - submit_ctx->submit_ts_ns;
+    if (submit_ctx->submit_ts_ns) {
+      e.latency_ns = ts - submit_ctx->submit_ts_ns;
+    }
     e.user_data = submit_ctx->user_data;
     e.opcode = submit_ctx->opcode;
     e.fd = submit_ctx->fd;
     e.len = submit_ctx->len;
     e.offset = submit_ctx->offset;
-    
+    e.sqe_flags = submit_ctx->sqe_flags;
+    e.ioprio = submit_ctx->ioprio;
+    e.buf_index = submit_ctx->buf_index;
+    e.inode = submit_ctx->inode;
+    e.dev = submit_ctx->dev;
+    e.fs_magic = submit_ctx->fs_magic;
+
     /* Clean up the map entry */
     io_uring_submit_map.delete(&req_ptr);
   }
@@ -3801,6 +3913,13 @@ int trace_io_uring_worker(struct pt_regs *ctx, void *req) {
     e.user_data = submit_ctx->user_data;
     e.opcode = submit_ctx->opcode;
     e.submit_ts_ns = submit_ctx->submit_ts_ns;
+    e.fd = submit_ctx->fd;
+    e.len = submit_ctx->len;
+    e.offset = submit_ctx->offset;
+    e.sqe_flags = submit_ctx->sqe_flags;
+    e.inode = submit_ctx->inode;
+    e.dev = submit_ctx->dev;
+    e.fs_magic = submit_ctx->fs_magic;
   }
 
   io_uring_events.perf_submit(ctx, &e, sizeof(e));


### PR DESCRIPTION
## Summary

The io_uring instrumentation already existed end-to-end (BPF probes, perf buffer, userspace callback, FlagMapper, WriterManager CSV, docs), but its SUBMIT/COMPLETE events carried **empty `opcode`/`fd`/`length`/`offset`/`user_data`** — those locals were hardcoded to zero/`-1` in `trace_io_uring_submit` and never read from the request. Every event reported `opcode=NOP` with no file or size, defeating the documented per-opcode/latency/throughput analyses.

This PR does two things (per request):

### 1. Populate the SQE fields (robustly)

Rather than reading the volatile internal `struct io_kiocb` (layout changes substantially between kernel releases), fields are captured at request-**prep** time from the **ABI-stable UAPI `struct io_uring_sqe`**:

- New `trace_io_uring_prep_rw` probe attaches to the read/write prep handler (`io_prep_rw`, with per-op `io_prep_read{,v,_fixed}` / `io_prep_write{,v,_fixed}` fallbacks). It is dispatched via the opcode table (`def->prep`) so it is not inlined and is kprobe-able.
- It reads `opcode/flags/ioprio/fd/off/len/user_data/buf_index` from a minimal stable mirror (`io_uring_sqe_min`), plus the backing file's `inode/dev/fs_magic` from `req->file` (the first member of `io_kiocb` on modern kernels, guarded by `is_regular_file`).
- Values are staged in `io_uring_submit_map` keyed by the request pointer and consumed by the SUBMIT/COMPLETE/WORKER probes.
- **Graceful degradation:** SUBMIT falls back to reading `req->file` directly; if the prep symbol is missing, SQE-only fields just stay empty rather than failing.

### 2. Mirror io_uring read/write into the fs/VFS trace

io_uring reads/writes call `->read_iter`/`->write_iter` directly and **bypass `vfs_read`/`vfs_write`**, so they never appear in the VFS trace. Completed io_uring `READ`/`WRITE` ops are now mirrored into the main fs log (`fs/fs_*.csv`) using the standard VFS 22-column schema, with file identity/inode/device/fs_type and result/latency. `fsync` is intentionally **not** mirrored — io_uring `FSYNC` already flows through `vfs_fsync` and mirroring would double-count.

The dedicated io_uring CSV additionally gains `inode`/`filename`/`device`/`fs_type` columns (appended → existing 38-column parsers unaffected).

## Files
- `src/tracer/prober/prober.c` — `io_uring_sqe_min`, `trace_io_uring_prep_rw`, reworked SUBMIT/COMPLETE/WORKER, extended event + submit-ctx structs.
- `src/tracer/KernelProbeTracker.py` — attach prep probe with fallbacks.
- `src/tracer/IOTracer.py` — file resolution, new io_uring columns, `_mirror_io_uring_to_fs`.
- `docs/traces/IO_URING_EVENTS.md`, `docs/traces/VFS_EVENTS.md` — documented.

## Testing
⚠️ BPF could **not** be compiled or loaded in this environment (no `bcc`, kernel headers, or debugfs). Python modules pass `py_compile`. The new kprobe targets (`io_prep_rw` & fallbacks) and the offset-0 `req->file` read should be validated on a live kernel (e.g. with `fio --ioengine=io_uring`) before merge — confirm SUBMIT/COMPLETE rows now show real opcode/fd/len/offset and that io_uring reads/writes appear in `fs_*.csv`.

https://claude.ai/code/session_016iTVPpFD8zvWAQcYSCvFK2

---
_Generated by [Claude Code](https://claude.ai/code/session_016iTVPpFD8zvWAQcYSCvFK2)_