### PR TITLE
Fix unbounded cache growth, writer races, and dropped uploads; add unit tests

### DIFF
--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -1,0 +1,31 @@
+name: Unit Tests
+
+# Runs the pure-Python unit tests (FlagMapper, PathResolver, utils). These have
+# no bcc/kernel dependency, so unlike the BPF compile job they run on any
+# runner without privileges.
+
+on:
+  push:
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - '.github/workflows/unit-tests.yml'
+  pull_request:
+    paths:
+      - 'src/**'
+      - 'tests/**'
+      - '.github/workflows/unit-tests.yml'
+  workflow_dispatch:
+
+jobs:
+  unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Run unit tests
+        run: python3 -m unittest discover -s tests -v

--- a/src/tracer/IOTracer.py
+++ b/src/tracer/IOTracer.py
@@ -142,6 +142,15 @@ class IOTracer:
         self.mmap_regions       = {}
         self.cmdline_cache      = {}  # pid -> cmdline, populated on first successful read
 
+        # Bounded-cache maintenance. The path resolver and cmdline caches are
+        # only evicted on PROCESS_EXEC, so over a long-running trace they would
+        # otherwise grow without bound. Maintenance runs from the perf-callback
+        # (polling) thread — the only thread that mutates these caches — so it
+        # never races with event processing.
+        self._event_count           = 0
+        self._maintenance_interval  = 50000  # events between cache sweeps
+        self._cmdline_cache_max     = 100000  # hard cap on cmdline cache entries
+
         if cache_sample_rate > 1:
             self.writer.set_cache_sampling(cache_sample_rate)
 
@@ -191,9 +200,13 @@ class IOTracer:
             data: Raw event data pointer
             size: Size of the event data
         """
+        self._event_count += 1
+        if self._event_count % self._maintenance_interval == 0:
+            self._run_cache_maintenance()
+
         event = self.b["events"].event(data)
         op_name = self.flag_mapper.op_fs_types.get(event.op, "[unknown]")
-        
+
         try:
             filename = event.filename.decode()
             if self.anonymous:
@@ -516,6 +529,32 @@ class IOTracer:
         # eviction, which fires for the new process before its events.
         self.cmdline_cache[pid] = result
         return result
+
+    def _run_cache_maintenance(self) -> None:
+        """
+        Bound the long-lived caches so an indefinite trace does not leak memory.
+
+        Runs from the perf-callback (polling) thread, which is the only thread
+        that mutates ``cmdline_cache`` and the path resolver caches, so no
+        locking is required.
+
+        - Delegates to ``PathResolver.cleanup_old_cache`` (otherwise never
+          called), which prunes stale per-PID entries and caps ``inode_to_path``.
+        - Caps ``cmdline_cache`` at ``_cmdline_cache_max`` entries. Entries are
+          deliberately retained past process exit so that CLOSE/EXIT events
+          buffered after the process is gone can still resolve a cmdline; when
+          the cap is exceeded we drop the oldest half (dicts preserve insertion
+          order), keeping the most recently seen PIDs.
+        """
+        try:
+            self.path_resolver.cleanup_old_cache()
+        except Exception as e:
+            if self.verbose:
+                logger("warning", f"Path resolver cache cleanup failed: {e}")
+
+        if len(self.cmdline_cache) > self._cmdline_cache_max:
+            items = list(self.cmdline_cache.items())
+            self.cmdline_cache = dict(items[len(items) // 2:])
 
     def _handle_process_exec(self, pid: int) -> None:
         """
@@ -1096,7 +1135,10 @@ class IOTracer:
             run_with_spinner("Compressing trace output", self.writer.force_flush)
 
             if self.automatic_upload:
-                run_with_spinner("Uploading traces", lambda: self.upload_manager.stop_worker(False))
+                # Drain the upload queue before stopping the workers — passing
+                # False here set the stop event immediately and abandoned any
+                # traces still queued for upload.
+                run_with_spinner("Uploading traces", lambda: self.upload_manager.stop_worker(True, timeout=30))
                 try:
                     os.removedirs(self.writer.output_dir)
                 except OSError:

--- a/src/tracer/IOTracer.py
+++ b/src/tracer/IOTracer.py
@@ -200,9 +200,7 @@ class IOTracer:
             data: Raw event data pointer
             size: Size of the event data
         """
-        self._event_count += 1
-        if self._event_count % self._maintenance_interval == 0:
-            self._run_cache_maintenance()
+        self._tick_maintenance()
 
         event = self.b["events"].event(data)
         op_name = self.flag_mapper.op_fs_types.get(event.op, "[unknown]")
@@ -530,6 +528,20 @@ class IOTracer:
         self.cmdline_cache[pid] = result
         return result
 
+    def _tick_maintenance(self) -> None:
+        """
+        Advance the event counter and run cache maintenance when it is due.
+
+        Called from every perf callback that runs on the polling thread and
+        touches the long-lived caches (``_print_event``, ``_print_event_dual``,
+        ``_print_event_io_uring``) so a workload dominated by any single event
+        family — e.g. rename/link/symlink (dual) or async io_uring I/O — still
+        triggers eviction instead of growing the caches unbounded.
+        """
+        self._event_count += 1
+        if self._event_count % self._maintenance_interval == 0:
+            self._run_cache_maintenance()
+
     def _run_cache_maintenance(self) -> None:
         """
         Bound the long-lived caches so an indefinite trace does not leak memory.
@@ -590,6 +602,8 @@ class IOTracer:
             data: Raw event data pointer
             size: Size of the event data
         """
+        self._tick_maintenance()
+
         event = self.b["events_dual"].event(data)
         op_name = self.flag_mapper.op_fs_types.get(event.op, "[unknown]")
         
@@ -791,6 +805,8 @@ class IOTracer:
             data: Raw event data pointer
             size: Size of the event data
         """
+        self._tick_maintenance()
+
         e = self.b["io_uring_events"].event(data)
         ts = datetime.today()
         

--- a/src/tracer/PathResolver.py
+++ b/src/tracer/PathResolver.py
@@ -95,14 +95,14 @@ class PathResolver:
                             files[inode] = target
                             # Update global inode cache
                             self.inode_to_path[inode] = target
-                    except:
+                    except OSError:
                         continue
-            
+
             self.pid_to_files[pid] = files
             self.last_update[pid] = current_time
             return files
-            
-        except:
+
+        except OSError:
             return {}
     
     def resolve_by_fd(self, pid: int, fd: int, inode: int = 0, filename: str = "") -> str:
@@ -234,8 +234,8 @@ class PathResolver:
                 pids_to_remove.append(pid)
         
         for pid in pids_to_remove:
-            del self.pid_to_files[pid]
-            del self.last_update[pid]
+            self.pid_to_files.pop(pid, None)
+            self.last_update.pop(pid, None)
         
         # Optionally limit inode cache size
         if len(self.inode_to_path) > 10000:

--- a/src/tracer/WriterManager.py
+++ b/src/tracer/WriterManager.py
@@ -498,7 +498,7 @@ class WriteManager:
         Flush filesystem snapshot buffer to a multi-part file.
 
         Writes buffer to filesystem_snapshot_part####_TIMESTAMP_DEVICEID.csv,
-        compresses it with Zstandard, and increments the part counter.
+        compresses it with gzip, and increments the part counter.
         """
         with self._stream_locks['fs_snap']:
             if not self.fs_snap_buffer:
@@ -641,6 +641,7 @@ class WriteManager:
 
     def flush_process_state_only(self):
         """Flush process state buffer to file."""
+        rotated = None
         with self._stream_locks['process']:
             if self.process_buffer:
                 if self._process_handle is None:
@@ -648,19 +649,21 @@ class WriteManager:
                 self.current_datetime = datetime.now()
 
                 self._write_buffer_to_file(self.process_buffer, self._process_handle, "Process State")
-                self.compress_log(self.output_process_file)
-                self.output_process_file = f"{self.output_dir}/process/process_{self.current_datetime.strftime('%Y%m%d_%H%M%S_%f')[:-3]}.csv"
-
                 self._process_handle.close()
+                rotated = self.output_process_file
+                self.output_process_file = f"{self.output_dir}/process/process_{self.current_datetime.strftime('%Y%m%d_%H%M%S_%f')[:-3]}.csv"
                 self._process_handle = open(self.output_process_file, 'a', buffering=8192)
                 self._reset_flush_timer()
 
                 # Mark process snapshot as complete
                 self.process_snapshot_session_active = False
                 logger("info", "Process Snapshot: completed and flushed")
+        if rotated is not None:
+            self.compress_log(rotated)
 
     def flush_cache_only(self):
         """Flush cache buffer to file."""
+        rotated = None
         with self._stream_locks['cache']:
             if self.cache_buffer:
                 if self._cache_handle is None:
@@ -668,16 +671,18 @@ class WriteManager:
                 self.current_datetime = datetime.now()
 
                 self._write_buffer_to_file(self.cache_buffer, self._cache_handle, "Cache")
-                self.compress_log(self.output_cache_file)
-                self.output_cache_file = f"{self.output_dir}/cache/cache_{self.current_datetime.strftime('%Y%m%d_%H%M%S_%f')[:-3]}.csv"
-
                 self._cache_handle.close()
+                rotated = self.output_cache_file
+                self.output_cache_file = f"{self.output_dir}/cache/cache_{self.current_datetime.strftime('%Y%m%d_%H%M%S_%f')[:-3]}.csv"
                 self._cache_handle = open(self.output_cache_file, 'a', buffering=8192)
                 self._reset_flush_timer()
+        if rotated is not None:
+            self.compress_log(rotated)
 
 
     def flush_vfs_only(self):
         """Flush VFS buffer to file."""
+        rotated = None
         with self._stream_locks['vfs']:
             if self.vfs_buffer:
                 if self._vfs_handle is None:
@@ -685,15 +690,21 @@ class WriteManager:
                 self.current_datetime = datetime.now()
 
                 self._write_buffer_to_file(self.vfs_buffer, self._vfs_handle, "VFS")
-                self.compress_log(self.output_vfs_file)
-                self.output_vfs_file = f"{self.output_dir}/fs/fs_{self.current_datetime.strftime('%Y%m%d_%H%M%S_%f')[:-3]}.csv"
-
+                # Close before compressing so we never gzip/delete a file that
+                # still has an open descriptor; rotate to a fresh output file.
                 self._vfs_handle.close()
+                rotated = self.output_vfs_file
+                self.output_vfs_file = f"{self.output_dir}/fs/fs_{self.current_datetime.strftime('%Y%m%d_%H%M%S_%f')[:-3]}.csv"
                 self._vfs_handle = open(self.output_vfs_file, 'a', buffering=8192)
                 self._reset_flush_timer()
+        # Compress outside the lock: gzip + disk I/O is slow and must not block
+        # the perf-callback flush or the periodic writer for this stream.
+        if rotated is not None:
+            self.compress_log(rotated)
 
     def flush_block_only(self):
         """Flush block buffer to file."""
+        rotated = None
         with self._stream_locks['block']:
             if self.block_buffer:
                 if self._block_handle is None:
@@ -701,15 +712,17 @@ class WriteManager:
                 self.current_datetime = datetime.now()
 
                 self._write_buffer_to_file(self.block_buffer, self._block_handle, "Block")
-                self.compress_log(self.output_block_file)
-                self.output_block_file = f"{self.output_dir}/ds/ds_{self.current_datetime.strftime('%Y%m%d_%H%M%S_%f')[:-3]}.csv"
-
                 self._block_handle.close()
+                rotated = self.output_block_file
+                self.output_block_file = f"{self.output_dir}/ds/ds_{self.current_datetime.strftime('%Y%m%d_%H%M%S_%f')[:-3]}.csv"
                 self._block_handle = open(self.output_block_file, 'a', buffering=8192)
                 self._reset_flush_timer()
+        if rotated is not None:
+            self.compress_log(rotated)
 
     def flush_pagefault_only(self):
         """Flush pagefault buffer to file."""
+        rotated = None
         with self._stream_locks['pagefault']:
             if self.pagefault_buffer:
                 if self._pagefault_handle is None:
@@ -717,15 +730,17 @@ class WriteManager:
                 self.current_datetime = datetime.now()
 
                 self._write_buffer_to_file(self.pagefault_buffer, self._pagefault_handle, "PageFault")
-                self.compress_log(self.output_pagefault_file)
-                self.output_pagefault_file = f"{self.output_dir}/pagefault/pagefault_{self.current_datetime.strftime('%Y%m%d_%H%M%S_%f')[:-3]}.csv"
-
                 self._pagefault_handle.close()
+                rotated = self.output_pagefault_file
+                self.output_pagefault_file = f"{self.output_dir}/pagefault/pagefault_{self.current_datetime.strftime('%Y%m%d_%H%M%S_%f')[:-3]}.csv"
                 self._pagefault_handle = open(self.output_pagefault_file, 'a', buffering=8192)
                 self._reset_flush_timer()
+        if rotated is not None:
+            self.compress_log(rotated)
 
     def flush_io_uring_only(self):
         """Flush io_uring buffer to file."""
+        rotated = None
         with self._stream_locks['io_uring']:
             if self.io_uring_buffer:
                 if self._io_uring_handle is None:
@@ -733,15 +748,24 @@ class WriteManager:
                 self.current_datetime = datetime.now()
 
                 self._write_buffer_to_file(self.io_uring_buffer, self._io_uring_handle, "IO_Uring")
-                self.compress_log(self.output_io_uring_file)
-                self.output_io_uring_file = f"{self.output_dir}/io_uring/io_uring_{self.current_datetime.strftime('%Y%m%d_%H%M%S_%f')[:-3]}.csv"
-
                 self._io_uring_handle.close()
+                rotated = self.output_io_uring_file
+                self.output_io_uring_file = f"{self.output_dir}/io_uring/io_uring_{self.current_datetime.strftime('%Y%m%d_%H%M%S_%f')[:-3]}.csv"
                 self._io_uring_handle = open(self.output_io_uring_file, 'a', buffering=8192)
                 self._reset_flush_timer()
+        if rotated is not None:
+            self.compress_log(rotated)
 
     def force_flush(self):
         """Flush all buffers and compress all output files."""
+        # Make sure every buffer is on disk and all handles are closed before we
+        # compress. _cleanup normally does this, but it is bypassed on the
+        # unhandled-exception exit path in IOTracer.trace(); without this we
+        # would compress files that are missing buffered rows or still hold an
+        # open descriptor. Both calls are idempotent when _cleanup already ran.
+        self.write_to_disk()
+        self.close_handles()
+
         self.compress_log(self.output_block_file)
         self.compress_log(self.output_vfs_file)
         self.compress_log(self.output_cache_file)

--- a/src/tracer/WriterManager.py
+++ b/src/tracer/WriterManager.py
@@ -149,6 +149,21 @@ class WriteManager:
         self.pagefault_max_events = 8000
         self.io_uring_max_events = 8000
 
+        # Per-stream locks. Buffer flushes are triggered both from the
+        # perf-callback (polling) thread via append_*_log -> flush_*_only and
+        # from the periodic-flush thread via write_to_disk. Both paths open,
+        # write, close and swap the same file handle, so each stream needs a
+        # lock to avoid writing to a closed/stale handle or interleaving rows.
+        self._stream_locks = {
+            'vfs':       threading.Lock(),
+            'block':     threading.Lock(),
+            'cache':     threading.Lock(),
+            'process':   threading.Lock(),
+            'fs_snap':   threading.Lock(),
+            'pagefault': threading.Lock(),
+            'io_uring':  threading.Lock(),
+        }
+
         # File handles for each output
         self._vfs_handle = None
         self._block_handle = None
@@ -481,15 +496,17 @@ class WriteManager:
     def flush_fssnap_only(self):
         """
         Flush filesystem snapshot buffer to a multi-part file.
-        
+
         Writes buffer to filesystem_snapshot_part####_TIMESTAMP_DEVICEID.csv,
         compresses it with Zstandard, and increments the part counter.
         """
-        if self.fs_snap_buffer:
+        with self._stream_locks['fs_snap']:
+            if not self.fs_snap_buffer:
+                return
             # Initialize snapshot session if not already active
             if not self.fs_snapshot_session_active:
                 self.start_fs_snapshot_session()
-            
+
             # Generate part filename with zero-padded part number
             part_str = f"{self.fs_snapshot_part_number:04d}"
             part_filename = (
@@ -498,44 +515,44 @@ class WriteManager:
                 f"{self.fs_snapshot_device_id}.csv"
             )
             part_filepath = f"{self.output_dir}/filesystem_snapshot/{part_filename}"
-            
+
             # Open file handle for this part if needed
             if self._fs_snap_handle is None or self.output_fs_snapshot_file != part_filepath:
                 if self._fs_snap_handle is not None:
                     self._fs_snap_handle.close()
                 self._fs_snap_handle = open(part_filepath, 'a', buffering=8192)
                 self.output_fs_snapshot_file = part_filepath
-            
+
             # Write buffer to file
             self._write_buffer_to_file(self.fs_snap_buffer, self._fs_snap_handle, "Filesystem Snapshot")
-            
+
             # Close handle before compression
             self._fs_snap_handle.close()
             self._fs_snap_handle = None
-            
+
             # Compress with gzip
             if os.path.exists(part_filepath):
                 # Don't log or count each part - we'll log when snapshot is complete
                 with open(part_filepath, "rb") as f_in:
                     with gzip.open(part_filepath + ".gz", "wb") as f_out:
                         shutil.copyfileobj(f_in, f_out)
-                
+
                 os.remove(part_filepath)
                 compressed_file = part_filepath + ".gz"
-                
+
                 # Store for later upload (after snapshot completion and final part rename)
                 if self.automatic_upload:
                     self.fs_snapshot_parts_pending_upload.append(compressed_file)
             else:
                 logger("warning", f"Snapshot file not found for compression: {part_filepath}")
-            
+
             # Increment part number for next flush
             self.fs_snapshot_part_number += 1
-            
+
             # Log snapshot progress
             parts_written = self.fs_snapshot_part_number - 1
             logger("info", f"FS Snapshot: part {parts_written} written ({len(self.fs_snap_buffer)} events remain in buffer)")
-            
+
             self._reset_flush_timer()
 
     def start_fs_snapshot_session(self):
@@ -624,98 +641,104 @@ class WriteManager:
 
     def flush_process_state_only(self):
         """Flush process state buffer to file."""
-        if self.process_buffer:
-            if self._process_handle is None:
+        with self._stream_locks['process']:
+            if self.process_buffer:
+                if self._process_handle is None:
+                    self._process_handle = open(self.output_process_file, 'a', buffering=8192)
+                self.current_datetime = datetime.now()
+
+                self._write_buffer_to_file(self.process_buffer, self._process_handle, "Process State")
+                self.compress_log(self.output_process_file)
+                self.output_process_file = f"{self.output_dir}/process/process_{self.current_datetime.strftime('%Y%m%d_%H%M%S_%f')[:-3]}.csv"
+
+                self._process_handle.close()
                 self._process_handle = open(self.output_process_file, 'a', buffering=8192)
-            self.current_datetime = datetime.now()
+                self._reset_flush_timer()
 
-            self._write_buffer_to_file(self.process_buffer, self._process_handle, "Process State")
-            self.compress_log(self.output_process_file)
-            self.output_process_file = f"{self.output_dir}/process/process_{self.current_datetime.strftime('%Y%m%d_%H%M%S_%f')[:-3]}.csv"
-
-            self._process_handle.close()
-            self._process_handle = open(self.output_process_file, 'a', buffering=8192)
-            self._reset_flush_timer()
-            
-            # Mark process snapshot as complete
-            self.process_snapshot_session_active = False
-            logger("info", "Process Snapshot: completed and flushed")
+                # Mark process snapshot as complete
+                self.process_snapshot_session_active = False
+                logger("info", "Process Snapshot: completed and flushed")
 
     def flush_cache_only(self):
         """Flush cache buffer to file."""
-        if self.cache_buffer:
-            if self._cache_handle is None:
+        with self._stream_locks['cache']:
+            if self.cache_buffer:
+                if self._cache_handle is None:
+                    self._cache_handle = open(self.output_cache_file, 'a', buffering=8192)
+                self.current_datetime = datetime.now()
+
+                self._write_buffer_to_file(self.cache_buffer, self._cache_handle, "Cache")
+                self.compress_log(self.output_cache_file)
+                self.output_cache_file = f"{self.output_dir}/cache/cache_{self.current_datetime.strftime('%Y%m%d_%H%M%S_%f')[:-3]}.csv"
+
+                self._cache_handle.close()
                 self._cache_handle = open(self.output_cache_file, 'a', buffering=8192)
-            self.current_datetime = datetime.now()
-
-            self._write_buffer_to_file(self.cache_buffer, self._cache_handle, "Cache")
-            self.compress_log(self.output_cache_file)
-            self.output_cache_file = f"{self.output_dir}/cache/cache_{self.current_datetime.strftime('%Y%m%d_%H%M%S_%f')[:-3]}.csv"
-
-            self._cache_handle.close()
-            self._cache_handle = open(self.output_cache_file, 'a', buffering=8192)
-            self._reset_flush_timer()
+                self._reset_flush_timer()
 
 
     def flush_vfs_only(self):
         """Flush VFS buffer to file."""
-        if self.vfs_buffer:
-            if self._vfs_handle is None:
-                self._vfs_handle = open(self.output_vfs_file, 'a', buffering=8192)
-            self.current_datetime = datetime.now()
-            
-            self._write_buffer_to_file(self.vfs_buffer, self._vfs_handle, "VFS")
-            self.compress_log(self.output_vfs_file)
-            self.output_vfs_file = f"{self.output_dir}/fs/fs_{self.current_datetime.strftime('%Y%m%d_%H%M%S_%f')[:-3]}.csv"
+        with self._stream_locks['vfs']:
+            if self.vfs_buffer:
+                if self._vfs_handle is None:
+                    self._vfs_handle = open(self.output_vfs_file, 'a', buffering=8192)
+                self.current_datetime = datetime.now()
 
-            self._vfs_handle.close()
-            self._vfs_handle = open(self.output_vfs_file, 'a', buffering=8192)
-            self._reset_flush_timer()
+                self._write_buffer_to_file(self.vfs_buffer, self._vfs_handle, "VFS")
+                self.compress_log(self.output_vfs_file)
+                self.output_vfs_file = f"{self.output_dir}/fs/fs_{self.current_datetime.strftime('%Y%m%d_%H%M%S_%f')[:-3]}.csv"
+
+                self._vfs_handle.close()
+                self._vfs_handle = open(self.output_vfs_file, 'a', buffering=8192)
+                self._reset_flush_timer()
 
     def flush_block_only(self):
         """Flush block buffer to file."""
-        if self.block_buffer:
-            if self._block_handle is None:
-                self._block_handle = open(self.output_block_file, 'a', buffering=8192)
-            self.current_datetime = datetime.now()
-            
-            self._write_buffer_to_file(self.block_buffer, self._block_handle, "Block")
-            self.compress_log(self.output_block_file)
-            self.output_block_file = f"{self.output_dir}/ds/ds_{self.current_datetime.strftime('%Y%m%d_%H%M%S_%f')[:-3]}.csv"
+        with self._stream_locks['block']:
+            if self.block_buffer:
+                if self._block_handle is None:
+                    self._block_handle = open(self.output_block_file, 'a', buffering=8192)
+                self.current_datetime = datetime.now()
 
-            self._block_handle.close()
-            self._block_handle = open(self.output_block_file, 'a', buffering=8192)
-            self._reset_flush_timer()
+                self._write_buffer_to_file(self.block_buffer, self._block_handle, "Block")
+                self.compress_log(self.output_block_file)
+                self.output_block_file = f"{self.output_dir}/ds/ds_{self.current_datetime.strftime('%Y%m%d_%H%M%S_%f')[:-3]}.csv"
+
+                self._block_handle.close()
+                self._block_handle = open(self.output_block_file, 'a', buffering=8192)
+                self._reset_flush_timer()
 
     def flush_pagefault_only(self):
         """Flush pagefault buffer to file."""
-        if self.pagefault_buffer:
-            if self._pagefault_handle is None:
-                self._pagefault_handle = open(self.output_pagefault_file, 'a', buffering=8192)
-            self.current_datetime = datetime.now()
-            
-            self._write_buffer_to_file(self.pagefault_buffer, self._pagefault_handle, "PageFault")
-            self.compress_log(self.output_pagefault_file)
-            self.output_pagefault_file = f"{self.output_dir}/pagefault/pagefault_{self.current_datetime.strftime('%Y%m%d_%H%M%S_%f')[:-3]}.csv"
+        with self._stream_locks['pagefault']:
+            if self.pagefault_buffer:
+                if self._pagefault_handle is None:
+                    self._pagefault_handle = open(self.output_pagefault_file, 'a', buffering=8192)
+                self.current_datetime = datetime.now()
 
-            self._pagefault_handle.close()
-            self._pagefault_handle = open(self.output_pagefault_file, 'a', buffering=8192)
-            self._reset_flush_timer()
+                self._write_buffer_to_file(self.pagefault_buffer, self._pagefault_handle, "PageFault")
+                self.compress_log(self.output_pagefault_file)
+                self.output_pagefault_file = f"{self.output_dir}/pagefault/pagefault_{self.current_datetime.strftime('%Y%m%d_%H%M%S_%f')[:-3]}.csv"
+
+                self._pagefault_handle.close()
+                self._pagefault_handle = open(self.output_pagefault_file, 'a', buffering=8192)
+                self._reset_flush_timer()
 
     def flush_io_uring_only(self):
         """Flush io_uring buffer to file."""
-        if self.io_uring_buffer:
-            if self._io_uring_handle is None:
+        with self._stream_locks['io_uring']:
+            if self.io_uring_buffer:
+                if self._io_uring_handle is None:
+                    self._io_uring_handle = open(self.output_io_uring_file, 'a', buffering=8192)
+                self.current_datetime = datetime.now()
+
+                self._write_buffer_to_file(self.io_uring_buffer, self._io_uring_handle, "IO_Uring")
+                self.compress_log(self.output_io_uring_file)
+                self.output_io_uring_file = f"{self.output_dir}/io_uring/io_uring_{self.current_datetime.strftime('%Y%m%d_%H%M%S_%f')[:-3]}.csv"
+
+                self._io_uring_handle.close()
                 self._io_uring_handle = open(self.output_io_uring_file, 'a', buffering=8192)
-            self.current_datetime = datetime.now()
-
-            self._write_buffer_to_file(self.io_uring_buffer, self._io_uring_handle, "IO_Uring")
-            self.compress_log(self.output_io_uring_file)
-            self.output_io_uring_file = f"{self.output_dir}/io_uring/io_uring_{self.current_datetime.strftime('%Y%m%d_%H%M%S_%f')[:-3]}.csv"
-
-            self._io_uring_handle.close()
-            self._io_uring_handle = open(self.output_io_uring_file, 'a', buffering=8192)
-            self._reset_flush_timer()
+                self._reset_flush_timer()
 
     def force_flush(self):
         """Flush all buffers and compress all output files."""
@@ -798,46 +821,53 @@ class WriteManager:
     def write_to_disk(self):
         """Write all buffered data to disk using parallel threads."""
         def write_vfs():
-            if self.vfs_buffer:
-                if self._vfs_handle is None:
-                    self._vfs_handle = open(self.output_vfs_file, 'a', buffering=8192)
-                self._write_buffer_to_file(self.vfs_buffer, self._vfs_handle, "VFS")
+            with self._stream_locks['vfs']:
+                if self.vfs_buffer:
+                    if self._vfs_handle is None:
+                        self._vfs_handle = open(self.output_vfs_file, 'a', buffering=8192)
+                    self._write_buffer_to_file(self.vfs_buffer, self._vfs_handle, "VFS")
 
         def write_block():
-            if self.block_buffer:
-                if self._block_handle is None:
-                    self._block_handle = open(self.output_block_file, 'a', buffering=8192)
-                self._write_buffer_to_file(self.block_buffer, self._block_handle, "Block")
+            with self._stream_locks['block']:
+                if self.block_buffer:
+                    if self._block_handle is None:
+                        self._block_handle = open(self.output_block_file, 'a', buffering=8192)
+                    self._write_buffer_to_file(self.block_buffer, self._block_handle, "Block")
 
         def write_cache():
-            if self.cache_buffer:
-                if self._cache_handle is None:
-                    self._cache_handle = open(self.output_cache_file, 'a', buffering=8192)
-                self._write_buffer_to_file(self.cache_buffer, self._cache_handle, "Cache")
+            with self._stream_locks['cache']:
+                if self.cache_buffer:
+                    if self._cache_handle is None:
+                        self._cache_handle = open(self.output_cache_file, 'a', buffering=8192)
+                    self._write_buffer_to_file(self.cache_buffer, self._cache_handle, "Cache")
 
         def write_process():
-            if self.process_buffer:
-                if self._process_handle is None:
-                    self._process_handle = open(self.output_process_file, 'a', buffering=8192)
-                self._write_buffer_to_file(self.process_buffer, self._process_handle, "Process State")
+            with self._stream_locks['process']:
+                if self.process_buffer:
+                    if self._process_handle is None:
+                        self._process_handle = open(self.output_process_file, 'a', buffering=8192)
+                    self._write_buffer_to_file(self.process_buffer, self._process_handle, "Process State")
 
         def write_fssnap():
-            if self.fs_snap_buffer:
-                if self._fs_snap_handle is None:
-                    self._fs_snap_handle = open(self.output_fs_snapshot_file, 'a', buffering=8192)
-                self._write_buffer_to_file(self.fs_snap_buffer, self._fs_snap_handle, "Filesystem Snapshot")
+            with self._stream_locks['fs_snap']:
+                if self.fs_snap_buffer:
+                    if self._fs_snap_handle is None:
+                        self._fs_snap_handle = open(self.output_fs_snapshot_file, 'a', buffering=8192)
+                    self._write_buffer_to_file(self.fs_snap_buffer, self._fs_snap_handle, "Filesystem Snapshot")
 
         def write_pagefault():
-            if self.pagefault_buffer:
-                if self._pagefault_handle is None:
-                    self._pagefault_handle = open(self.output_pagefault_file, 'a', buffering=8192)
-                self._write_buffer_to_file(self.pagefault_buffer, self._pagefault_handle, "PageFault")
+            with self._stream_locks['pagefault']:
+                if self.pagefault_buffer:
+                    if self._pagefault_handle is None:
+                        self._pagefault_handle = open(self.output_pagefault_file, 'a', buffering=8192)
+                    self._write_buffer_to_file(self.pagefault_buffer, self._pagefault_handle, "PageFault")
 
         def write_io_uring():
-            if self.io_uring_buffer:
-                if self._io_uring_handle is None:
-                    self._io_uring_handle = open(self.output_io_uring_file, 'a', buffering=8192)
-                self._write_buffer_to_file(self.io_uring_buffer, self._io_uring_handle, "IO_Uring")
+            with self._stream_locks['io_uring']:
+                if self.io_uring_buffer:
+                    if self._io_uring_handle is None:
+                        self._io_uring_handle = open(self.output_io_uring_file, 'a', buffering=8192)
+                    self._write_buffer_to_file(self.io_uring_buffer, self._io_uring_handle, "IO_Uring")
 
         threads = []
         
@@ -954,7 +984,7 @@ class WriteManager:
                 self._add_to_bundle(dst)
             os.remove(src)
         except Exception as e:
-            logger("error", f"Failed compressing log {input_file}")
+            logger("error", f"Failed compressing log {input_file}: {e}")
             
     def compress_dir(self, input_dir: str):
         """
@@ -978,7 +1008,7 @@ class WriteManager:
             shutil.rmtree(src)
 
         except Exception as e:
-            logger("error", f"Failed compressing directory {input_dir}")
+            logger("error", f"Failed compressing directory {input_dir}: {e}")
         
 
     def close_handles(self):

--- a/tests/test_flag_mapper.py
+++ b/tests/test_flag_mapper.py
@@ -1,0 +1,80 @@
+"""
+Unit tests for src.tracer.FlagMapper.
+
+FlagMapper has no external dependencies, so its decoding logic is fully
+unit-testable without a kernel or bcc.
+"""
+
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from src.tracer.FlagMapper import FlagMapper
+
+
+class FsFlagTests(unittest.TestCase):
+    def setUp(self):
+        self.m = FlagMapper()
+
+    def test_rdonly(self):
+        self.assertEqual(self.m.format_fs_flags(0o0), "O_RDONLY")
+
+    def test_rdwr_creat(self):
+        # O_RDWR (0o2) | O_CREAT (0o100)
+        self.assertEqual(self.m.format_fs_flags(0o102), "O_RDWR|O_CREAT")
+
+    def test_wronly_append(self):
+        # O_WRONLY (0o1) | O_APPEND (0o2000)
+        out = self.m.format_fs_flags(0o2001)
+        self.assertIn("O_WRONLY", out)
+        self.assertIn("O_APPEND", out)
+
+
+class MmapProtTests(unittest.TestCase):
+    def setUp(self):
+        self.m = FlagMapper()
+
+    def test_prot_none(self):
+        self.assertEqual(self.m.format_mmap_prot_flags(0), "PROT_NONE")
+
+    def test_no_map(self):
+        self.assertEqual(self.m.format_mmap_map_flags(0), "NO_MAP")
+
+
+class ErrnoTests(unittest.TestCase):
+    def test_zero_is_empty(self):
+        self.assertEqual(FlagMapper.format_errno(0), "")
+
+    def test_known_errno(self):
+        self.assertEqual(FlagMapper.format_errno(2), "ENOENT")
+
+    def test_magnitude_is_taken(self):
+        # Callers pass -ret; format_errno should accept either sign.
+        self.assertEqual(FlagMapper.format_errno(-13), "EACCES")
+
+    def test_unknown_errno_falls_back(self):
+        self.assertEqual(FlagMapper.format_errno(99999), "ERRNO(99999)")
+
+
+class FsTypeTests(unittest.TestCase):
+    def test_zero_is_empty(self):
+        self.assertEqual(FlagMapper.format_fs_type(0), "")
+
+    def test_ext_magic(self):
+        self.assertEqual(FlagMapper.format_fs_type(0xEF53), "EXT2/3/4")
+
+    def test_unknown_magic_falls_back(self):
+        self.assertEqual(FlagMapper.format_fs_type(0x1234), "FS(0x1234)")
+
+
+class OpTypeTests(unittest.TestCase):
+    def test_op_fs_types_known(self):
+        m = FlagMapper()
+        self.assertEqual(m.op_fs_types.get(3), "OPEN")
+        self.assertEqual(m.op_fs_types.get(1), "READ")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_path_resolver.py
+++ b/tests/test_path_resolver.py
@@ -1,0 +1,70 @@
+"""
+Unit tests for src.tracer.PathResolver.
+
+Focuses on the in-memory cache behaviour — especially cleanup_old_cache, which
+is the bounded-memory safety valve for long-running traces — without touching
+/proc.
+"""
+
+import os
+import sys
+import time
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from src.tracer.PathResolver import PathResolver
+
+
+class ResolvePathTests(unittest.TestCase):
+    def test_cache_hit_returns_path(self):
+        r = PathResolver()
+        r.inode_to_path[42] = "/tmp/foo"
+        self.assertEqual(r.resolve_path(42), "/tmp/foo")
+
+    def test_fallback_to_filename(self):
+        r = PathResolver()
+        self.assertEqual(r.resolve_path(7, filename="bar.txt"), "bar.txt")
+
+    def test_fallback_to_inode_marker(self):
+        r = PathResolver()
+        self.assertEqual(r.resolve_path(7), "[inode:7]")
+
+
+class CleanupOldCacheTests(unittest.TestCase):
+    def test_prunes_stale_pids(self):
+        r = PathResolver(cache_timeout=10)
+        # last_update older than cache_timeout * 10 should be removed
+        stale_pid = 1234
+        r.pid_to_files[stale_pid] = {1: "/a"}
+        r.last_update[stale_pid] = time.time() - (r.cache_timeout * 10 + 5)
+
+        fresh_pid = 5678
+        r.pid_to_files[fresh_pid] = {2: "/b"}
+        r.last_update[fresh_pid] = time.time()
+
+        r.cleanup_old_cache()
+
+        self.assertNotIn(stale_pid, r.pid_to_files)
+        self.assertNotIn(stale_pid, r.last_update)
+        self.assertIn(fresh_pid, r.pid_to_files)
+
+    def test_caps_inode_cache(self):
+        r = PathResolver()
+        for i in range(10001):
+            r.inode_to_path[i] = f"/path/{i}"
+        r.cleanup_old_cache()
+        # Over the 10000 threshold it trims to the most recent 5000 entries.
+        self.assertEqual(len(r.inode_to_path), 5000)
+        # The most recently inserted entries are the ones retained.
+        self.assertIn(10000, r.inode_to_path)
+
+    def test_is_idempotent_when_small(self):
+        r = PathResolver()
+        r.inode_to_path[1] = "/a"
+        r.cleanup_old_cache()
+        self.assertEqual(r.inode_to_path, {1: "/a"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,80 @@
+"""
+Unit tests for src.utility.utils.
+
+These cover the pure-Python helpers that do not depend on bcc/kernel access,
+so they run in any environment with a stdlib Python (no root, no eBPF).
+Written with stdlib unittest so they run via either:
+    python3 -m unittest discover -s tests
+    pytest tests/
+"""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from src.utility.utils import (
+    format_csv_row,
+    simple_hash,
+    hash_component,
+    hash_filename_in_path,
+    inet4_from_event,
+)
+
+
+class FormatCsvRowTests(unittest.TestCase):
+    def test_plain_fields(self):
+        self.assertEqual(format_csv_row("a", "b", "c"), "a,b,c")
+
+    def test_no_trailing_newline(self):
+        self.assertFalse(format_csv_row("a", "b").endswith("\n"))
+
+    def test_quotes_fields_with_commas(self):
+        self.assertEqual(format_csv_row("a", "b,c"), 'a,"b,c"')
+
+    def test_escapes_embedded_quotes(self):
+        self.assertEqual(format_csv_row('say "hi"'), '"say ""hi"""')
+
+    def test_integers_are_stringified(self):
+        self.assertEqual(format_csv_row(1, 2, 3), "1,2,3")
+
+
+class HashTests(unittest.TestCase):
+    def test_simple_hash_is_deterministic(self):
+        self.assertEqual(simple_hash("hello"), simple_hash("hello"))
+
+    def test_simple_hash_length_respected(self):
+        self.assertEqual(len(simple_hash("hello", 8)), 8)
+
+    def test_simple_hash_differs_for_different_input(self):
+        self.assertNotEqual(simple_hash("a"), simple_hash("b"))
+
+    def test_hash_component_preserves_extension(self):
+        out = hash_component("document.txt")
+        self.assertTrue(out.endswith(".txt"))
+        self.assertNotIn("document", out)
+
+    def test_hash_component_no_extension_when_disabled(self):
+        out = hash_component("document.txt", keep_ext=False)
+        self.assertFalse(out.endswith(".txt"))
+
+    def test_hash_filename_in_path_keeps_directory_and_ext(self):
+        out = hash_filename_in_path(Path("/home/user/secret.log"))
+        self.assertTrue(out.startswith("/home/user/"))
+        self.assertTrue(out.endswith(".log"))
+        self.assertNotIn("secret", out)
+
+
+class InetTests(unittest.TestCase):
+    def test_inet4_roundtrip(self):
+        # 127.0.0.1 in network byte order as a uint32
+        import socket
+        import struct
+        packed = struct.unpack("!I", socket.inet_aton("127.0.0.1"))[0]
+        self.assertEqual(inet4_from_event(packed), "127.0.0.1")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

A review of the repo surfaced a cluster of long-run robustness bugs plus a complete absence of unit tests. This PR fixes the high-value, contained issues and adds a first test suite.

### Fixes

1. **Unbounded memory growth (most serious for an "indefinite" tracer)**
   - `PathResolver.cleanup_old_cache()` — which prunes stale per-PID entries and caps `inode_to_path` at 10k — **was never called anywhere**. It's now invoked periodically.
   - `IOTracer.cmdline_cache` was only evicted on `PROCESS_EXEC`, so every PID that ever ran left a permanent entry. It's now capped (`_cmdline_cache_max`), dropping the oldest half when exceeded while preserving the "survive process exit" property the cache was designed for.
   - Both run from the **perf-callback (polling) thread**, the only thread that mutates these caches, so no new cross-thread race is introduced.

2. **Data race on `WriteManager` file handles**
   - `flush_*_only()` runs on the polling thread (via `append_*_log`) while `write_to_disk()` runs concurrently from the periodic-flush thread. They shared `_*_handle`/buffers with no lock, and `flush_*_only` closes+reopens the handle mid-flight — so a concurrent write could hit a closed/stale handle or interleave rows. Each output stream now has its own lock guarding buffer+handle access. (No nested lock acquisition, so no deadlock risk.)

3. **Pending uploads dropped on shutdown**
   - On exit the tracer called `stop_worker(False)`, which set the stop event immediately and abandoned anything still queued. Now drains the queue first via `stop_worker(True, timeout=30)`.

4. **Swallowed error details** — `compress_log`/`compress_dir` now include the exception in their error logs; bare `except:` in `PathResolver` narrowed to `except OSError`; `cleanup_old_cache` made tolerant of missing keys.

### Tests

- New `tests/` suite (stdlib `unittest`, also pytest-collectable) covering the dependency-free logic: `format_csv_row` escaping, hashing/anonymization helpers, `FlagMapper` flag/errno/fs-type decoding, and `PathResolver` cache + `cleanup_old_cache` behaviour. 31 tests, all passing.
- New `unit-tests.yml` CI job runs them on push (no kernel/bcc required), complementing the existing BPF-compile job.

## Test plan
- `python3 -m unittest discover -s tests -v` → 31 passed locally.
- `py_compile` on all edited modules passes.
- Behavioural changes are confined to caches/locks/shutdown; no trace schema or output-format changes.

https://claude.ai/code/session_01F9ZJAaqq3qHtaQTf2mtMNx

---
_Generated by [Claude Code](https://claude.ai/code/session_01F9ZJAaqq3qHtaQTf2mtMNx)_