### PR TITLE
Trace analysis fixes + self-describing format (schema v2)

### DIFF
--- a/docs/traces/BLOCK_IO_EVENTS.md
+++ b/docs/traces/BLOCK_IO_EVENTS.md
@@ -22,6 +22,7 @@
 | 12 | Queue Latency | `float` | Queue/scheduler latency in milliseconds (insert → issue); empty if unavailable |
 | 13 | Command Flags | `string` | Pipe-separated REQ_* flags (e.g., `REQ_SYNC\|REQ_META`); empty if no flags set or on kernel ≥ 5.17 |
 | 14 | Operation Code | `string` | Raw block operation code name (e.g., `REQ_OP_READ`, `REQ_OP_WRITE`); empty on kernel ≥ 5.17 |
+| 15 | Request ID | `u64` | Monotonic per-request id, unique within a trace session and assigned at issue time. Distinguishes separate I/Os that reuse the same `(Device, Sector)` pair, which are otherwise identical apart from their timestamps |
 
 > **Note:** Command Flags (field 13) and Operation Code (field 14) are only available on Linux kernel versions < 5.17. The `cmd_flags` field was removed from the `block_rq_complete` tracepoint in kernel 5.17+. On newer kernels (including 5.17, 6.x), these fields will always be empty. Use the Operation field (field 5) and RWBS flags to distinguish I/O types on newer kernels.
 

--- a/docs/traces/BLOCK_IO_EVENTS.md
+++ b/docs/traces/BLOCK_IO_EVENTS.md
@@ -23,6 +23,7 @@
 | 13 | Command Flags | `string` | Pipe-separated REQ_* flags (e.g., `REQ_SYNC\|REQ_META`); empty if no flags set or on kernel ≥ 5.17 |
 | 14 | Operation Code | `string` | Raw block operation code name (e.g., `REQ_OP_READ`, `REQ_OP_WRITE`); empty on kernel ≥ 5.17 |
 | 15 | Request ID | `u64` | Monotonic per-request id, unique within a trace session and assigned at issue time. Distinguishes separate I/Os that reuse the same `(Device, Sector)` pair, which are otherwise identical apart from their timestamps |
+| 16 | mono_ns | `u64` | Completion time in `CLOCK_MONOTONIC` nanoseconds (kernel `bpf_ktime_get_ns()`) — the common clock for correlating across streams. Add the manifest's `clock.mono_to_real_offset_ns` to recover wall-clock ns. |
 
 > **Note:** Command Flags (field 13) and Operation Code (field 14) are only available on Linux kernel versions < 5.17. The `cmd_flags` field was removed from the `block_rq_complete` tracepoint in kernel 5.17+. On newer kernels (including 5.17, 6.x), these fields will always be empty. Use the Operation field (field 5) and RWBS flags to distinguish I/O types on newer kernels.
 

--- a/docs/traces/FILESYSTEM_SNAPSHOT.md
+++ b/docs/traces/FILESYSTEM_SNAPSHOT.md
@@ -21,6 +21,7 @@
 | 4 | Creation Time | `datetime` | File creation time (`st_birthtime`); falls back to `st_mtime` if unavailable |
 | 5 | Modification Time | `datetime` | Last data modification time (`st_mtime`) |
 | 6 | Access Time | `datetime` | Last access time (`st_atime`) |
+| 7 | mono_ns | `u64` | Snapshot time in `CLOCK_MONOTONIC` nanoseconds (`time.monotonic_ns()`, captured once per snapshot) — the common cross-stream correlation clock; add the manifest's `clock.mono_to_real_offset_ns` to recover wall-clock ns. |
 
 ## Excluded Filesystems
 

--- a/docs/traces/MANIFEST.md
+++ b/docs/traces/MANIFEST.md
@@ -1,0 +1,85 @@
+# Trace Manifest (`manifest.json`)
+
+Every trace session writes a `manifest.json` at the root of its output
+directory. It makes the trace **self-describing**: the exact schema, the clocks,
+the tracer/host versions, the session window, and collection diagnostics — so a
+consumer never has to hard-code column layouts or guess which version produced a
+trace.
+
+It is written when tracing starts (so a schema exists even if the run is killed)
+and rewritten at shutdown with the stop time and final diagnostics.
+
+## Schema versioning
+
+`schema_version` identifies the on-disk format. Consumers should read it and
+adapt rather than assume a fixed layout.
+
+| Version | Format |
+|---------|--------|
+| 1 | Headerless CSVs, no manifest, per-stream clocks. |
+| 2 | **CSV header row** on every file + this manifest + a common `mono_ns` (CLOCK_MONOTONIC) column appended to every stream. |
+
+As of **schema_version 2**:
+
+- Every CSV file (including rotated parts) begins with a **header row** naming
+  its columns — the same names listed under `streams.<key>.columns` here.
+- Every record carries a trailing **`mono_ns`** column: `CLOCK_MONOTONIC`
+  nanoseconds, the single clock shared across all streams for correlation
+  (kernel `bpf_ktime_get_ns()` for perf-event streams; `time.monotonic_ns()` for
+  the userspace snapshot streams). The wall-clock `timestamp` column is still
+  column 1.
+
+## Structure
+
+```jsonc
+{
+  "schema_version": 2,
+  "streams": {
+    "fs":  { "subdir": "fs", "filename_prefix": "fs", "description": "...",
+             "wall_clock": "CLOCK_REALTIME (derived from kernel CLOCK_MONOTONIC)",
+             "columns": [ { "name": "timestamp", "type": "datetime", "unit": "", "description": "..." }, ... ] },
+    "ds":  { ... }, "cache": { ... }, "pagefault": { ... },
+    "process": { ... }, "filesystem_snapshot": { ... }
+  },
+  "tracer":  { "version": "..." },
+  "machine_id": "...",
+  "host":    { "platform": "...", "kernel": "...", "python": "..." },
+  "clock": {
+    "wall_clock": "CLOCK_REALTIME",
+    "mono_clock": "CLOCK_MONOTONIC",
+    "mono_to_real_offset_ns": 1700000000000000000,
+    "note": "mono_ns is the common cross-stream correlation clock ..."
+  },
+  "session": { "started_at": "ISO-8601", "stopped_at": "ISO-8601", "duration_seconds": 123.4 },
+  "diagnostics": {
+    "attached_probes": [ "vfs_read", "vfs_write", "block_rq_complete", ... ],
+    "lost_events":     { "fs": 0, "ds": 0 },
+    "rows_written":    { "VFS": 12345, "Block": 678, ... },
+    "block":           { "issued": 1000, "completed": 990, "missed": 10 }
+  }
+}
+```
+
+## Correlating across streams
+
+All streams share the `mono_ns` clock, so records from different streams can be
+ordered against each other directly by `mono_ns`. To convert any `mono_ns` to
+wall-clock nanoseconds:
+
+```
+wall_ns = mono_ns + clock.mono_to_real_offset_ns
+```
+
+## Diagnostics — spotting collection problems
+
+- **`lost_events`** — per-stream count of kernel perf-buffer overruns (events
+  dropped before userspace read them). Non-zero means the buffer was too small
+  or the consumer fell behind.
+- **`rows_written`** — total rows persisted per stream. A stream with attached
+  probes but `0` rows is a dead/disabled collection path.
+- **`block`** — `issued`/`completed`/`missed` block requests. A high
+  `missed`/`completed` ratio means the issue-tracking map was evicted under load
+  (completions dropped) — the explanation if block events thin out before the
+  end of a long trace.
+- **`attached_probes`** — the kernel functions the tracer successfully attached
+  to this session.

--- a/docs/traces/PAGE_CACHE_EVENTS.md
+++ b/docs/traces/PAGE_CACHE_EVENTS.md
@@ -27,6 +27,7 @@
 | 8 | CPU ID | `u32` | CPU where event occurred |
 | 9 | Device ID | `u32` | Device ID from the file's superblock |
 | 10 | Count | `u32` | Number of pages affected by the operation (1 for single-page, N for bulk) |
+| 11 | mono_ns | `u64` | Record time in `CLOCK_MONOTONIC` nanoseconds (kernel `bpf_ktime_get_ns()`) — the common cross-stream correlation clock; add the manifest's `clock.mono_to_real_offset_ns` to recover wall-clock ns. |
 
 ## Event Types
 

--- a/docs/traces/PAGE_FAULT_EVENTS.md
+++ b/docs/traces/PAGE_FAULT_EVENTS.md
@@ -19,6 +19,7 @@
 | 8 | Offset | `u64` | File offset in pages (`pgoff`); empty if `0` |
 | 9 | Address | `hex string` | Faulting virtual address (e.g., `0x7f4a3b2c1000`); empty if `0` |
 | 10 | Device ID | `u32` | Device ID from the file's superblock; empty if `0` |
+| 11 | mono_ns | `u64` | Record time in `CLOCK_MONOTONIC` nanoseconds (kernel `bpf_ktime_get_ns()`) — the common cross-stream correlation clock; add the manifest's `clock.mono_to_real_offset_ns` to recover wall-clock ns. |
 
 ## Fault Types
 

--- a/docs/traces/PROCESS_SNAPSHOT.md
+++ b/docs/traces/PROCESS_SNAPSHOT.md
@@ -23,6 +23,7 @@
 | 9 | CPU 2m | `float` | CPU utilization % averaged over last 2 minutes |
 | 10 | CPU 1h | `float` | CPU utilization % averaged over last 1 hour |
 | 11 | Status | `string` | Process status (see table below) |
+| 12 | mono_ns | `u64` | Snapshot time in `CLOCK_MONOTONIC` nanoseconds (`time.monotonic_ns()`, captured once per snapshot) — the common cross-stream correlation clock; add the manifest's `clock.mono_to_real_offset_ns` to recover wall-clock ns. |
 
 ## Process Status Values
 

--- a/docs/traces/VFS_EVENTS.md
+++ b/docs/traces/VFS_EVENTS.md
@@ -176,7 +176,7 @@ The path captured is relative to the mount namespace of the probed process. In c
 | 14 | cmdline | `string` | Full command line (`argv` joined by spaces) of the process that triggered the event; empty if unresolvable (see below) |
 | 15 | return_value | `s64` | Raw syscall return value for `READ`/`WRITE` (bytes moved if `>= 0`, negative `errno` on failure); empty for other operations |
 | 16 | errno | `string` | Error name (e.g. `EAGAIN`) when a `READ`/`WRITE` failed (`return_value < 0`); empty on success or for other operations |
-| 17 | bytes_completed (actual) | `u64` | **Actual** bytes read/written for `READ`/`WRITE` (`return_value` when `>= 0`); compare against column 6 (`Size`, requested) to detect short I/O. Empty on failure or for other operations |
+| 17 | bytes_completed (actual) | `u64` | **Actual** bytes read/written for `READ`/`WRITE` (`return_value` when `>= 0`); compare against column 6 (`Size (requested)`) to detect short I/O. Empty on failure or for other operations |
 | 18 | duration_ns | `u64` | Operation duration in nanoseconds (entry → return) for `READ`/`WRITE`; empty for other operations |
 | 19 | device | `string` | Backing device of the file as `major:minor` (from `super_block->s_dev`); populated for `READ`/`WRITE`/`OPEN`; empty otherwise |
 | 20 | ppid | `u32` | Parent process ID (`real_parent->tgid`); populated for `READ`/`WRITE`/`OPEN`; empty otherwise |

--- a/docs/traces/VFS_EVENTS.md
+++ b/docs/traces/VFS_EVENTS.md
@@ -160,12 +160,12 @@ The path captured is relative to the mount namespace of the probed process. In c
 
 | # | Field | Type | Description |
 |---|-------|------|-------------|
-| 1 | Timestamp | `datetime` | Event timestamp (`YYYY-MM-DD HH:MM:SS.ffffff`) |
+| 1 | Timestamp | `datetime` | Event timestamp (`YYYY-MM-DD HH:MM:SS.ffffff`), derived from the kernel's per-event `bpf_ktime_get_ns()` (CLOCK_MONOTONIC) converted to wall-clock. This is the time the event actually occurred, so rows are correctly ordered when sorted by this column even though the per-CPU perf buffers deliver them in batches. |
 | 2 | Operation | `string` | VFS operation type (see table below) |
 | 3 | PID | `u32` | Process ID |
 | 4 | Command | `string` | Process name (max 16 characters) |
 | 5 | Filename | `string` | File path; for dual-path operations (`RENAME`, `LINK`, `SYMLINK`) formatted as `old_path -> new_path` |
-| 6 | Size | `u64` | I/O size in bytes (`0` for non-I/O operations) |
+| 6 | Size (requested) | `u64` | **Requested** I/O size in bytes — the `count` argument to `read`/`write` (or operation size for others); `0` for non-I/O operations. The **actual** bytes transferred are in column 17 (`bytes_completed`), which can be smaller (short read/write). |
 | 7 | Inode | `u64` | File inode number; empty if `0` |
 | 8 | Flags | `string` | Operation-specific flags for non-MMAP operations (see tables below); empty when the operation has no defined flag value to render |
 | 9 | Offset | `u64` | File offset for positioned I/O; empty if `0` |
@@ -176,7 +176,7 @@ The path captured is relative to the mount namespace of the probed process. In c
 | 14 | cmdline | `string` | Full command line (`argv` joined by spaces) of the process that triggered the event; empty if unresolvable (see below) |
 | 15 | return_value | `s64` | Raw syscall return value for `READ`/`WRITE` (bytes moved if `>= 0`, negative `errno` on failure); empty for other operations |
 | 16 | errno | `string` | Error name (e.g. `EAGAIN`) when a `READ`/`WRITE` failed (`return_value < 0`); empty on success or for other operations |
-| 17 | bytes_completed | `u64` | Bytes actually read/written for `READ`/`WRITE` (`return_value` when `>= 0`); empty on failure or for other operations |
+| 17 | bytes_completed (actual) | `u64` | **Actual** bytes read/written for `READ`/`WRITE` (`return_value` when `>= 0`); compare against column 6 (`Size`, requested) to detect short I/O. Empty on failure or for other operations |
 | 18 | duration_ns | `u64` | Operation duration in nanoseconds (entry → return) for `READ`/`WRITE`; empty for other operations |
 | 19 | device | `string` | Backing device of the file as `major:minor` (from `super_block->s_dev`); populated for `READ`/`WRITE`/`OPEN`; empty otherwise |
 | 20 | ppid | `u32` | Parent process ID (`real_parent->tgid`); populated for `READ`/`WRITE`/`OPEN`; empty otherwise |

--- a/docs/traces/VFS_EVENTS.md
+++ b/docs/traces/VFS_EVENTS.md
@@ -182,6 +182,7 @@ The path captured is relative to the mount namespace of the probed process. In c
 | 20 | ppid | `u32` | Parent process ID (`real_parent->tgid`); populated for `READ`/`WRITE`/`OPEN`; empty otherwise |
 | 21 | container_id | `u64` | cgroup v2 id of the process (container identifier); populated for `READ`/`WRITE`/`OPEN`; empty otherwise |
 | 22 | fs_type | `string` | Source filesystem name derived from the superblock magic (e.g. `EXT2/3/4`, `XFS`, `BTRFS`, `OVERLAYFS`, `NFS`), letting physical-disk I/O be distinguished from network/overlay sources; populated for `READ`/`WRITE`/`OPEN`; empty otherwise |
+| 23 | mono_ns | `u64` | Record time in `CLOCK_MONOTONIC` nanoseconds (kernel `bpf_ktime_get_ns()`) — the common clock for correlating across streams. Add the manifest's `clock.mono_to_real_offset_ns` to recover wall-clock ns. |
 
 > **Note on filesystem classification (`fs_type`) and sockets:** virtual/pseudo filesystems (procfs, sysfs, tmpfs, cgroupfs, debugfs, …) and sockets/pipes are filtered out at the eBPF layer by `is_regular_file()`, so they never appear as fs-trace rows. Their *absence* is the signal that an access was virtual/socket I/O rather than physical filesystem I/O. The `fs_type` column then names the concrete backing filesystem of the events that do appear, so physical-disk filesystems (`EXT2/3/4`, `XFS`, `BTRFS`, …) can be told apart from network (`NFS`, `CIFS`) and container-overlay (`OVERLAYFS`) sources.
 

--- a/docs/traces/VFS_EVENTS.md
+++ b/docs/traces/VFS_EVENTS.md
@@ -164,7 +164,7 @@ The path captured is relative to the mount namespace of the probed process. In c
 | 2 | Operation | `string` | VFS operation type (see table below) |
 | 3 | PID | `u32` | Process ID |
 | 4 | Command | `string` | Process name (max 16 characters) |
-| 5 | Filename | `string` | File path; for dual-path operations (`RENAME`, `LINK`, `SYMLINK`) formatted as `old_path -> new_path` |
+| 5 | Filename | `string` | File path; for dual-path operations (`RENAME`, `LINK`, `SYMLINK`) formatted as `old_path -> new_path`. For `OPEN`, the path is resolved to absolute via `/proc/<pid>/fd`; if that races (fd already closed) and the captured path was relative, it is resolved against the openat `dirfd` / process cwd as a fallback |
 | 6 | Size (requested) | `u64` | **Requested** I/O size in bytes — the `count` argument to `read`/`write` (or operation size for others); `0` for non-I/O operations. The **actual** bytes transferred are in column 17 (`bytes_completed`), which can be smaller (short read/write). |
 | 7 | Inode | `u64` | File inode number; empty if `0` |
 | 8 | Flags | `string` | Operation-specific flags for non-MMAP operations (see tables below); empty when the operation has no defined flag value to render |

--- a/src/tracer/IOTracer.py
+++ b/src/tracer/IOTracer.py
@@ -19,6 +19,7 @@ Usage:
 import shutil
 import signal
 import os
+import ctypes
 from bcc import BPF
 import time
 import sys
@@ -313,6 +314,14 @@ class IOTracer:
                     else:
                         filename = self.path_resolver.resolve_open_path(
                             pid=event.pid, inode=event.inode, filename=filename
+                        )
+                    # Last resort: if still relative (fd already closed / process
+                    # gone), resolve the captured relative path against the
+                    # openat dirfd or process cwd.
+                    if filename and not filename.startswith('/'):
+                        dirfd = event.dirfd if hasattr(event, 'dirfd') else self.path_resolver.AT_FDCWD
+                        filename = self.path_resolver.resolve_relative(
+                            pid=event.pid, dirfd=dirfd, relpath=filename, inode=event.inode
                         )
             else:
                 cached = self.path_resolver.inode_to_path.get(event.inode)
@@ -800,8 +809,11 @@ class IOTracer:
         # Note: op_code is 0 on kernel 5.17+ where cmd_flags is unavailable - don't decode it
         op_code = event.op_code if hasattr(event, 'op_code') else 0
         op_code_str = self.flag_mapper.decode_block_op_code(op_code) if (op_code is not None and op_code != 0) else ""
-        
-        output = format_csv_row(timestamp, pid, comm, sector, ops_str, bio_size, latency_ms, tid, cpu_id, ppid, dev_str, queue_time_ms, cmd_flags_str, op_code_str)
+
+        # Monotonic per-request id (disambiguates repeated I/O to the same sector)
+        req_id = event.req_id if hasattr(event, 'req_id') else ""
+
+        output = format_csv_row(timestamp, pid, comm, sector, ops_str, bio_size, latency_ms, tid, cpu_id, ppid, dev_str, queue_time_ms, cmd_flags_str, op_code_str, req_id)
 
 
         if sector == 0 and bio_size == 0:
@@ -971,10 +983,37 @@ class IOTracer:
 
         run_with_spinner("Flushing trace data", _flush)
 
+    def _log_block_diagnostics(self):
+        """Summarise block-tracing health from the per-CPU ``block_stats`` map.
+
+        Reports issued vs. completed requests and how many completions arrived
+        with no tracked issue context. A high miss rate means the issue map was
+        evicted under load (completions dropped) — the likely explanation if
+        block events appear to stop before the end of a long trace.
+        """
+        try:
+            stats = self.b["block_stats"]
+            issued    = sum(stats[ctypes.c_int(0)])
+            completed = sum(stats[ctypes.c_int(1)])
+            missed    = sum(stats[ctypes.c_int(2)])
+        except Exception:
+            return
+
+        if not (issued or completed or missed):
+            return
+
+        total_completions = completed + missed
+        miss_pct = (missed / total_completions * 100) if total_completions else 0.0
+        logger("info",
+               f"Block diagnostics: {issued} issued, {completed} completed, "
+               f"{missed} completions without a tracked issue "
+               f"({miss_pct:.1f}% of completions). A high miss rate indicates the "
+               f"issue map was evicted under load (dropped completions).")
+
     def _lost_cb(self, lost):
         """
         Callback for handling lost events in the perf buffer.
-        
+
         Args:
             lost: Number of events that were lost
         """
@@ -1113,7 +1152,9 @@ class IOTracer:
             if self.verbose:
                 actual_duration = time.time() - start
                 logger("info", f"Trace completed after {actual_duration:.2f} seconds")
-            
+
+            self._log_block_diagnostics()
+
             print()
             logger("info", "Trace stopped")
 

--- a/src/tracer/IOTracer.py
+++ b/src/tracer/IOTracer.py
@@ -197,35 +197,34 @@ class IOTracer:
             print("Your device are incompatible with this version of IO Tracer. Please notify us at io-tracer@googlegroups.com")
             sys.exit(1)
 
-    # Pseudo-filesystem superblock magics whose I/O is kernel/diagnostic noise
-    # (procfs, sysfs, cgroup v1/v2, debugfs, tracefs, bpf) rather than real
-    # storage traffic. Events backed by these filesystems are dropped.
-    _PSEUDO_FS_MAGICS = frozenset({
-        0x9FA0,      # PROCFS
-        0x62656572,  # SYSFS
-        0x27E0EB,    # CGROUP (v1)
-        0x63677270,  # CGROUP2
-        0x64626720,  # DEBUGFS
-        0x74726163,  # TRACEFS
-        0xCAFE4A11,  # BPF
-    })
-
     def _should_filter_process(self, comm: str) -> bool:
         """Helper to filter out I/O unrelated system processes."""
         prefixes = ("swapper/", "ksoftirqd/", "irq/", "migration/", "stopper/")
         return comm.startswith(prefixes)
 
+    def _ns_to_walltime(self, ts_ns):
+        """Convert a kernel ``bpf_ktime_get_ns()`` (CLOCK_MONOTONIC) value to a
+        wall-clock ``datetime``.
+
+        Returns the userspace receive time when ``ts_ns`` is missing/zero, or if
+        the value is out of ``datetime``'s representable range — a garbage
+        timestamp must never raise out of a perf-buffer callback.
+        """
+        if not ts_ns:
+            return datetime.today()
+        try:
+            return datetime.fromtimestamp((ts_ns + self._mono_to_real_offset_ns) / 1e9)
+        except (OverflowError, OSError, ValueError):
+            return datetime.today()
+
     def _event_walltime(self, event):
-        """Convert a kernel event's bpf_ktime_get_ns() timestamp to wall-clock.
+        """Wall-clock time for a perf event, from its kernel ``ts`` field.
 
         Using the kernel's per-event monotonic time (rather than the userspace
         receive time) yields correctly ordered timestamps across the per-CPU
         perf buffers. Falls back to receive time when the event carries no ts.
         """
-        ts_ns = getattr(event, "ts", 0)
-        if not ts_ns:
-            return datetime.today()
-        return datetime.fromtimestamp((ts_ns + self._mono_to_real_offset_ns) / 1e9)
+        return self._ns_to_walltime(getattr(event, "ts", 0))
 
     def _print_event(self, cpu, data, size):        
         """
@@ -264,11 +263,6 @@ class IOTracer:
             comm = "[decode_error]"
 
         if self._should_filter_process(comm):
-            return
-
-        # Drop I/O backed by pseudo-filesystems (procfs/sysfs/cgroup/...), which
-        # is kernel/diagnostic noise rather than real storage traffic.
-        if getattr(event, "fs_magic", 0) in self._PSEUDO_FS_MAGICS:
             return
 
         inode_val = event.inode if event.inode != 0 else ""
@@ -327,6 +321,13 @@ class IOTracer:
                 cached = self.path_resolver.inode_to_path.get(event.inode)
                 if cached:
                     filename = cached
+
+        # Invariant: an OPEN filename is absolute or a clean basename, never an
+        # unanchored relative path. If it is still relative here (inode==0 skipped
+        # resolution above, or every resolver raced a closed fd/cwd), reduce it to
+        # its basename. Anonymous mode already hashed the path at decode time.
+        if op_name == 'OPEN' and not self.anonymous and filename and not filename.startswith('/'):
+            filename = os.path.basename(filename) or filename
 
         if raw_address:
             if op_name == "MMAP":
@@ -881,7 +882,10 @@ class IOTracer:
         if e.event_type != 2:
             return
 
-        ts = datetime.today()
+        # Use the kernel event time (io_uring's struct names it timestamp_ns) so
+        # these mirrored rows share the same clock as the syscall-origin fs rows
+        # they interleave with in the fs trace.
+        ts = self._ns_to_walltime(getattr(e, "timestamp_ns", 0))
         comm = e.comm.decode("utf-8", errors="replace").strip("\x00")
 
         if self._should_filter_process(comm):

--- a/src/tracer/IOTracer.py
+++ b/src/tracer/IOTracer.py
@@ -147,7 +147,9 @@ class IOTracer:
         # wall-clock time. Using the kernel's per-event timestamp instead of the
         # userspace receive time keeps rows correctly ordered in time across the
         # per-CPU perf buffers (which deliver in batches, not global order).
-        self._mono_to_real_offset = time.time() - time.clock_gettime(time.CLOCK_MONOTONIC)
+        # Integer-ns math avoids the float precision loss of subtracting two
+        # large second-valued floats.
+        self._mono_to_real_offset_ns = time.time_ns() - time.monotonic_ns()
         # The tracer (and its in-process snapshot/upload threads) read /proc,
         # write the trace files, and upload them — all of which is self-noise we
         # don't want in the trace. Filter events from our own pid.
@@ -212,10 +214,6 @@ class IOTracer:
         prefixes = ("swapper/", "ksoftirqd/", "irq/", "migration/", "stopper/")
         return comm.startswith(prefixes)
 
-    def _skip_event(self, comm: str, pid: int) -> bool:
-        """Drop events from kernel threads and the tracer's own processes."""
-        return pid == self._self_pid or self._should_filter_process(comm)
-
     def _event_walltime(self, event):
         """Convert a kernel event's bpf_ktime_get_ns() timestamp to wall-clock.
 
@@ -226,7 +224,7 @@ class IOTracer:
         ts_ns = getattr(event, "ts", 0)
         if not ts_ns:
             return datetime.today()
-        return datetime.fromtimestamp(ts_ns / 1e9 + self._mono_to_real_offset)
+        return datetime.fromtimestamp((ts_ns + self._mono_to_real_offset_ns) / 1e9)
 
     def _print_event(self, cpu, data, size):        
         """
@@ -243,6 +241,9 @@ class IOTracer:
         self._tick_maintenance()
 
         event = self.b["events"].event(data)
+        # Drop the tracer's own I/O before any decode/timestamp work.
+        if event.pid == self._self_pid:
+            return
         op_name = self.flag_mapper.op_fs_types.get(event.op, "[unknown]")
 
         try:
@@ -261,7 +262,7 @@ class IOTracer:
         except UnicodeDecodeError:
             comm = "[decode_error]"
 
-        if self._skip_event(comm, event.pid):
+        if self._should_filter_process(comm):
             return
 
         # Drop I/O backed by pseudo-filesystems (procfs/sysfs/cgroup/...), which
@@ -650,6 +651,9 @@ class IOTracer:
         self._tick_maintenance()
 
         event = self.b["events_dual"].event(data)
+        # Drop the tracer's own I/O before any decode/timestamp work.
+        if event.pid == self._self_pid:
+            return
         op_name = self.flag_mapper.op_fs_types.get(event.op, "[unknown]")
         
         try:
@@ -669,7 +673,7 @@ class IOTracer:
         except UnicodeDecodeError:
             comm = "[decode_error]"
 
-        if self._skip_event(comm, event.pid):
+        if self._should_filter_process(comm):
             return
 
         inode_old = event.inode_old if event.inode_old != 0 else ""
@@ -709,11 +713,13 @@ class IOTracer:
             size: Size of the event data
         """
         event = self.b["cache_events"].event(data)
-        timestamp = self._event_walltime(event)
         pid = event.pid
+        if pid == self._self_pid:
+            return
+        timestamp = self._event_walltime(event)
         comm = event.comm.decode('utf-8', errors='replace')
 
-        if self._skip_event(comm, pid):
+        if self._should_filter_process(comm):
             return
         
         event_types = {
@@ -756,12 +762,14 @@ class IOTracer:
         """
         event = self.b["bl_events"].event(data)
 
-        timestamp = self._event_walltime(event)
         pid = event.pid
+        if pid == self._self_pid:
+            return
+        timestamp = self._event_walltime(event)
         tid = event.tid
         comm = event.comm.decode('utf-8', errors='replace')
 
-        if self._skip_event(comm, pid):
+        if self._should_filter_process(comm):
             return
             
         sector = event.sector
@@ -816,13 +824,14 @@ class IOTracer:
             size: Size of the event data
         """
         event = self.b["pagefault_events"].event(data)
-        timestamp = self._event_walltime(event)
-
         pid = event.pid
+        if pid == self._self_pid:
+            return
+        timestamp = self._event_walltime(event)
         tid = event.tid
         comm = event.comm.decode('utf-8', errors='replace')
 
-        if self._skip_event(comm, pid):
+        if self._should_filter_process(comm):
             return
             
         address = hex(event.address) if event.address else ""

--- a/src/tracer/IOTracer.py
+++ b/src/tracer/IOTracer.py
@@ -142,6 +142,17 @@ class IOTracer:
         self.mmap_regions       = {}
         self.cmdline_cache      = {}  # pid -> cmdline, populated on first successful read
 
+        # Wall-clock conversion for kernel event timestamps. bpf_ktime_get_ns()
+        # is CLOCK_MONOTONIC (ns since boot); adding this offset recovers
+        # wall-clock time. Using the kernel's per-event timestamp instead of the
+        # userspace receive time keeps rows correctly ordered in time across the
+        # per-CPU perf buffers (which deliver in batches, not global order).
+        self._mono_to_real_offset = time.time() - time.clock_gettime(time.CLOCK_MONOTONIC)
+        # The tracer (and its in-process snapshot/upload threads) read /proc,
+        # write the trace files, and upload them — all of which is self-noise we
+        # don't want in the trace. Filter events from our own pid.
+        self._self_pid = os.getpid()
+
         # Bounded-cache maintenance. The path resolver and cmdline caches are
         # only evicted on PROCESS_EXEC, so over a long-running trace they would
         # otherwise grow without bound. Maintenance runs from the perf-callback
@@ -183,10 +194,39 @@ class IOTracer:
             print("Your device are incompatible with this version of IO Tracer. Please notify us at io-tracer@googlegroups.com")
             sys.exit(1)
 
+    # Pseudo-filesystem superblock magics whose I/O is kernel/diagnostic noise
+    # (procfs, sysfs, cgroup v1/v2, debugfs, tracefs, bpf) rather than real
+    # storage traffic. Events backed by these filesystems are dropped.
+    _PSEUDO_FS_MAGICS = frozenset({
+        0x9FA0,      # PROCFS
+        0x62656572,  # SYSFS
+        0x27E0EB,    # CGROUP (v1)
+        0x63677270,  # CGROUP2
+        0x64626720,  # DEBUGFS
+        0x74726163,  # TRACEFS
+        0xCAFE4A11,  # BPF
+    })
+
     def _should_filter_process(self, comm: str) -> bool:
         """Helper to filter out I/O unrelated system processes."""
         prefixes = ("swapper/", "ksoftirqd/", "irq/", "migration/", "stopper/")
         return comm.startswith(prefixes)
+
+    def _skip_event(self, comm: str, pid: int) -> bool:
+        """Drop events from kernel threads and the tracer's own processes."""
+        return pid == self._self_pid or self._should_filter_process(comm)
+
+    def _event_walltime(self, event):
+        """Convert a kernel event's bpf_ktime_get_ns() timestamp to wall-clock.
+
+        Using the kernel's per-event monotonic time (rather than the userspace
+        receive time) yields correctly ordered timestamps across the per-CPU
+        perf buffers. Falls back to receive time when the event carries no ts.
+        """
+        ts_ns = getattr(event, "ts", 0)
+        if not ts_ns:
+            return datetime.today()
+        return datetime.fromtimestamp(ts_ns / 1e9 + self._mono_to_real_offset)
 
     def _print_event(self, cpu, data, size):        
         """
@@ -214,16 +254,21 @@ class IOTracer:
         except UnicodeDecodeError:
             filename = ""
         
-        timestamp = datetime.today()
-        
+        timestamp = self._event_walltime(event)
+
         try:
             comm = event.comm.decode()
         except UnicodeDecodeError:
             comm = "[decode_error]"
-            
-        if self._should_filter_process(comm):
+
+        if self._skip_event(comm, event.pid):
             return
-            
+
+        # Drop I/O backed by pseudo-filesystems (procfs/sysfs/cgroup/...), which
+        # is kernel/diagnostic noise rather than real storage traffic.
+        if getattr(event, "fs_magic", 0) in self._PSEUDO_FS_MAGICS:
+            return
+
         inode_val = event.inode if event.inode != 0 else ""
         
         size_val = event.size if event.size is not None else 0
@@ -617,16 +662,16 @@ class IOTracer:
             filename_old = ""
             filename_new = ""
         
-        timestamp = datetime.today()
-        
+        timestamp = self._event_walltime(event)
+
         try:
             comm = event.comm.decode()
         except UnicodeDecodeError:
             comm = "[decode_error]"
-            
-        if self._should_filter_process(comm):
+
+        if self._skip_event(comm, event.pid):
             return
-            
+
         inode_old = event.inode_old if event.inode_old != 0 else ""
         inode_new = event.inode_new if event.inode_new != 0 else ""
         
@@ -664,11 +709,11 @@ class IOTracer:
             size: Size of the event data
         """
         event = self.b["cache_events"].event(data)
-        timestamp = datetime.today()
+        timestamp = self._event_walltime(event)
         pid = event.pid
         comm = event.comm.decode('utf-8', errors='replace')
-        
-        if self._should_filter_process(comm):
+
+        if self._skip_event(comm, pid):
             return
         
         event_types = {
@@ -710,13 +755,13 @@ class IOTracer:
             size: Size of the event data
         """
         event = self.b["bl_events"].event(data)
-        
-        timestamp = datetime.today()
+
+        timestamp = self._event_walltime(event)
         pid = event.pid
         tid = event.tid
         comm = event.comm.decode('utf-8', errors='replace')
-        
-        if self._should_filter_process(comm):
+
+        if self._skip_event(comm, pid):
             return
             
         sector = event.sector
@@ -771,13 +816,13 @@ class IOTracer:
             size: Size of the event data
         """
         event = self.b["pagefault_events"].event(data)
-        timestamp = datetime.today()
-        
+        timestamp = self._event_walltime(event)
+
         pid = event.pid
         tid = event.tid
         comm = event.comm.decode('utf-8', errors='replace')
-        
-        if self._should_filter_process(comm):
+
+        if self._skip_event(comm, pid):
             return
             
         address = hex(event.address) if event.address else ""

--- a/src/tracer/IOTracer.py
+++ b/src/tracer/IOTracer.py
@@ -20,6 +20,8 @@ import shutil
 import signal
 import os
 import ctypes
+import json
+import platform
 from bcc import BPF
 import time
 import sys
@@ -27,6 +29,7 @@ from bisect import bisect_right
 from pathlib import Path
 from datetime import datetime
 
+from . import schema
 from .ObjectStorageManager import ObjectStorageManager
 from ..utility.utils import capture_machine_id, format_csv_row, logger, hash_filename_in_path, simple_hash, run_with_spinner
 from .WriterManager import WriteManager
@@ -155,6 +158,10 @@ class IOTracer:
         # write the trace files, and upload them — all of which is self-noise we
         # don't want in the trace. Filter events from our own pid.
         self._self_pid = os.getpid()
+        # Per-stream dropped-event tallies (kernel perf-buffer overruns), folded
+        # into the session manifest.
+        self._lost_counts = {}
+        self.version = version
 
         # Bounded-cache maintenance. The path resolver and cmdline caches are
         # only evicted on PROCESS_EXEC, so over a long-running trace they would
@@ -395,7 +402,8 @@ class IOTracer:
             flags_val, offset_val, tid_val, mmap_prot_val, mmap_flags_val,
             address_val, cmdline,
             return_value, errno_val, bytes_completed, duration_ns,
-            dev_val, ppid_val, container_id, fs_type_val
+            dev_val, ppid_val, container_id, fs_type_val,
+            getattr(event, "ts", 0)
         )
         self.writer.append_fs_log(output)
 
@@ -707,11 +715,12 @@ class IOTracer:
             flags_val, "", "", "", "",   # offset, tid, mmap_prot, mmap_flags
             "", cmdline,                 # address, cmdline
             "", "", "", "",              # return_value, errno, bytes_completed, duration_ns
-            "", "", "", ""               # device, ppid, container_id, fs_type
+            "", "", "", "",              # device, ppid, container_id, fs_type
+            getattr(event, "ts", 0)      # mono_ns
         )
         self.writer.append_fs_log(output)
-    
-    def _print_event_cache(self, cpu, data, size):       
+
+    def _print_event_cache(self, cpu, data, size):
         """
         Callback for processing page cache events from the perf buffer.
         
@@ -754,7 +763,7 @@ class IOTracer:
         dev_id = event.dev_id if hasattr(event, 'dev_id') else ""
         count = event.count if hasattr(event, 'count') else ""
 
-        output = format_csv_row(timestamp, pid, comm, event_name, inode, index, size, cpu_id, dev_id, count)
+        output = format_csv_row(timestamp, pid, comm, event_name, inode, index, size, cpu_id, dev_id, count, getattr(event, "ts", 0))
 
         self.writer.append_cache_log(output)
 
@@ -814,7 +823,7 @@ class IOTracer:
         # Monotonic per-request id (disambiguates repeated I/O to the same sector)
         req_id = event.req_id if hasattr(event, 'req_id') else ""
 
-        output = format_csv_row(timestamp, pid, comm, sector, ops_str, bio_size, latency_ms, tid, cpu_id, ppid, dev_str, queue_time_ms, cmd_flags_str, op_code_str, req_id)
+        output = format_csv_row(timestamp, pid, comm, sector, ops_str, bio_size, latency_ms, tid, cpu_id, ppid, dev_str, queue_time_ms, cmd_flags_str, op_code_str, req_id, getattr(event, "ts", 0))
 
 
         if sector == 0 and bio_size == 0:
@@ -854,7 +863,7 @@ class IOTracer:
         major = "MAJOR" if event.major else "MINOR"
         dev_id = event.dev_id if hasattr(event, 'dev_id') and event.dev_id != 0 else ""
         
-        output = format_csv_row(timestamp, pid, tid, comm, fault_type, major, inode, offset, address, dev_id)
+        output = format_csv_row(timestamp, pid, tid, comm, fault_type, major, inode, offset, address, dev_id, getattr(event, "ts", 0))
         self.writer.append_pagefault_log(output)
 
     def _print_event_io_uring(self, cpu, data, size):
@@ -971,7 +980,8 @@ class IOTracer:
             ts, op_name, e.pid, comm, filename, size_val, e.inode,
             flags_val, offset_val, tid_val, "", "", "", cmdline,
             return_value, errno_val, bytes_completed, duration_ns,
-            dev_val, "", "", fs_type_val
+            dev_val, "", "", fs_type_val,
+            getattr(e, "timestamp_ns", 0)   # mono_ns
         )
         self.writer.append_fs_log(output)
 
@@ -987,43 +997,101 @@ class IOTracer:
 
         run_with_spinner("Flushing trace data", _flush)
 
-    def _log_block_diagnostics(self):
-        """Summarise block-tracing health from the per-CPU ``block_stats`` map.
+    def _block_stats(self):
+        """Read the per-CPU ``block_stats`` map → {issued, completed, missed}.
 
-        Reports issued vs. completed requests and how many completions arrived
-        with no tracked issue context. A high miss rate means the issue map was
-        evicted under load (completions dropped) — the likely explanation if
-        block events appear to stop before the end of a long trace.
+        Returns an empty dict if the map is unavailable or all-zero. ``missed``
+        counts completions with no tracked issue ctx (LRU-evicted or pre-trace).
         """
         try:
             stats = self.b["block_stats"]
-            issued    = sum(stats[ctypes.c_int(0)])
-            completed = sum(stats[ctypes.c_int(1)])
-            missed    = sum(stats[ctypes.c_int(2)])
+            out = {
+                "issued":    int(sum(stats[ctypes.c_int(0)])),
+                "completed": int(sum(stats[ctypes.c_int(1)])),
+                "missed":    int(sum(stats[ctypes.c_int(2)])),
+            }
         except Exception:
-            return
+            return {}
+        return out if any(out.values()) else {}
 
-        if not (issued or completed or missed):
-            return
+    def _log_block_diagnostics(self):
+        """Log a summary of block-tracing health from ``block_stats``.
 
-        total_completions = completed + missed
-        miss_pct = (missed / total_completions * 100) if total_completions else 0.0
+        A high miss rate means the issue map was evicted under load (completions
+        dropped) — the likely explanation if block events appear to stop before
+        the end of a long trace.
+        """
+        s = self._block_stats()
+        if not s:
+            return
+        total_completions = s["completed"] + s["missed"]
+        miss_pct = (s["missed"] / total_completions * 100) if total_completions else 0.0
         logger("info",
-               f"Block diagnostics: {issued} issued, {completed} completed, "
-               f"{missed} completions without a tracked issue "
+               f"Block diagnostics: {s['issued']} issued, {s['completed']} completed, "
+               f"{s['missed']} completions without a tracked issue "
                f"({miss_pct:.1f}% of completions). A high miss rate indicates the "
                f"issue map was evicted under load (dropped completions).")
 
-    def _lost_cb(self, lost):
-        """
-        Callback for handling lost events in the perf buffer.
+    def _attached_probes(self):
+        """Sorted list of kernel functions the tracer has probes attached to."""
+        try:
+            events = ([e for e, _ in self.probe_tracker.kprobes] +
+                      [e for e, _ in self.probe_tracker.kretprobes])
+            return sorted(set(events))
+        except Exception:
+            return []
 
-        Args:
-            lost: Number of events that were lost
+    def _write_manifest(self, started_at, stopped_at=None):
+        """Write the per-session ``manifest.json`` (schema + clock + versions +
+        session window + diagnostics). Written once when tracing starts and
+        rewritten at shutdown with the stop time and final diagnostics.
         """
-        if lost > 0:
-            if self.verbose:
-                logger("warning", f"Lost {lost} events in kernel buffer")
+        manifest = schema.schema_for_manifest()
+        duration = (stopped_at - started_at).total_seconds() if stopped_at else None
+        manifest.update({
+            "tracer": {"version": self.version},
+            "machine_id": capture_machine_id(),
+            "host": {
+                "platform": platform.platform(),
+                "kernel": platform.release(),
+                "python": platform.python_version(),
+            },
+            "clock": {
+                "wall_clock": "CLOCK_REALTIME",
+                "mono_clock": "CLOCK_MONOTONIC",
+                "mono_to_real_offset_ns": self._mono_to_real_offset_ns,
+                "note": ("mono_ns is the common cross-stream correlation clock "
+                         "(CLOCK_MONOTONIC ns). Add mono_to_real_offset_ns to it "
+                         "to recover wall-clock nanoseconds."),
+            },
+            "session": {
+                "started_at": started_at.isoformat(),
+                "stopped_at": stopped_at.isoformat() if stopped_at else None,
+                "duration_seconds": duration,
+            },
+            "diagnostics": {
+                "attached_probes": self._attached_probes(),
+                "lost_events": dict(self._lost_counts),
+                "rows_written": dict(self.writer.rows_written),
+                "block": self._block_stats(),
+            },
+        })
+        try:
+            path = os.path.join(self.writer.output_dir, "manifest.json")
+            with open(path, "w") as f:
+                json.dump(manifest, f, indent=2)
+        except OSError as e:
+            logger("warning", f"Could not write manifest.json: {e}")
+
+    def _make_lost_cb(self, label):
+        """Build a per-buffer lost-event callback that tallies drops by stream
+        label (for the session manifest) and warns when verbose."""
+        def _cb(lost):
+            if lost > 0:
+                self._lost_counts[label] = self._lost_counts.get(label, 0) + lost
+                if self.verbose:
+                    logger("warning", f"Lost {lost} {label} events in kernel buffer")
+        return _cb
 
     def trace(self):
         """
@@ -1059,27 +1127,27 @@ class IOTracer:
 
         # Open perf buffers for each event type
         self.b["events"].open_perf_buffer(
-            self._print_event, 
-            page_cnt=self.page_cnt, 
-            lost_cb=self._lost_cb
+            self._print_event,
+            page_cnt=self.page_cnt,
+            lost_cb=self._make_lost_cb("fs")
         )
 
         self.b["events_dual"].open_perf_buffer(
             self._print_event_dual,
             page_cnt=self.page_cnt,
-            lost_cb=self._lost_cb
+            lost_cb=self._make_lost_cb("fs")
         )
 
         self.b["bl_events"].open_perf_buffer(
-            self._print_event_block, 
-            page_cnt=self.page_cnt, 
-            lost_cb=self._lost_cb
+            self._print_event_block,
+            page_cnt=self.page_cnt,
+            lost_cb=self._make_lost_cb("ds")
         )
 
         # self.b["cache_events"].open_perf_buffer(
-        #     self._print_event_cache, 
-        #     page_cnt=self.page_cnt, 
-        #     lost_cb=self._lost_cb
+        #     self._print_event_cache,
+        #     page_cnt=self.page_cnt,
+        #     lost_cb=self._make_lost_cb("cache")
         # )
 
         # Page fault events for mmap I/O tracking
@@ -1087,7 +1155,7 @@ class IOTracer:
         #     self.b["pagefault_events"].open_perf_buffer(
         #         self._print_event_pagefault,
         #         page_cnt=self.page_cnt,
-        #         lost_cb=self._lost_cb
+        #         lost_cb=self._make_lost_cb("pagefault")
         #     )
         # except KeyError:
         #     if self.verbose:
@@ -1098,13 +1166,18 @@ class IOTracer:
             self.b["io_uring_events"].open_perf_buffer(
                 self._print_event_io_uring,
                 page_cnt=self.page_cnt,
-                lost_cb=self._lost_cb
+                lost_cb=self._make_lost_cb("fs")
             )
         except KeyError:
             if self.verbose:
                 logger("warning", "io_uring_events buffer not available")
 
         start = time.time()
+        # Write the session manifest up front so a self-describing schema exists
+        # even if the run is killed; it is rewritten at shutdown with the stop
+        # time and final diagnostics.
+        self._session_started_at = datetime.now()
+        self._write_manifest(self._session_started_at)
         if self.duration is not None:
             duration_target = self.duration
             end_time = start + duration_target
@@ -1158,6 +1231,13 @@ class IOTracer:
                 logger("info", f"Trace completed after {actual_duration:.2f} seconds")
 
             self._log_block_diagnostics()
+            # Finalise the manifest with stop time + final diagnostics. Guarded
+            # so a manifest failure never blocks shutdown/flush.
+            try:
+                self._write_manifest(getattr(self, "_session_started_at", datetime.now()),
+                                     datetime.now())
+            except Exception as e:
+                logger("warning", f"Could not finalise manifest.json: {e}")
 
             print()
             logger("info", "Trace stopped")

--- a/src/tracer/PathResolver.py
+++ b/src/tracer/PathResolver.py
@@ -222,6 +222,11 @@ class PathResolver:
         except OSError:
             return relpath
 
+        # The kernel appends " (deleted)" when the base directory has been
+        # unlinked; joining onto that yields a path that never existed, so bail.
+        if base.endswith(" (deleted)"):
+            return relpath
+
         resolved = os.path.normpath(os.path.join(base, relpath))
         if inode:
             self.inode_to_path[inode] = resolved

--- a/src/tracer/PathResolver.py
+++ b/src/tracer/PathResolver.py
@@ -186,6 +186,47 @@ class PathResolver:
 
         return filename
 
+    # openat() dirfd sentinel: resolve relative to the process cwd.
+    AT_FDCWD = -100
+
+    def resolve_relative(self, pid: int, dirfd: int, relpath: str, inode: int = 0) -> str:
+        """Resolve a relative open path against its openat dirfd / process cwd.
+
+        Used as a fallback when fd-based resolution could not produce an
+        absolute path (e.g. the fd was already closed). The base directory is
+        read from ``/proc/<pid>/cwd`` (for ``AT_FDCWD``) or
+        ``/proc/<pid>/fd/<dirfd>`` (for a directory fd), then joined with the
+        captured relative path. Best effort — falls back to ``relpath`` if the
+        process/dir is gone.
+
+        Args:
+            pid:     Process that performed the open
+            dirfd:   openat dirfd (``AT_FDCWD`` for cwd-relative)
+            relpath: The relative path string captured by eBPF
+            inode:   Inode (optional) — populates the cache on success
+
+        Returns:
+            str: Absolute, normalised path, or ``relpath`` if resolution fails
+        """
+        if not pid or not relpath or relpath.startswith("/"):
+            return relpath
+
+        try:
+            if dirfd == self.AT_FDCWD:
+                base = os.readlink(f"/proc/{pid}/cwd")
+            else:
+                base = os.readlink(f"/proc/{pid}/fd/{dirfd}")
+                if (base.startswith("pipe:") or base.startswith("socket:") or
+                        base.startswith("anon_inode:")):
+                    return relpath
+        except OSError:
+            return relpath
+
+        resolved = os.path.normpath(os.path.join(base, relpath))
+        if inode:
+            self.inode_to_path[inode] = resolved
+        return resolved
+
     def resolve_path(self, inode: int, pid: int | None = None, filename: str | None = None) -> str:
         """
         Resolve the full path for an inode.

--- a/src/tracer/WriterManager.py
+++ b/src/tracer/WriterManager.py
@@ -29,6 +29,7 @@ from datetime import datetime
 import tarfile
 
 from .ObjectStorageManager import ObjectStorageManager
+from . import schema
 from ..utility.utils import (
     logger, capture_machine_id,
     compress_file_zstd, require_zstandard, ZSTD_LEVEL,
@@ -76,6 +77,10 @@ class WriteManager:
         self.current_datetime = datetime.now()
 
         self.created_files = 0
+        # Total rows written to disk per stream (keyed by buffer label), for the
+        # session manifest — lets a consumer spot a stream whose probes attached
+        # but produced no events.
+        self.rows_written = {}
         self.last_status_log_time = time.time()
         self.status_log_interval = 60  # Log status every 60 seconds
         self.output_dir = output_dir
@@ -209,6 +214,21 @@ class WriteManager:
 
         # Process snapshot session tracking
         self.process_snapshot_session_active = False
+
+    # WriteManager stream key -> schema.STREAMS key.
+    _SCHEMA_KEY = {
+        'vfs': 'fs', 'block': 'ds', 'cache': 'cache', 'pagefault': 'pagefault',
+        'process': 'process', 'fs_snap': 'filesystem_snapshot',
+    }
+
+    def _open_log_file(self, path: str, wm_key: str):
+        """Open a stream's CSV for appending, writing the schema header row first
+        when the file is new/empty so every (rotated) file is self-describing."""
+        is_new = (not os.path.exists(path)) or os.path.getsize(path) == 0
+        handle = open(path, 'a', buffering=8192)
+        if is_new:
+            handle.write(schema.header_line(self._SCHEMA_KEY[wm_key]) + "\n")
+        return handle
 
     def _calculate_event_rate(self, event_type: str) -> float:
         """
@@ -391,7 +411,7 @@ class WriteManager:
         """
         if isinstance(log_output, str):
             if self._fs_snap_handle is None:
-                self._fs_snap_handle = open(self.output_fs_snapshot_file, 'a', buffering=8192)
+                self._fs_snap_handle = self._open_log_file(self.output_fs_snapshot_file, 'fs_snap')
             self.fs_snap_buffer.append(log_output)
             self.event_timestamps['fs_state'].append(time.time())
         else:
@@ -525,7 +545,7 @@ class WriteManager:
             if self._fs_snap_handle is None or self.output_fs_snapshot_file != part_filepath:
                 if self._fs_snap_handle is not None:
                     self._fs_snap_handle.close()
-                self._fs_snap_handle = open(part_filepath, 'a', buffering=8192)
+                self._fs_snap_handle = self._open_log_file(part_filepath, 'fs_snap')
                 self.output_fs_snapshot_file = part_filepath
 
             # Write buffer to file
@@ -648,14 +668,14 @@ class WriteManager:
         with self._stream_locks['process']:
             if self.process_buffer:
                 if self._process_handle is None:
-                    self._process_handle = open(self.output_process_file, 'a', buffering=8192)
+                    self._process_handle = self._open_log_file(self.output_process_file, 'process')
                 self.current_datetime = datetime.now()
 
                 self._write_buffer_to_file(self.process_buffer, self._process_handle, "Process State")
                 self._process_handle.close()
                 rotated = self.output_process_file
                 self.output_process_file = f"{self.output_dir}/process/process_{self.current_datetime.strftime('%Y%m%d_%H%M%S_%f')[:-3]}.csv"
-                self._process_handle = open(self.output_process_file, 'a', buffering=8192)
+                self._process_handle = self._open_log_file(self.output_process_file, 'process')
                 self._reset_flush_timer()
 
                 # Mark process snapshot as complete
@@ -699,7 +719,7 @@ class WriteManager:
             # Land any buffered rows in the current file first.
             if buf:
                 if handle is None:
-                    handle = open(cur_file, 'a', buffering=8192)
+                    handle = self._open_log_file(cur_file, key)
                     setattr(self, s['handle'], handle)
                 self.current_datetime = datetime.now()
                 self._write_buffer_to_file(buf, handle, s['log'])
@@ -712,7 +732,7 @@ class WriteManager:
             # Skip rotating an empty file (avoids zero-byte uploads); just keep
             # appending to it.
             if not os.path.exists(cur_file) or os.path.getsize(cur_file) == 0:
-                setattr(self, s['handle'], open(cur_file, 'a', buffering=8192))
+                setattr(self, s['handle'], self._open_log_file(cur_file, key))
                 return
 
             rotated = cur_file
@@ -723,7 +743,7 @@ class WriteManager:
                 f"{self._stream_seq[key]:04d}.csv"
             )
             setattr(self, s['file'], new_file)
-            setattr(self, s['handle'], open(new_file, 'a', buffering=8192))
+            setattr(self, s['handle'], self._open_log_file(new_file, key))
             self._stream_opened[key] = time.monotonic()
             self._reset_flush_timer()
         # Compress outside the lock: gzip + disk I/O is slow and must not block
@@ -822,12 +842,15 @@ class WriteManager:
             
         try:
             string_buffer = io.StringIO()
-            
+
+            n = 0
             while buffer:
                 event = buffer.popleft()
                 string_buffer.write(event)
                 string_buffer.write('\n')
-            
+                n += 1
+            self.rows_written[buffer_name] = self.rows_written.get(buffer_name, 0) + n
+
             complete_data = string_buffer.getvalue()
             file_handle.write(complete_data)
             file_handle.flush()
@@ -843,42 +866,42 @@ class WriteManager:
             with self._stream_locks['vfs']:
                 if self.vfs_buffer:
                     if self._vfs_handle is None:
-                        self._vfs_handle = open(self.output_vfs_file, 'a', buffering=8192)
+                        self._vfs_handle = self._open_log_file(self.output_vfs_file, 'vfs')
                     self._write_buffer_to_file(self.vfs_buffer, self._vfs_handle, "VFS")
 
         def write_block():
             with self._stream_locks['block']:
                 if self.block_buffer:
                     if self._block_handle is None:
-                        self._block_handle = open(self.output_block_file, 'a', buffering=8192)
+                        self._block_handle = self._open_log_file(self.output_block_file, 'block')
                     self._write_buffer_to_file(self.block_buffer, self._block_handle, "Block")
 
         def write_cache():
             with self._stream_locks['cache']:
                 if self.cache_buffer:
                     if self._cache_handle is None:
-                        self._cache_handle = open(self.output_cache_file, 'a', buffering=8192)
+                        self._cache_handle = self._open_log_file(self.output_cache_file, 'cache')
                     self._write_buffer_to_file(self.cache_buffer, self._cache_handle, "Cache")
 
         def write_process():
             with self._stream_locks['process']:
                 if self.process_buffer:
                     if self._process_handle is None:
-                        self._process_handle = open(self.output_process_file, 'a', buffering=8192)
+                        self._process_handle = self._open_log_file(self.output_process_file, 'process')
                     self._write_buffer_to_file(self.process_buffer, self._process_handle, "Process State")
 
         def write_fssnap():
             with self._stream_locks['fs_snap']:
                 if self.fs_snap_buffer:
                     if self._fs_snap_handle is None:
-                        self._fs_snap_handle = open(self.output_fs_snapshot_file, 'a', buffering=8192)
+                        self._fs_snap_handle = self._open_log_file(self.output_fs_snapshot_file, 'fs_snap')
                     self._write_buffer_to_file(self.fs_snap_buffer, self._fs_snap_handle, "Filesystem Snapshot")
 
         def write_pagefault():
             with self._stream_locks['pagefault']:
                 if self.pagefault_buffer:
                     if self._pagefault_handle is None:
-                        self._pagefault_handle = open(self.output_pagefault_file, 'a', buffering=8192)
+                        self._pagefault_handle = self._open_log_file(self.output_pagefault_file, 'pagefault')
                     self._write_buffer_to_file(self.pagefault_buffer, self._pagefault_handle, "PageFault")
 
         threads = []

--- a/src/tracer/prober/prober.c
+++ b/src/tracer/prober/prober.c
@@ -781,6 +781,8 @@ static bool is_regular_file(struct file *file) {
   case XENFS_SUPER_MAGIC:
   case RPCAUTH_GSSMAGIC:
   case TRACEFS_MAGIC:
+  case 0x63677270:  /* CGROUP2_SUPER_MAGIC — cgroup v2 unified hierarchy */
+  case 0xCAFE4A11:  /* BPF_FS_MAGIC — bpffs */
   case 0x19800202:
     is_virtual = true;
     break;
@@ -827,6 +829,8 @@ static bool is_regular_file_from_path(const struct path *path) {
   case XENFS_SUPER_MAGIC:
   case RPCAUTH_GSSMAGIC:
   case TRACEFS_MAGIC:
+  case 0x63677270:  /* CGROUP2_SUPER_MAGIC — cgroup v2 unified hierarchy */
+  case 0xCAFE4A11:  /* BPF_FS_MAGIC — bpffs */
   case 0x19800202:
     return false;
   default:

--- a/src/tracer/prober/prober.c
+++ b/src/tracer/prober/prober.c
@@ -119,6 +119,12 @@ struct bpf_task_work {};   /* task_work field, added in 6.14 */
 /** Maximum length for captured filenames (including null terminator) */
 #define FILENAME_MAX_LEN 256
 
+/** openat() dirfd sentinel meaning "resolve relative to the cwd". Defined here
+ *  in case the BPF include set doesn't pull in <linux/fcntl.h>. */
+#ifndef AT_FDCWD
+#define AT_FDCWD -100
+#endif
+
 /** Length of block operation type string (e.g., "R", "W", "RA") */
 #define OP_LEN 8
 
@@ -241,6 +247,9 @@ struct data_t {
   u32 ppid;                       /**< Parent process ID (real_parent->tgid) */
   u64 cgroup_id;                  /**< cgroup v2 id — container identifier */
   u32 fs_magic;                   /**< Superblock magic for filesystem-type classification */
+  s32 dirfd;                      /**< OPEN only: openat dirfd, for userspace
+                                    *   resolution of relative paths against the
+                                    *   process cwd/dirfd. AT_FDCWD otherwise. */
 };
 
 /**
@@ -313,6 +322,9 @@ struct block_event {
   u32 dev;                  /**< Device number (major:minor encoded) for partition ID */
   u64 queue_time_ns;        /**< Time from insert to issue (scheduler latency) */
   u32 op_code;              /**< Raw block operation code (REQ_OP_*) */
+  u64 req_id;               /**< Monotonic per-request id, unique within a trace
+                              *   session. Disambiguates distinct I/Os that reuse
+                              *   the same (dev, sector). */
 };
 
 /* ============================================================================
@@ -563,6 +575,7 @@ struct vfs_info {
  */
 struct block_issue_ctx {
   u64 ts;                   /**< Issue timestamp (device latency baseline) */
+  u64 req_id;               /**< Monotonic per-request id (see block_event.req_id) */
   u32 pid;                  /**< Submitting process ID */
   u32 tid;                  /**< Submitting thread ID */
   u32 ppid;                 /**< Submitter's parent PID */
@@ -588,6 +601,19 @@ struct block_rq_key_t {
  * map and starve later requests. */
 BPF_TABLE("lru_hash", struct block_rq_key_t, struct block_issue_ctx, block_start_times, 10240); /**< Issue time + submitter, keyed by dev+sector */
 BPF_TABLE("lru_hash", struct block_rq_key_t, u64, block_insert_times, 10240);  /**< Tracks block request insert time (queue latency) */
+
+/* Monotonic generator for per-request IDs (see block_event.req_id). A single
+ * u64 bumped atomically at issue time; lets consumers disambiguate repeated
+ * I/O to the same (dev, sector) and correlate a request across its lifecycle. */
+BPF_ARRAY(block_req_id_gen, u64, 1);
+
+/* Block-tracing diagnostics counters (per-CPU, summed in userspace at exit):
+ *   [0] requests issued, [1] requests completed (emitted),
+ *   [2] completions with no matching issue ctx (LRU-evicted or pre-trace).
+ * A growing [2] relative to [1] indicates the issue map is being evicted under
+ * load (i.e. completions are being dropped), which would explain block events
+ * thinning out before the end of a long trace. */
+BPF_PERCPU_ARRAY(block_stats, u64, 3);
 
 /* Configuration map - stores tracer PID to exclude self-tracing */
 BPF_HASH(tracer_config, u32, u32, 1);    /**< Key 0 = tracer PID to exclude */
@@ -617,6 +643,7 @@ BPF_PERCPU_ARRAY(dual_data_buffer, struct data_dual_t, 1);
  */
 struct open_path_t {
   char path[FILENAME_MAX_LEN]; /**< User-space path string from openat args */
+  s32 dfd;                     /**< openat dirfd arg (AT_FDCWD for cwd-relative) */
 };
 
 /* Staged path from trace_do_sys_openat2_entry, consumed by trace_vfs_open */
@@ -1153,6 +1180,7 @@ int trace_do_sys_openat2_entry(struct pt_regs *ctx) {
   }
 
   struct open_path_t staged = {};
+  staged.dfd = (s32)PT_REGS_PARM1(ctx);  /* dirfd for relative-path resolution */
   bpf_probe_read_user_str(staged.path, sizeof(staged.path), user_path);
   open_path_staging.update(&pid_tgid, &staged);
   return 0;
@@ -1192,6 +1220,10 @@ int trace_openat_entry_x64(struct pt_regs *ctx) {
   }
 
   struct open_path_t staged = {};
+  /* openat dirfd is the first syscall arg (uregs->di). */
+  unsigned long dfd_arg = 0;
+  bpf_probe_read_kernel(&dfd_arg, sizeof(dfd_arg), &uregs->di);
+  staged.dfd = (s32)dfd_arg;
   bpf_probe_read_user_str(staged.path, sizeof(staged.path), user_path);
   open_path_staging.update(&pid_tgid, &staged);
   return 0;
@@ -1247,11 +1279,19 @@ int trace_vfs_open(struct pt_regs *ctx, const struct path *path,
   // this is already an absolute path (e.g. /etc/ld.so.cache, /lib/x86_64-linux-gnu/libc.so.6).
   // Fall back to d_name (basename) for opens that don't come through openat
   // (e.g. exec paths, kernel-internal opens).
+  // Default to cwd-relative; overridden below when an openat dirfd was captured.
+  data.dirfd = AT_FDCWD;
   struct open_path_t *staged_path = open_path_staging.lookup(&pid_tgid);
-  if (staged_path && staged_path->path[0] == '/') {
+  if (staged_path && staged_path->path[0] != '\0') {
+    // Use the caller's path string verbatim — absolute paths are already
+    // complete, and relative paths keep their directory components (rather than
+    // collapsing to a basename). data.dirfd carries the openat dirfd so
+    // userspace can resolve relative paths against the cwd/dirfd.
     bpf_probe_read_kernel(data.filename, sizeof(data.filename), staged_path->path);
+    data.dirfd = staged_path->dfd;
   } else {
-    // Fallback: read d_name (basename) from the dentry
+    // Fallback: read d_name (basename) from the dentry for opens that don't
+    // come through openat (e.g. exec paths, kernel-internal opens).
     struct dentry *path_dentry = NULL;
     bpf_probe_read_kernel(&path_dentry, sizeof(path_dentry), &path->dentry);
     if (path_dentry) {
@@ -2530,7 +2570,20 @@ TRACEPOINT_PROBE(block, block_rq_issue) {
   ictx.tid = (u32)pid_tgid;
   ictx.ppid = get_ppid();
   bpf_get_current_comm(&ictx.comm, sizeof(ictx.comm));
+
+  // Assign a monotonic per-request id, carried to the completion event.
+  u32 gen_key = 0;
+  u64 *gen = block_req_id_gen.lookup(&gen_key);
+  if (gen)
+    ictx.req_id = __sync_fetch_and_add(gen, 1);
+
   block_start_times.update(&key, &ictx);
+
+  // Diagnostics: count issued requests.
+  u32 stat_issued = 0;
+  u64 *issued = block_stats.lookup(&stat_issued);
+  if (issued)
+    *issued += 1;
 
   return 0;
 }
@@ -2545,8 +2598,16 @@ TRACEPOINT_PROBE(block, block_rq_complete) {
   // Must use the same key formula as block_rq_issue/insert.
   struct block_rq_key_t key = block_rq_key(args->dev, args->sector);
   struct block_issue_ctx *ictx = block_start_times.lookup(&key);
-  if (!ictx)
+  if (!ictx) {
+    // No matching issue ctx: either evicted from the LRU map under load (a
+    // dropped completion) or issued before tracing started. Count it so the
+    // exit summary can flag whether block events are being lost.
+    u32 stat_miss = 2;
+    u64 *miss = block_stats.lookup(&stat_miss);
+    if (miss)
+      *miss += 1;
     return 0;
+  }
 
   // Filter the tracer's own I/O by the SUBMITTER pid — the current pid here
   // is the interrupted task, not the process that did the I/O.
@@ -2585,6 +2646,7 @@ TRACEPOINT_PROBE(block, block_rq_complete) {
   
   event.latency_ns = latency;
   event.queue_time_ns = queue_time;  // New: queue time
+  event.req_id = ictx->req_id;       // Stable per-request id
   
 #ifdef HAS_CMD_FLAGS
   event.cmd_flags = args->cmd_flags; // Capture REQ_* command flags
@@ -2603,6 +2665,12 @@ TRACEPOINT_PROBE(block, block_rq_complete) {
   bpf_probe_read_kernel(&event.op, sizeof(event.op), &args->rwbs);
 
   bl_events.perf_submit(args, &event, sizeof(event));
+
+  // Diagnostics: count completed (emitted) requests.
+  u32 stat_completed = 1;
+  u64 *completed = block_stats.lookup(&stat_completed);
+  if (completed)
+    *completed += 1;
 
   block_start_times.delete(&key);
   block_insert_times.delete(&key);

--- a/src/tracer/schema.py
+++ b/src/tracer/schema.py
@@ -1,0 +1,193 @@
+"""
+Central trace-schema definition — the single source of truth for the on-disk
+format. Both the CSV headers (written by WriteManager) and the per-session
+``manifest.json`` are derived from the tables here, so they can never drift from
+each other or from this module.
+
+Every stream carries:
+  * column 1 ``timestamp``  — wall-clock (CLOCK_REALTIME), ``YYYY-MM-DD HH:MM:SS.ffffff``
+  * a trailing ``mono_ns``  — CLOCK_MONOTONIC nanoseconds, the common cross-stream
+                              correlation clock (kernel ``bpf_ktime_get_ns()`` for
+                              perf-event streams, ``time.monotonic_ns()`` for the
+                              userspace snapshot streams).
+
+Bump ``SCHEMA_VERSION`` whenever a stream's columns change; consumers should read
+it from ``manifest.json`` and adapt.
+"""
+
+# v1: original headerless CSVs, no manifest, per-stream clocks.
+# v2: CSV headers + manifest.json + a common ``mono_ns`` column on every stream.
+SCHEMA_VERSION = 2
+
+
+def _col(name, ctype, unit="", desc=""):
+    return {"name": name, "type": ctype, "unit": unit, "description": desc}
+
+
+# The trailing common-clock column appended to every stream.
+_MONO_NS = _col(
+    "mono_ns", "u64", "nanoseconds",
+    "CLOCK_MONOTONIC timestamp of the record — the common clock for correlating "
+    "across streams. Kernel bpf_ktime_get_ns() for perf events; time.monotonic_ns() "
+    "for snapshots.",
+)
+
+
+def _stream(subdir, prefix, description, clock, columns):
+    return {
+        "subdir": subdir,
+        "filename_prefix": prefix,
+        "description": description,
+        # Clock backing the wall-clock ``timestamp`` column.
+        "wall_clock": clock,
+        "columns": columns + [_MONO_NS],
+    }
+
+
+# stream key -> definition. Keys match the output sub-directory names.
+STREAMS = {
+    "fs": _stream(
+        "fs", "fs",
+        "VFS / filesystem operation events (also receives io_uring READ/WRITE "
+        "mirrored rows).",
+        "CLOCK_REALTIME (derived from kernel CLOCK_MONOTONIC)",
+        [
+            _col("timestamp", "datetime", "", "Event wall-clock time (YYYY-MM-DD HH:MM:SS.ffffff)."),
+            _col("operation", "string", "", "VFS operation type (READ, WRITE, OPEN, ...)."),
+            _col("pid", "u32"),
+            _col("command", "string", "", "Process name (<=16 chars)."),
+            _col("filename", "string", "", "File path; 'old -> new' for dual-path ops."),
+            _col("size_requested", "u64", "bytes", "Requested I/O size (count arg); 0 for non-I/O ops."),
+            _col("inode", "u64"),
+            _col("flags", "string", "", "Operation-specific flags; empty when none."),
+            _col("offset", "u64", "bytes", "File offset for positioned I/O; empty if 0."),
+            _col("tid", "u32"),
+            _col("mmap_prot", "string", "", "MMAP PROT_* flags; empty for non-MMAP."),
+            _col("mmap_flags", "string", "", "MMAP MAP_* flags; empty for non-MMAP."),
+            _col("address", "string", "", "Mapping address (hex) for MMAP/MUNMAP/MREMAP."),
+            _col("cmdline", "string", "", "Full argv of the triggering process."),
+            _col("return_value", "s64", "", "Raw READ/WRITE return (bytes or -errno); empty otherwise."),
+            _col("errno", "string", "", "Error name when READ/WRITE failed; empty otherwise."),
+            _col("bytes_completed", "u64", "bytes", "Actual bytes moved by READ/WRITE; empty otherwise."),
+            _col("duration_ns", "u64", "nanoseconds", "READ/WRITE entry->return duration; empty otherwise."),
+            _col("device", "string", "", "Backing device major:minor for READ/WRITE/OPEN."),
+            _col("ppid", "u32"),
+            _col("container_id", "u64", "", "cgroup v2 id (container identifier)."),
+            _col("fs_type", "string", "", "Source filesystem name from superblock magic."),
+        ],
+    ),
+    "ds": _stream(
+        "ds", "ds",
+        "Block-device (disk) I/O completion events.",
+        "CLOCK_REALTIME (derived from kernel CLOCK_MONOTONIC)",
+        [
+            _col("timestamp", "datetime", "", "Completion wall-clock time."),
+            _col("pid", "u32", "", "Submitting process ID."),
+            _col("command", "string"),
+            _col("sector", "u64", "", "Starting sector (LBA)."),
+            _col("operation", "string", "", "Block op type (read, write, discard, ...)."),
+            _col("size", "u64", "bytes", "I/O size."),
+            _col("latency_ms", "float", "milliseconds", "Device latency (issue->completion)."),
+            _col("tid", "u32"),
+            _col("cpu_id", "u32", "", "CPU that processed completion."),
+            _col("ppid", "u32"),
+            _col("device", "string", "", "Device major:minor."),
+            _col("queue_latency_ms", "float", "milliseconds", "Scheduler latency (insert->issue)."),
+            _col("command_flags", "string", "", "REQ_* flags; empty on kernel >=5.17."),
+            _col("operation_code", "string", "", "Raw REQ_OP_* name; empty on kernel >=5.17."),
+            _col("request_id", "u64", "", "Monotonic per-request id (this trace session)."),
+        ],
+    ),
+    "cache": _stream(
+        "cache", "cache",
+        "Page-cache events (hit/miss/dirty/writeback/evict/...).",
+        "CLOCK_REALTIME (derived from kernel CLOCK_MONOTONIC)",
+        [
+            _col("timestamp", "datetime"),
+            _col("pid", "u32"),
+            _col("command", "string"),
+            _col("event_type", "string", "", "Cache event type (HIT, MISS, DIRTY, ...)."),
+            _col("inode", "u64"),
+            _col("page_index", "u64", "", "Page offset within file (file offset / PAGE_SIZE)."),
+            _col("size_pages", "u32", "pages", "File size in pages (i_size >> 12)."),
+            _col("cpu_id", "u32"),
+            _col("device_id", "u32"),
+            _col("count", "u32", "pages", "Pages affected by the operation."),
+        ],
+    ),
+    "pagefault": _stream(
+        "pagefault", "pagefault",
+        "File-backed page-fault events (mmap I/O).",
+        "CLOCK_REALTIME (derived from kernel CLOCK_MONOTONIC)",
+        [
+            _col("timestamp", "datetime"),
+            _col("pid", "u32"),
+            _col("tid", "u32"),
+            _col("command", "string"),
+            _col("fault_type", "string", "", "Access type that triggered the fault."),
+            _col("severity", "string", "", "Fault severity (major/minor)."),
+            _col("inode", "u64", "", "Backing file inode; empty for anonymous."),
+            _col("offset_pages", "u64", "pages", "File offset in pages (pgoff)."),
+            _col("address", "string", "", "Faulting virtual address (hex)."),
+            _col("device_id", "u32"),
+        ],
+    ),
+    "process": _stream(
+        "process", "process",
+        "Periodic process-state snapshots (userspace, from /proc via psutil).",
+        "CLOCK_REALTIME",
+        [
+            _col("timestamp", "datetime", "", "Snapshot wall-clock time."),
+            _col("pid", "integer"),
+            _col("name", "string"),
+            _col("cmdline", "string", "", "Full command line (hashed in anonymous mode)."),
+            _col("vms_kb", "float", "KB", "Virtual memory size."),
+            _col("rss_kb", "float", "KB", "Resident set size."),
+            _col("creation_time", "datetime", "", "Process start time."),
+            _col("cpu_5s", "float", "percent", "CPU%% over last 5s."),
+            _col("cpu_2m", "float", "percent", "CPU%% over last 2m."),
+            _col("cpu_1h", "float", "percent", "CPU%% over last 1h."),
+            _col("status", "string"),
+        ],
+    ),
+    "filesystem_snapshot": _stream(
+        "filesystem_snapshot", "filesystem_snapshot",
+        "Filesystem inventory snapshot (userspace).",
+        "CLOCK_REALTIME",
+        [
+            _col("snapshot_timestamp", "datetime", "", "Time the snapshot was taken."),
+            _col("file_path", "string", "", "Full path (hashed in anonymous mode)."),
+            _col("size", "integer", "bytes"),
+            _col("creation_time", "datetime", "", "st_birthtime (falls back to st_mtime)."),
+            _col("modification_time", "datetime", "", "st_mtime."),
+            _col("access_time", "datetime", "", "st_atime."),
+        ],
+    ),
+}
+
+
+def column_names(stream_key):
+    """Ordered list of column names for a stream."""
+    return [c["name"] for c in STREAMS[stream_key]["columns"]]
+
+
+def header_line(stream_key):
+    """CSV header row (no trailing newline) for a stream."""
+    return ",".join(column_names(stream_key))
+
+
+def schema_for_manifest():
+    """The static (runtime-independent) schema block for manifest.json."""
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "streams": {
+            key: {
+                "subdir": s["subdir"],
+                "filename_prefix": s["filename_prefix"],
+                "description": s["description"],
+                "wall_clock": s["wall_clock"],
+                "columns": s["columns"],
+            }
+            for key, s in STREAMS.items()
+        },
+    }

--- a/src/tracer/snappers/FilesystemSnapper.py
+++ b/src/tracer/snappers/FilesystemSnapper.py
@@ -77,8 +77,9 @@ class FilesystemSnapper:
         Returns:
             bool: True if snapshot completed naturally, False if interrupted
         """
-        # Capture snapshot timestamp once for all files in this snapshot
-        snapshot_timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        # Capture snapshot timestamp once for all files in this snapshot.
+        # Millisecond resolution to match the process snapshot stream.
+        snapshot_timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
         count = 0
         def scan_dir(path: str, depth: int = 0):
             """Inner function for recursive directory scanning."""

--- a/src/tracer/snappers/FilesystemSnapper.py
+++ b/src/tracer/snappers/FilesystemSnapper.py
@@ -80,6 +80,8 @@ class FilesystemSnapper:
         # Capture snapshot timestamp once for all files in this snapshot.
         # Millisecond resolution to match the process snapshot stream.
         snapshot_timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+        # Common cross-stream clock, captured once for the whole snapshot.
+        snapshot_mono_ns = time.monotonic_ns()
         count = 0
         def scan_dir(path: str, depth: int = 0):
             """Inner function for recursive directory scanning."""
@@ -116,7 +118,7 @@ class FilesystemSnapper:
                                     hashed_rel = hash_rel_path(rel, keep_ext=True, length=12)
                                     hashed_path = os.path.join(os.sep, str(hashed_rel))
                                     hashed_path = hash_filename_in_path(Path(hashed_path))
-                                    out = format_csv_row(snapshot_timestamp, hashed_path, size, ctime, mtime, atime)
+                                    out = format_csv_row(snapshot_timestamp, hashed_path, size, ctime, mtime, atime, snapshot_mono_ns)
                                     self.wm.append_fs_snap_log(out)
                                     count += 1  
                                 else:
@@ -126,7 +128,7 @@ class FilesystemSnapper:
                                     ctime = datetime.fromtimestamp(getattr(est, "st_birthtime", est.st_mtime))
                                     mtime = datetime.fromtimestamp(est.st_mtime)
                                     atime = datetime.fromtimestamp(est.st_atime)
-                                    out = format_csv_row(snapshot_timestamp, hashed_path_str, size, ctime, mtime, atime)
+                                    out = format_csv_row(snapshot_timestamp, hashed_path_str, size, ctime, mtime, atime, snapshot_mono_ns)
                                     self.wm.append_fs_snap_log(out)
                                     count += 1     
                             elif entry.is_dir(follow_symlinks=False):

--- a/src/tracer/snappers/ProcessSnapper.py
+++ b/src/tracer/snappers/ProcessSnapper.py
@@ -85,6 +85,8 @@ class ProcessSnapper:
         
         # Millisecond resolution so snapshot rows can be ordered within a second.
         timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
+        # Common cross-stream clock, captured once for the whole snapshot.
+        snapshot_mono_ns = time.monotonic_ns()
         for proc in psutil.process_iter(['pid', 'name', 'memory_info','cmdline','create_time','status']):
             # Check if stop was requested during iteration
             if not self.running:
@@ -108,7 +110,7 @@ class ProcessSnapper:
                 cpu_2m = self.sampler.cpu_percent_for_interval(pid, create_time, 120.0) or 0.0
                 cpu_1h = self.sampler.cpu_percent_for_interval(pid, create_time, 3600.0) or 0.0
 
-                out = format_csv_row(ts, pid, name, cmdline, virtual_mem, working_set_size, datetime.fromtimestamp(create_time), cpu_5s, cpu_2m, cpu_1h, status)
+                out = format_csv_row(ts, pid, name, cmdline, virtual_mem, working_set_size, datetime.fromtimestamp(create_time), cpu_5s, cpu_2m, cpu_1h, status, snapshot_mono_ns)
                 
                 self.wm.append_process_log(out)
             except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess) as e:

--- a/src/tracer/snappers/ProcessSnapper.py
+++ b/src/tracer/snappers/ProcessSnapper.py
@@ -83,7 +83,8 @@ class ProcessSnapper:
         # Mark snapshot session as active
         self.wm.start_process_snapshot_session()
         
-        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        # Millisecond resolution so snapshot rows can be ordered within a second.
+        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S.%f")[:-3]
         for proc in psutil.process_iter(['pid', 'name', 'memory_info','cmdline','create_time','status']):
             # Check if stop was requested during iteration
             if not self.running:

--- a/tests/test_path_resolver.py
+++ b/tests/test_path_resolver.py
@@ -10,6 +10,7 @@ import os
 import sys
 import time
 import unittest
+from unittest import mock
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -64,6 +65,52 @@ class CleanupOldCacheTests(unittest.TestCase):
         r.inode_to_path[1] = "/a"
         r.cleanup_old_cache()
         self.assertEqual(r.inode_to_path, {1: "/a"})
+
+
+class ResolveRelativeTests(unittest.TestCase):
+    def test_absolute_path_returned_unchanged(self):
+        r = PathResolver()
+        # Absolute paths need no resolution and must not touch /proc.
+        with mock.patch("src.tracer.PathResolver.os.readlink") as rl:
+            self.assertEqual(
+                r.resolve_relative(pid=1, dirfd=PathResolver.AT_FDCWD, relpath="/etc/passwd"),
+                "/etc/passwd",
+            )
+            rl.assert_not_called()
+
+    def test_missing_pid_or_relpath_returns_relpath(self):
+        r = PathResolver()
+        self.assertEqual(r.resolve_relative(pid=0, dirfd=-100, relpath="a.txt"), "a.txt")
+        self.assertEqual(r.resolve_relative(pid=5, dirfd=-100, relpath=""), "")
+
+    def test_cwd_relative_joined_and_normalised(self):
+        r = PathResolver()
+        with mock.patch("src.tracer.PathResolver.os.readlink", return_value="/home/user/proj"):
+            out = r.resolve_relative(pid=99, dirfd=PathResolver.AT_FDCWD,
+                                     relpath="../data/x.bin", inode=7)
+        self.assertEqual(out, "/home/user/data/x.bin")
+        # Successful resolution populates the inode cache.
+        self.assertEqual(r.inode_to_path[7], "/home/user/data/x.bin")
+
+    def test_dirfd_relative_uses_fd_link(self):
+        r = PathResolver()
+        with mock.patch("src.tracer.PathResolver.os.readlink", return_value="/var/log") as rl:
+            out = r.resolve_relative(pid=99, dirfd=5, relpath="app/run.log")
+        self.assertEqual(out, "/var/log/app/run.log")
+        rl.assert_called_once_with("/proc/99/fd/5")
+
+    def test_pseudo_dir_base_falls_back(self):
+        r = PathResolver()
+        with mock.patch("src.tracer.PathResolver.os.readlink", return_value="pipe:[12345]"):
+            self.assertEqual(r.resolve_relative(pid=99, dirfd=5, relpath="x"), "x")
+
+    def test_oserror_falls_back_to_relpath(self):
+        r = PathResolver()
+        with mock.patch("src.tracer.PathResolver.os.readlink", side_effect=OSError):
+            self.assertEqual(
+                r.resolve_relative(pid=99, dirfd=PathResolver.AT_FDCWD, relpath="x.txt"),
+                "x.txt",
+            )
 
 
 if __name__ == "__main__":

--- a/tests/test_path_resolver.py
+++ b/tests/test_path_resolver.py
@@ -112,6 +112,20 @@ class ResolveRelativeTests(unittest.TestCase):
                 "x.txt",
             )
 
+    def test_deleted_base_dir_falls_back(self):
+        # /proc/<pid>/cwd of an unlinked dir reads as "/path (deleted)"; joining
+        # onto it would fabricate a path that never existed.
+        r = PathResolver()
+        with mock.patch("src.tracer.PathResolver.os.readlink",
+                        return_value="/tmp/gone (deleted)"):
+            self.assertEqual(
+                r.resolve_relative(pid=99, dirfd=PathResolver.AT_FDCWD,
+                                   relpath="x.txt", inode=5),
+                "x.txt",
+            )
+        # And it must not poison the inode cache with a bogus path.
+        self.assertNotIn(5, r.inode_to_path)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -1,0 +1,85 @@
+"""
+Unit tests for src.tracer.schema — the single source of truth for the on-disk
+trace format (CSV headers + manifest.json).
+"""
+
+import json
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from src.tracer import schema
+
+
+# Expected column counts INCLUDING the trailing mono_ns column. These must match
+# the number of fields each callback passes to format_csv_row.
+EXPECTED_COLUMN_COUNTS = {
+    "fs": 23,                  # 22 documented + mono_ns
+    "ds": 16,                  # 15 documented + mono_ns
+    "cache": 11,               # 10 + mono_ns
+    "pagefault": 11,           # 10 + mono_ns
+    "process": 12,             # 11 + mono_ns
+    "filesystem_snapshot": 7,  # 6 + mono_ns
+}
+
+
+class SchemaShapeTests(unittest.TestCase):
+    def test_schema_version_is_2(self):
+        self.assertEqual(schema.SCHEMA_VERSION, 2)
+
+    def test_all_streams_present(self):
+        self.assertEqual(set(schema.STREAMS), set(EXPECTED_COLUMN_COUNTS))
+
+    def test_column_counts(self):
+        for key, expected in EXPECTED_COLUMN_COUNTS.items():
+            self.assertEqual(len(schema.column_names(key)), expected,
+                             f"{key} column count")
+
+    def test_first_column_is_timestamp(self):
+        for key in schema.STREAMS:
+            self.assertIn("timestamp", schema.column_names(key)[0],
+                          f"{key} first column should be a timestamp")
+
+    def test_last_column_is_mono_ns(self):
+        for key in schema.STREAMS:
+            self.assertEqual(schema.column_names(key)[-1], "mono_ns",
+                             f"{key} last column should be mono_ns")
+
+    def test_column_names_unique_per_stream(self):
+        for key in schema.STREAMS:
+            names = schema.column_names(key)
+            self.assertEqual(len(names), len(set(names)), f"{key} has duplicate columns")
+
+
+class HeaderTests(unittest.TestCase):
+    def test_header_line_matches_columns(self):
+        for key in schema.STREAMS:
+            self.assertEqual(schema.header_line(key).split(","),
+                             schema.column_names(key))
+
+    def test_header_has_no_newline(self):
+        for key in schema.STREAMS:
+            self.assertNotIn("\n", schema.header_line(key))
+
+
+class ManifestTests(unittest.TestCase):
+    def test_manifest_block_is_json_serializable(self):
+        block = schema.schema_for_manifest()
+        # Round-trips through JSON without error.
+        restored = json.loads(json.dumps(block))
+        self.assertEqual(restored["schema_version"], 2)
+        self.assertEqual(set(restored["streams"]), set(EXPECTED_COLUMN_COUNTS))
+
+    def test_manifest_columns_carry_type_and_unit(self):
+        block = schema.schema_for_manifest()
+        for key, sdef in block["streams"].items():
+            for col in sdef["columns"]:
+                self.assertIn("name", col)
+                self.assertIn("type", col)
+                self.assertIn("unit", col)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Addresses issues surfaced by trace analysis, then makes the on-disk format self-describing.

> ⚠️ **The BPF (`prober.c`) changes in batches 2–3 are compile/CI-validated only** — they could not be runtime-tested here. Please validate against a real trace. Batches 1 and 4 are userspace and unit-tested.

> 🔶 **Breaking format change (schema_version 2):** every CSV now has a header row and a trailing `mono_ns` column. Consumers should read `schema_version` from `manifest.json` and adapt.

## Batch 1 — userspace quick wins
Kernel-time ordering (integer-ns offset) across all callbacks + io_uring mirror; ms-resolution process & filesystem snapshots; early self-pid filtering; cgroup v2 / bpffs added to the BPF `is_regular_file()` gate; `Size (requested)` vs `bytes_completed (actual)` doc clarification.

## Batch 2 — block layer
Monotonic per-request `req_id`; per-CPU `block_stats` (issued/completed/missed) diagnostics. Investigation found no leak/exhaustion bug behind "block stops early"; the counter lets you confirm the cause on a real trace.

## Batch 3 — path resolution (dirfd + cwd)
Capture openat dirfd; `resolve_relative()` anchors still-relative OPEN paths against `/proc/<pid>/cwd` or `/fd/<dirfd>` (guards unlinked dirs; basename fallback preserves the "absolute-or-basename" invariant).

## Batch 4 — self-describing format (schema v2) — *new*
Addresses the "no header row / no schema manifest / undocumented drift / no common clock / no drop counters" findings:
- **`src/tracer/schema.py`** — one source of truth for every stream's ordered `{name, type, unit}` columns; drives both headers and the manifest so they can't drift.
- **CSV headers** on every (rotated) file, via a single `_open_log_file()` helper.
- **Common `mono_ns` clock** (CLOCK_MONOTONIC) appended to every stream — kernel `bpf_ktime_get_ns()` for perf events, `time.monotonic_ns()` for snapshots; `manifest.clock.mono_to_real_offset_ns` recovers wall-clock. Records across streams are now correlatable on one clock.
- **`manifest.json`** per session: schema + per-stream columns, tracer/host/kernel versions, clock block, session start/stop/duration, and diagnostics.
- **Per-stream diagnostics**: per-buffer lost-event counters, per-stream `rows_written` (spots probes that attached but produced no events), attached-probe list, block stats. See `docs/traces/MANIFEST.md`.

*(Per your note, the ragged-column/garbled-extension issues were the analyzer's `split(",")` bug, not the collector — no change needed there.)*

## Out of scope
io_uring network visibility (feature add; io_uring socket ops have no file inode, removed in #39).

## Testing
- `python3 -m unittest discover -s tests` — **58 pass** (new: `test_schema.py`, `resolve_relative` tests).
- Verified header-writing (header once, rows appended) and integer-ns clock conversion (~34µs).
- BPF: compile/CI only — needs your runtime validation.

https://claude.ai/code/session_01CvTZftUZ3VNJMcWc3bLa3C