### PR TITLE
Sync documentation with schema v2, Zstandard, and io_uring stream removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ sudo apt install python3-pytest
 
 ## Usage
 ```
-usage: sudo iotrc [-h] [-v] [-a] [--dev] [--computer-id] [--reward]
+usage: sudo iotrc [-h] [-v] [-a] [--computer-id] [--reward] [--no-upload] {dev} ...
 
 Trace IO syscalls
 
@@ -61,9 +61,13 @@ options:
   -h, --help       show this help message and exit
   -v, --verbose    Print verbose output
   -a, --anonimize  Enable anonymization of process and file names
-  --dev            Developer mode with extra logs and checks
   --computer-id    Print this machine ID and exit
   --reward         Show your reward code (unlocked after uploading traces)
+  --no-upload      Disable automatic upload of traces (for testing)
+
+subcommands:
+  {dev}            Run in developer mode with extra logs and checks
+                   (supports --trace-bucket NAME to override the upload bucket)
 ```
 
 ## Trace Types

--- a/docs/MULTIPART_FILESYSTEM_SNAPSHOT.md
+++ b/docs/MULTIPART_FILESYSTEM_SNAPSHOT.md
@@ -11,7 +11,7 @@ The filesystem snapshot feature now supports splitting large filesystem scans in
 Each part of a filesystem snapshot follows this naming pattern:
 
 ```
-filesystem_snapshot_part####_TIMESTAMP_DEVICEID.csv.gz
+filesystem_snapshot_part####_TIMESTAMP_DEVICEID.csv.zst
 ```
 
 Where:
@@ -24,7 +24,7 @@ Where:
 The final part is renamed to indicate completion:
 
 ```
-filesystem_snapshot_part####_TIMESTAMP_DEVICEID_complete_partsN.csv.gz
+filesystem_snapshot_part####_TIMESTAMP_DEVICEID_complete_partsN.csv.zst
 ```
 
 The `_complete_partsN` suffix indicates:
@@ -36,14 +36,14 @@ The `_complete_partsN` suffix indicates:
 A 3-part filesystem snapshot might produce these files:
 
 ```
-filesystem_snapshot_part0001_20260214_120000_ABC123DEF456.csv.gz
-filesystem_snapshot_part0002_20260214_120000_ABC123DEF456.csv.gz
-filesystem_snapshot_part0003_20260214_120000_ABC123DEF456_complete_parts3.csv.gz
+filesystem_snapshot_part0001_20260214_120000_ABC123DEF456.csv.zst
+filesystem_snapshot_part0002_20260214_120000_ABC123DEF456.csv.zst
+filesystem_snapshot_part0003_20260214_120000_ABC123DEF456_complete_parts3.csv.zst
 ```
 
 ## Compression
 
-Files are compressed using **gzip** for reliable and efficient compression.
+Files are compressed using **Zstandard** (`.zst`) for reliable and efficient compression.
 
 ## Implementation Details
 
@@ -60,7 +60,7 @@ Files are compressed using **gzip** for reliable and efficient compression.
    - `mark_fs_snapshot_complete()`: Rename final part with completion marker
 
 3. **Modified Methods**:
-   - `flush_fssnap_only()`: Now writes to part-based files with gzip compression
+   - `flush_fssnap_only()`: Now writes to part-based files with Zstandard compression
 
 ### FilesystemSnapper Changes
 
@@ -68,13 +68,13 @@ The `filesystem_snapshot()` method now calls `mark_fs_snapshot_complete()` after
 
 ### Utils Changes
 
-Uses the existing `compress_log()` function that:
-- Compresses files using gzip
+Uses the existing `compress_file_zstd()` helper that:
+- Compresses files using Zstandard
 - Removes the original uncompressed file after compression
 
 ## Buffer Flushing
 
-The filesystem snapshot buffer is flushed when it reaches the threshold (`fs_snap_max_events`, default 8000 entries). Each flush creates a new part file. This prevents memory overflow during large filesystem scans.
+The filesystem snapshot buffer is flushed when it reaches the threshold (`fs_snap_max_events`, default 80000 entries). Each flush creates a new part file. This prevents memory overflow during large filesystem scans.
 
 ## Memory Optimization
 
@@ -178,4 +178,4 @@ else:
 
 This feature requires:
 - All parts must have consistent timestamp and device ID
-- gzip is available by default in Python's standard library
+- Zstandard support via the `zstandard` package (see `requirements.txt`)

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,9 +22,11 @@ linux_trace_v4_test/{MACHINE_ID}/{YYYYMMDD_HHMMSS_mmm}/
 ├── pagefault/             # Page fault events
 ├── process/               # Process state snapshots
 ├── filesystem_snapshot/   # Filesystem metadata snapshots
-├── system_spec/           # System specification files
-└── manifest.json          # Self-describing schema for this session
+└── system_spec/           # System specification files
 ```
+
+A self-describing `manifest.json` (schema version, per-stream columns, and clock
+diagnostics) is written at the session root and delivered inside the session archive.
 
 - `{MACHINE_ID}`: Uppercase machine identifier
 - `{YYYYMMDD_HHMMSS_mmm}`: Timestamp with millisecond precision

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,15 +15,15 @@ This directory contains the complete documentation for IO Tracer's trace output,
 Traces are stored in object storage with the following prefix structure:
 
 ```
-linux_trace_v3_test/{MACHINE_ID}/{YYYYMMDD_HHMMSS_mmm}/
-├── fs/                    # VFS traces
+linux_trace_v4_test/{MACHINE_ID}/{YYYYMMDD_HHMMSS_mmm}/
+├── fs/                    # VFS traces (also receives mirrored io_uring I/O)
 ├── ds/                    # Block device traces
 ├── cache/                 # Page cache events
 ├── pagefault/             # Page fault events
-├── io_uring/              # io_uring async I/O events
 ├── process/               # Process state snapshots
 ├── filesystem_snapshot/   # Filesystem metadata snapshots
-└── system_spec/           # System specification files
+├── system_spec/           # System specification files
+└── manifest.json          # Self-describing schema for this session
 ```
 
 - `{MACHINE_ID}`: Uppercase machine identifier

--- a/docs/TRACE_FORMAT.md
+++ b/docs/TRACE_FORMAT.md
@@ -2,39 +2,59 @@
 
 This document describes the CSV output format for all trace types produced by io-tracer-linux.
 
+The on-disk schema is defined once, in [`src/tracer/schema.py`](../src/tracer/schema.py),
+which is the single source of truth. The CSV header rows written by `WriteManager`
+and the per-session `manifest.json` are both derived from it, so the column lists
+below mirror that module. Bump `SCHEMA_VERSION` there whenever columns change.
+
 ## Output Structure
 
 Traces are uploaded to object storage with the following prefix structure:
 
 ```
-linux_trace_v3_test/{MACHINE_ID}/{YYYYMMDD_HHMMSS_mmm}/
+linux_trace_v4_test/{MACHINE_ID}/{YYYYMMDD_HHMMSS_mmm}/
 ├── fs/                    # VFS (Virtual File System) traces
 ├── ds/                    # Block device traces
 ├── cache/                 # Page cache events
 ├── pagefault/             # Memory-mapped page fault events
-├── io_uring/              # io_uring async I/O events
 ├── process/               # Process state snapshots
 ├── filesystem_snapshot/   # Filesystem metadata snapshots
-└── system_spec/           # System specification files
+├── system_spec/           # System specification files
+└── manifest.json          # Self-describing schema for this session
 ```
 
 - `{MACHINE_ID}`: Uppercase machine identifier
 - `{YYYYMMDD_HHMMSS_mmm}`: Timestamp with millisecond precision
 
-Each subdirectory contains CSV files that are automatically compressed to `.csv.gz` format.
+Each subdirectory contains CSV files that are automatically compressed to `.csv.zst`
+(Zstandard) format. Every CSV begins with a header row, and every stream carries a
+trailing `mono_ns` column (`CLOCK_MONOTONIC` nanoseconds) — the common clock for
+correlating records across streams.
+
+> **io_uring:** there is no separate `io_uring/` output stream. io_uring read/write
+> I/O bypasses the VFS probes, so it is mirrored into the `fs/` (VFS) trace instead.
+> See [IO_URING_EVENTS.md](traces/IO_URING_EVENTS.md).
+
+### manifest.json
+
+A `manifest.json` is written once per session. It embeds `schema_version`, the full
+column list (name, type, unit, description) for every stream, and runtime diagnostics
+(per-stream row counts, the `CLOCK_MONOTONIC`→`CLOCK_REALTIME` offset used to derive
+wall-clock timestamps, etc.). Consumers should read the schema from `manifest.json`
+rather than hard-coding column positions.
 
 ---
 
 ## 1. VFS (Virtual File System) Traces
 
-**Location:** `linux_trace_v3_test/{MACHINE_ID}/{TIMESTAMP}/fs/fs_*.csv.gz`
+**Location:** `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/fs/fs_*.csv.zst`
 
-**Description:** Captures all file system operations at the VFS layer, including reads, writes, opens, closes, and metadata operations.
+**Description:** Captures all file system operations at the VFS layer, including reads, writes, opens, closes, and metadata operations. Also receives io_uring READ/WRITE rows mirrored from the io_uring instrumentation.
 
 ### CSV Header
 
 ```csv
-timestamp,operation,pid,command,filename,size,inode,flags,offset,tid,mmap_prot,mmap_flags,address,cmdline,return_value,errno,bytes_completed,duration_ns,device,ppid,container_id,fs_type
+timestamp,operation,pid,command,filename,size_requested,inode,flags,offset,tid,mmap_prot,mmap_flags,address,cmdline,return_value,errno,bytes_completed,duration_ns,device,ppid,container_id,fs_type,mono_ns
 ```
 
 `return_value`, `errno`, `bytes_completed`, and `duration_ns` are populated for `READ`/`WRITE`; `device`, `ppid`, `container_id`, and `fs_type` are populated for `READ`/`WRITE`/`OPEN`. All are empty for operations that do not carry them.
@@ -45,30 +65,30 @@ For operations captured and examples, see [VFS_EVENTS.md](traces/VFS_EVENTS.md).
 
 ## 2. Block Device Traces
 
-**Location:** `linux_trace_v3_test/{MACHINE_ID}/{TIMESTAMP}/ds/ds_*.csv.gz`
+**Location:** `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/ds/ds_*.csv.zst`
 
 **Description:** Captures block layer I/O operations with latency measurements from issue to completion.
 
 ### CSV Header
 
 ```csv
-timestamp,pid,command,sector,operation,size,latency_ms,tid,cpu_id,ppid,dev,queue_time_ms,cmd_flags,op_code
+timestamp,pid,command,sector,operation,size,latency_ms,tid,cpu_id,ppid,device,queue_latency_ms,command_flags,operation_code,request_id,mono_ns
 ```
 
-For operations captured and examples, see [BLOCK_IO_EVENTS.md](traces/BLOCK_IO_EVENTS.md).
+`command_flags` and `operation_code` are empty on kernel ≥ 5.17. For operations captured and examples, see [BLOCK_IO_EVENTS.md](traces/BLOCK_IO_EVENTS.md).
 
 ---
 
 ## 3. Cache Events
 
-**Location:** `linux_trace_v3_test/{MACHINE_ID}/{TIMESTAMP}/cache/cache_*.csv.gz`
+**Location:** `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/cache/cache_*.csv.zst`
 
 **Description:** Captures page cache operations including hits, misses, dirty pages, writeback, and evictions.
 
 ### CSV Header
 
 ```csv
-timestamp,pid,command,event_type,inode,index,size,cpu_id,dev_id,count
+timestamp,pid,command,event_type,inode,page_index,size_pages,cpu_id,device_id,count,mono_ns
 ```
 
 For event types and examples, see [PAGE_CACHE_EVENTS.md](traces/PAGE_CACHE_EVENTS.md).
@@ -77,65 +97,55 @@ For event types and examples, see [PAGE_CACHE_EVENTS.md](traces/PAGE_CACHE_EVENT
 
 ## 4. Page Fault Events
 
-**Location:** `linux_trace_v3_test/{MACHINE_ID}/{TIMESTAMP}/pagefault/pagefault_*.csv.gz`
+**Location:** `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/pagefault/pagefault_*.csv.zst`
 
 **Description:** Captures file-backed page faults from memory-mapped I/O operations. Tracks which memory accesses trigger disk reads (major faults) vs cache hits (minor faults).
 
 ### CSV Header
 
 ```csv
-timestamp,pid,tid,command,fault_type,severity,inode,offset,address,dev_id
+timestamp,pid,tid,command,fault_type,severity,inode,offset_pages,address,device_id,mono_ns
 ```
 
 For fault types and examples, see [PAGE_FAULT_EVENTS.md](traces/PAGE_FAULT_EVENTS.md).
 
 ---
 
-## 5. io_uring Events
+## 5. Process Snapshots
 
-**Location:** `linux_trace_v3_test/{MACHINE_ID}/{TIMESTAMP}/io_uring/io_uring_*.csv.gz`
-
-**Description:** Captures io_uring async I/O events for high-performance applications.
-
-For CSV format and examples, see [IO_URING_EVENTS.md](traces/IO_URING_EVENTS.md).
-
----
-
-## 6. Process Snapshots
-
-**Location:** `linux_trace_v3_test/{MACHINE_ID}/{TIMESTAMP}/process/process_*.csv.gz`
+**Location:** `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/process/process_*.csv.zst`
 
 **Description:** Periodic snapshots of all running processes (captured every 5 minutes by default).
 
 ### CSV Header
 
 ```csv
-timestamp,pid,name,cmdline,virtual_mem_kb,rss_kb,create_time,cpu_5s,cpu_2m,cpu_1h,status
+timestamp,pid,name,cmdline,vms_kb,rss_kb,creation_time,cpu_5s,cpu_2m,cpu_1h,status,mono_ns
 ```
 
 For field details and examples, see [PROCESS_SNAPSHOT.md](traces/PROCESS_SNAPSHOT.md).
 
 ---
 
-## 7. Filesystem Snapshots
+## 6. Filesystem Snapshots
 
-**Location:** `linux_trace_v3_test/{MACHINE_ID}/{TIMESTAMP}/filesystem_snapshot/filesystem_snapshot_*.csv.gz`
+**Location:** `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/filesystem_snapshot/filesystem_snapshot_*.csv.zst`
 
-**Description:** Periodic directory tree snapshots showing file metadata (captured hourly by default).
+**Description:** Periodic directory tree snapshots showing file metadata (captured hourly by default). Large scans are split into multiple parts — see [MULTIPART_FILESYSTEM_SNAPSHOT.md](MULTIPART_FILESYSTEM_SNAPSHOT.md).
 
 ### CSV Header
 
 ```csv
-snapshot_timestamp,path,size,ctime,mtime,atime
+snapshot_timestamp,file_path,size,creation_time,modification_time,access_time,mono_ns
 ```
 
 For field details and examples, see [FILESYSTEM_SNAPSHOT.md](traces/FILESYSTEM_SNAPSHOT.md).
 
 ---
 
-## 8. System Specification Files
+## 7. System Specification Files
 
-**Location:** `linux_trace_v3_test/{MACHINE_ID}/{TIMESTAMP}/system_spec/`
+**Location:** `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/system_spec/`
 
 These are JSON files capturing system hardware and configuration at trace start:
 
@@ -152,9 +162,9 @@ For field details, see [SYSTEM_SNAPSHOT.md](traces/SYSTEM_SNAPSHOT.md).
 ## Data Types and Conventions
 
 ### Timestamps
-- Format: `YYYY-MM-DD HH:MM:SS.ffffff` (microsecond precision)
-- Timezone: Local system time
-- Source: `datetime.datetime.today()` (Python) or `bpf_ktime_get_ns()` (eBPF)
+- `timestamp` column format: `YYYY-MM-DD HH:MM:SS.ffffff` (microsecond precision)
+- Timezone: Local system time (`CLOCK_REALTIME`, derived from the kernel's `CLOCK_MONOTONIC` for perf-event streams)
+- `mono_ns` column: raw `CLOCK_MONOTONIC` nanoseconds — `bpf_ktime_get_ns()` for perf-event streams, `time.monotonic_ns()` for userspace snapshots. This is the common cross-stream correlation clock.
 
 ### File Paths
 - Always absolute paths when available
@@ -172,7 +182,7 @@ For field details, see [SYSTEM_SNAPSHOT.md](traces/SYSTEM_SNAPSHOT.md).
 - All sizes in bytes unless specified
 - Sector count: 512-byte sectors (multiply by 512 for bytes)
 - Page size: 4096 bytes (4 KiB)
-- Cache index × 4096 = byte offset
+- Cache `page_index` × 4096 = byte offset
 
 ### Special Values
 - `0` - Not applicable or unavailable
@@ -184,19 +194,20 @@ For field details, see [SYSTEM_SNAPSHOT.md](traces/SYSTEM_SNAPSHOT.md).
 ## Compression and File Rotation
 
 ### Compression
-- All CSV files are automatically compressed with gzip
+- All CSV files are automatically compressed with Zstandard
 - Original `.csv` files are deleted after compression
-- Final archives: `.csv.gz` format
+- Final archives: `.csv.zst` format
 
 ### File Rotation
-Files are rotated and compressed when buffers reach thresholds:
-- **VFS traces:** Every 1000 events
-- **Block traces:** Every 1000 events  
-- **Cache traces:** Every 10000 events (before sampling)
-- **Network traces:** Every 1000 events
-- **Snapshots:** Each snapshot creates a new file
+Continuous streams (VFS, block, cache, page fault) are rotated and compressed when any
+of the following is reached (see `WriteManager` in `src/tracer/WriterManager.py`):
+- **Event count:** ~80,000–100,000 buffered events (adaptively raised under load)
+- **File age:** 20 minutes since the current file was opened
+- **File size:** 100 MB uncompressed on disk
 
-File naming: `{type}_{YYYYMMDD_HHMMSS_mmm}.csv.gz`
+Snapshots (process, filesystem) are written as whole units rather than rotated mid-session.
+
+File naming: `{type}_{YYYYMMDD_HHMMSS_mmm}_{seq}.csv.zst`
 
 ---
 
@@ -205,41 +216,42 @@ File naming: `{type}_{YYYYMMDD_HHMMSS_mmm}.csv.gz`
 ### Command Line
 ```bash
 # View compressed file
-zcat fs_*.csv.gz | less
+zstd -dc fs_*.csv.zst | less
 
 # Parse with csvkit
-zcat fs_*.csv.gz | csvstat
+zstd -dc fs_*.csv.zst | csvstat
 
 # Count events
-zcat fs_*.csv.gz | wc -l
+zstd -dc fs_*.csv.zst | wc -l
 
 # Filter specific operation
-zcat fs_*.csv.gz | grep ",WRITE,"
+zstd -dc fs_*.csv.zst | grep ",WRITE,"
 ```
 
 ### Python
 ```python
-import gzip
 import csv
+import io
+import zstandard
 
-with gzip.open('fs_20240115_103045_123.csv.gz', 'rt') as f:
-    reader = csv.reader(f)
+with open('fs_20240115_103045_123_0001.csv.zst', 'rb') as fh:
+    text = io.TextIOWrapper(zstandard.ZstdDecompressor().stream_reader(fh), encoding='utf-8')
+    reader = csv.DictReader(text)  # first row is the schema header
     for row in reader:
-        timestamp, operation, pid, command, filename, size, inode, flags, latency = row
-        print(f"{timestamp}: {operation} on {filename} by {command} ({pid})")
+        print(f"{row['timestamp']}: {row['operation']} on {row['filename']} by {row['command']} ({row['pid']})")
 ```
 
 ### Pandas
 ```python
-import pandas as pd
 import glob
+import pandas as pd
 
-# Single file
-df = pd.read_csv('fs_20240115_103045_123.csv.gz', compression='gzip')
+# pandas reads .zst natively when the `zstandard` package is installed
+df = pd.read_csv('fs_20240115_103045_123_0001.csv.zst')
 
 # Multiple files in a directory
-files = glob.glob('*.csv.gz')
-df = pd.concat([pd.read_csv(f, compression='gzip') for f in files])
+files = glob.glob('*.csv.zst')
+df = pd.concat([pd.read_csv(f) for f in files])
 ```
 
 ---
@@ -251,32 +263,20 @@ Expected event rates (highly workload-dependent):
 - **VFS:** 1-100K events/sec
 - **Block:** 100-10K events/sec
 - **Cache:** 10K-1M events/sec (before sampling)
-- **Network:** 100-100K events/sec
-
-### Sampling
-Cache events support sampling to reduce overhead:
-```bash
-python3 iotrc.py --cache-sample-rate 10
-```
 
 ### Lost Events
-If kernel buffers overflow, events may be lost. Monitor logs for:
-```
-[WARN] Lost N events in kernel buffer
-```
-
-Increase buffer size to reduce losses:
-```bash
-python3 iotrc.py --page-cnt 128  # Default: 64
-```
+If kernel buffers overflow, events may be lost. Monitor logs for warnings about lost
+events in the kernel buffer.
 
 ---
 
 ## Version Information
 
 This documentation applies to:
-- **io-tracer-linux** version 1.0+
+- **Trace schema:** version 2 (`SCHEMA_VERSION` in `src/tracer/schema.py`)
 - **Kernel:** Linux 5.4+
 - **BCC:** 0.18.0+
 
 Field availability may vary by kernel version. Check logs for warnings about unavailable probes.
+</content>
+</invoke>

--- a/docs/TRACE_FORMAT.md
+++ b/docs/TRACE_FORMAT.md
@@ -19,12 +19,13 @@ linux_trace_v4_test/{MACHINE_ID}/{YYYYMMDD_HHMMSS_mmm}/
 ├── pagefault/             # Memory-mapped page fault events
 ├── process/               # Process state snapshots
 ├── filesystem_snapshot/   # Filesystem metadata snapshots
-├── system_spec/           # System specification files
-└── manifest.json          # Self-describing schema for this session
+└── system_spec/           # System specification files
 ```
 
 - `{MACHINE_ID}`: Uppercase machine identifier
 - `{YYYYMMDD_HHMMSS_mmm}`: Timestamp with millisecond precision
+
+A self-describing `manifest.json` is also produced for each session (see below).
 
 Each subdirectory contains CSV files that are automatically compressed to `.csv.zst`
 (Zstandard) format. Every CSV begins with a header row, and every stream carries a
@@ -37,11 +38,13 @@ correlating records across streams.
 
 ### manifest.json
 
-A `manifest.json` is written once per session. It embeds `schema_version`, the full
-column list (name, type, unit, description) for every stream, and runtime diagnostics
-(per-stream row counts, the `CLOCK_MONOTONIC`→`CLOCK_REALTIME` offset used to derive
-wall-clock timestamps, etc.). Consumers should read the schema from `manifest.json`
-rather than hard-coding column positions.
+A `manifest.json` is written once per session at the session-directory root. It embeds
+`schema_version`, the full column list (name, type, unit, description) for every stream,
+and runtime diagnostics (per-stream row counts, the `CLOCK_MONOTONIC`→`CLOCK_REALTIME`
+offset used to derive wall-clock timestamps, etc.). It is delivered inside the session's
+compressed archive (a `.tar.zst` of the session directory) rather than as a standalone
+object under the prefix. Consumers should read the schema from `manifest.json` rather
+than hard-coding column positions.
 
 ---
 
@@ -278,5 +281,3 @@ This documentation applies to:
 - **BCC:** 0.18.0+
 
 Field availability may vary by kernel version. Check logs for warnings about unavailable probes.
-</content>
-</invoke>

--- a/docs/TRACE_TYPES.md
+++ b/docs/TRACE_TYPES.md
@@ -15,9 +15,9 @@ IO Tracer uses eBPF/BPF technology to intercept kernel functions and collect var
 
 | # | Snapshot Type | Description | Output |
 |---|--------------|-------------|--------|
-| 1 | [Filesystem Snapshot](traces/FILESYSTEM_SNAPSHOT.md) | Filesystem state (paths, sizes, timestamps) | `filesystem_snap.csv.gz` |
-| 2 | [Process Snapshot](traces/PROCESS_SNAPSHOT.md) | Running process information | `process_snap.csv` |
-| 3 | [System Snapshot](traces/SYSTEM_SNAPSHOT.md) | Hardware and software specifications | `device_spec.txt` |
+| 1 | [Filesystem Snapshot](traces/FILESYSTEM_SNAPSHOT.md) | Filesystem state (paths, sizes, timestamps) | `filesystem_snapshot/*.csv.zst` |
+| 2 | [Process Snapshot](traces/PROCESS_SNAPSHOT.md) | Running process information | `process/*.csv.zst` |
+| 3 | [System Snapshot](traces/SYSTEM_SNAPSHOT.md) | Hardware and software specifications | `system_spec/*.json` |
 
 ## Architecture Overview
 
@@ -52,13 +52,13 @@ IO Tracer uses eBPF/BPF technology to intercept kernel functions and collect var
 │           │                                                    │
 │  ┌────────▼────────┐                                           │
 │  │  WriterManager  │    Output:                               │
-│  │                  │    • fs/*.csv (VFS events)              │  │
-│  │                  │    • ds/*.csv (block events)            │  │
-│  │                  │    • cache/*.csv (cache events)         │  │
-│  │                  │    • pagefault/*.csv (page faults)      │  │
-│  │                  │    • filesystem_snapshot/*.csv.gz       │  │
-│  │                  │    • process/*.csv                      │  │
-│  │                  │    • system_spec/*                      │  │
+│  │                  │    • fs/*.csv.zst (VFS events)          │  │
+│  │                  │    • ds/*.csv.zst (block events)        │  │
+│  │                  │    • cache/*.csv.zst (cache events)     │  │
+│  │                  │    • pagefault/*.csv.zst (page faults)  │  │
+│  │                  │    • filesystem_snapshot/*.csv.zst      │  │
+│  │                  │    • process/*.csv.zst                  │  │
+│  │                  │    • system_spec/*.json                 │  │
 │  └──────────────────┘                                           │
 └─────────────────────────────────────────────────────────────────┘
 ```

--- a/docs/traces/BLOCK_IO_EVENTS.md
+++ b/docs/traces/BLOCK_IO_EVENTS.md
@@ -133,4 +133,4 @@ Character flags from the block layer tracepoint `rwbs` string. Each character in
 | `P` | PRIO | High priority |
 | `B` | BARRIER | Barrier (legacy) |
 
-**Output File:** `linux_trace_v3_test/{MACHINE_ID}/{TIMESTAMP}/ds/ds_*.csv`
+**Output File:** `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/ds/ds_*.csv.zst`

--- a/docs/traces/FILESYSTEM_SNAPSHOT.md
+++ b/docs/traces/FILESYSTEM_SNAPSHOT.md
@@ -38,26 +38,26 @@ Files on virtual/pseudo filesystems are automatically excluded by skipping diffe
 
 ## Anonymous Mode
 
-When `--anonymous` is enabled, file paths are hashed using a deterministic hash function (12-character hash). Directory structure is preserved but individual path components are replaced with hashes. File extensions are kept for analysis purposes.
+When anonymization is enabled (`-a`/`--anonimize`), file paths are hashed using a deterministic hash function (12-character hash). Directory structure is preserved but individual path components are replaced with hashes. File extensions are kept for analysis purposes.
 
-**Output File:** `linux_trace_v3_test/{MACHINE_ID}/{TIMESTAMP}/filesystem_snapshot/filesystem_snapshot_part####_TIMESTAMP_DEVICEID*.csv.gz`
+**Output File:** `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/filesystem_snapshot/filesystem_snapshot_part####_TIMESTAMP_DEVICEID*.csv.zst`
 
 ## Multi-Part Files
 
 To optimize memory usage during large filesystem scans, snapshots are automatically split into multiple compressed parts:
 
-**File Naming:** `filesystem_snapshot_part####_TIMESTAMP_DEVICEID.csv.gz`
+**File Naming:** `filesystem_snapshot_part####_TIMESTAMP_DEVICEID.csv.zst`
 
 - Part numbers are zero-padded (e.g., `part0001`, `part0002`, ...)
-- Each part is compressed with gzip immediately after writing
+- Each part is compressed with Zstandard immediately after writing
 - TIMESTAMP format: `YYYYMMDD_HHMMSS`
 - DEVICEID: Uppercase machine identifier
 
 **Completion Marker:** The final part is renamed to indicate completion:
 
-- Format: `filesystem_snapshot_part####_TIMESTAMP_DEVICEID_complete_partsN.csv.gz`
+- Format: `filesystem_snapshot_part####_TIMESTAMP_DEVICEID_complete_partsN.csv.zst`
 - The `_complete_partsN` suffix indicates this is the last part, where N is the total number of parts
-- Example: `filesystem_snapshot_part0003_20260214_120000_ABC123_complete_parts3.csv.gz` means 3 parts total and this is the final one
+- Example: `filesystem_snapshot_part0003_20260214_120000_ABC123_complete_parts3.csv.zst` means 3 parts total and this is the final one
 
 **Reading Multi-Part Snapshots:**
 1. Locate all parts with matching TIMESTAMP and DEVICEID

--- a/docs/traces/IO_URING_EVENTS.md
+++ b/docs/traces/IO_URING_EVENTS.md
@@ -2,6 +2,13 @@
 
 **Description:** Captures io_uring asynchronous I/O operations including syscall entry, SQE submissions, completions with latency, and async worker executions.
 
+> **No dedicated output stream.** The standalone `io_uring/` trace stream has been
+> removed. io_uring file READ/WRITE I/O is surfaced **only** by mirroring it into
+> the `fs/` (VFS) trace (see [Mirroring into the fs/VFS trace](#mirroring-into-the-fsvfs-trace)).
+> The probes and fields documented below are still attached/captured in the BPF
+> program, but the non-mirrored fields (ring pointers, worker info, queue depths,
+> etc.) are not currently written to any output file.
+
 **Kernel Probes Attached:**
 - `__io_uring_enter` / `__sys_io_uring_enter` — io_uring_enter syscall
 - `io_prep_rw` (or per-op `io_prep_read{,v,_fixed}` / `io_prep_write{,v,_fixed}`) — SQE field capture
@@ -24,6 +31,10 @@ If the prep symbol is unavailable on a given kernel, the SUBMIT probe falls back
 > **Note:** This captures SQE fields for the read/write opcode families (the bulk of filesystem I/O). Other opcodes (e.g. `OPENAT`, `STATX`) are not prepped through `io_prep_rw`, so their `opcode`/`fd`/`len`/`offset` columns may be empty.
 
 ## Data Captured
+
+The table below lists the fields the BPF program collects internally for each
+io_uring event. Only READ/WRITE events are emitted (mirrored into the `fs/` trace);
+the remaining fields are not written to a standalone CSV.
 
 | # | Field | Type | Description |
 |---|-------|------|-------------|
@@ -162,13 +173,13 @@ latency_ns = complete_ts_ns - submit_ts_ns
 
 ## Mirroring into the fs/VFS trace
 
-io_uring read/write operations call `->read_iter`/`->write_iter` directly and **never pass through `vfs_read`/`vfs_write`**, so they are invisible to the VFS probes. To make async I/O visible alongside syscall I/O, each completed io_uring read/write is also emitted into the main **fs/VFS trace** (`fs/fs_*.csv`) using the standard VFS 22-column schema:
+io_uring read/write operations call `->read_iter`/`->write_iter` directly and **never pass through `vfs_read`/`vfs_write`**, so they are invisible to the VFS probes. To make async I/O visible alongside syscall I/O, each completed io_uring read/write is also emitted into the main **fs/VFS trace** (`fs/fs_*.csv.zst`) using the standard VFS schema:
 
 - **Mirrored opcodes:** `READV`, `READ_FIXED`, `READ` → `READ`; `WRITEV`, `WRITE_FIXED`, `WRITE` → `WRITE`.
 - **Trigger:** COMPLETE events only (so `bytes_completed`/`duration_ns` are known), and only when a backing inode was resolved.
 - **Columns:** filename/inode/device/fs_type come from the prep-time file capture; `size` is the SQE length, `bytes_completed`/`errno` from the CQE result, `duration_ns` from the submit→complete latency. The generic `flags` column carries the decoded **SQE flags** (`FIXED_FILE|ASYNC|IO_LINK…`) in place of the open-file `O_*` flags, which are not available on the io_uring path.
 
-`fsync` is intentionally **not** mirrored: io_uring `FSYNC` calls `vfs_fsync` internally and is therefore already captured by the VFS fsync probe — mirroring it would double-count. The full async-specific detail (req_ptr, user_data, worker, queue depths) always remains in the dedicated io_uring CSV.
+`fsync` is intentionally **not** mirrored: io_uring `FSYNC` calls `vfs_fsync` internally and is therefore already captured by the VFS fsync probe — mirroring it would double-count. The full async-specific detail (req_ptr, user_data, worker, queue depths) is captured internally but, with the dedicated io_uring stream removed, is not currently written to any output file.
 
 ## Analysis Use Cases
 
@@ -204,4 +215,4 @@ The io_uring tracepoint probes (`io_uring:io_uring_submit_sqe`, `io_uring:io_uri
 
 2. If the format includes `req`, `opcode`, `user_data`, and `flags` fields, change `#if 0` to `#if 1` around line 4218 in `prober.c`.
 
-**Output File:** `linux_trace_v3_test/{MACHINE_ID}/{TIMESTAMP}/io_uring/io_uring_*.csv`
+**Output File:** none — io_uring READ/WRITE I/O is mirrored into the fs/VFS trace at `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/fs/fs_*.csv.zst`. There is no standalone `io_uring/` stream.

--- a/docs/traces/PAGE_CACHE_EVENTS.md
+++ b/docs/traces/PAGE_CACHE_EVENTS.md
@@ -44,9 +44,9 @@
 | 8 | `READAHEAD` | Pages prefetched into cache by readahead |
 | 9 | `RECLAIM` | Pages reclaimed under memory pressure (kswapd/direct reclaim) |
 
-**Output File:** `linux_trace_v3_test/{MACHINE_ID}/{TIMESTAMP}/cache/cache_*.csv`
+**Output File:** `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/cache/cache_*.csv.zst`
 
 **Important Limitation — Filename Resolution:**
 The filename is **not captured** for cache events due to eBPF constraints. Cache events provide only: folio/page → address_space → inode. Resolving inode → filename requires traversing `inode->i_dentry` (a linked list of hard links), which is impractical in eBPF. Use inode numbers to correlate with VFS events or filesystem snapshots.
 
-**Note:** Cache events can be sampled using `--cache-sample-rate N` to reduce overhead (captures 1 in N events).
+**Note:** Cache events support sampling to reduce overhead (captures 1 in N events) via `WriteManager.set_cache_sampling(N)`. Sampling is currently configured in code and not exposed as a CLI flag.

--- a/docs/traces/PAGE_FAULT_EVENTS.md
+++ b/docs/traces/PAGE_FAULT_EVENTS.md
@@ -35,4 +35,4 @@
 | `MAJOR` | Page not in memory — requires disk I/O to load the page |
 | `MINOR` | Page already in page cache — no disk I/O needed (soft fault) |
 
-**Output File:** `linux_trace_v3_test/{MACHINE_ID}/{TIMESTAMP}/pagefault/pagefault_*.csv`
+**Output File:** `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/pagefault/pagefault_*.csv.zst`

--- a/docs/traces/PROCESS_SNAPSHOT.md
+++ b/docs/traces/PROCESS_SNAPSHOT.md
@@ -38,7 +38,7 @@
 | `dead` | Process is dead (should not normally be seen) |
 | `idle` | Process is idle (kernel threads) |
 
-**Output File:** `linux_trace_v3_test/{MACHINE_ID}/{TIMESTAMP}/process/process_*.csv`
+**Output File:** `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/process/process_*.csv.zst`
 
 ## Incomplete Snapshot Handling
 

--- a/docs/traces/SYSTEM_SNAPSHOT.md
+++ b/docs/traces/SYSTEM_SNAPSHOT.md
@@ -2,7 +2,7 @@
 
 **Description:** Captures hardware and software specifications for trace context.
 
-**Location:** `linux_trace_v3_test/{MACHINE_ID}/{TIMESTAMP}/system_spec/`
+**Location:** `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/system_spec/`
 
 **Collection Method:**
 - Queries system information once at trace start

--- a/docs/traces/VFS_EVENTS.md
+++ b/docs/traces/VFS_EVENTS.md
@@ -22,7 +22,7 @@
 - `vfs_fallocate` — File space pre-allocation operations
 - `do_sendfile` / `__do_sendfile` — Efficient file-to-file transfer operations
 
-> **io_uring-origin rows:** `READ`/`WRITE` operations issued via io_uring bypass `vfs_read`/`vfs_write` (they call `->read_iter`/`->write_iter` directly), so they are mirrored into this trace from the io_uring instrumentation rather than captured by a VFS probe. They use the same schema; their `flags` column carries io_uring SQE flags (`FIXED_FILE|ASYNC|…`) instead of `O_*` flags, and `ppid`/`container_id` are empty. See [IO_URING_EVENTS.md](IO_URING_EVENTS.md#mirroring-into-the-fsvfs-trace). Each such row also has a full-detail counterpart in the io_uring CSV.
+> **io_uring-origin rows:** `READ`/`WRITE` operations issued via io_uring bypass `vfs_read`/`vfs_write` (they call `->read_iter`/`->write_iter` directly), so they are mirrored into this trace from the io_uring instrumentation rather than captured by a VFS probe. They use the same schema; their `flags` column carries io_uring SQE flags (`FIXED_FILE|ASYNC|…`) instead of `O_*` flags, and `ppid`/`container_id` are empty. See [IO_URING_EVENTS.md](IO_URING_EVENTS.md#mirroring-into-the-fsvfs-trace). There is no separate io_uring output stream; the fs mirror is the only place these rows appear.
 
 ## Filename Resolution
 
@@ -456,4 +456,4 @@ In some cases, the filename field may be empty. This occurs when the kernel data
 - Check the inode field — if it's non-zero, the file exists but the path couldn't be resolved
 - Correlate with the operation type and process command to determine if the empty filename is expected
 
-**Output File:** `linux_trace_v3_test/{MACHINE_ID}/{TIMESTAMP}/fs/fs_*.csv.gz`
+**Output File:** `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/fs/fs_*.csv.zst`

--- a/src/tracer/WriterManager.py
+++ b/src/tracer/WriterManager.py
@@ -139,7 +139,7 @@ class WriteManager:
         self.adaptive_thread = threading.Thread(target=self._adaptive_sizing, daemon=True)
         self.adaptive_thread.start()
         
-        # Start periodic flush thread (every 20 minutes)
+        # Start periodic flush thread (every 5 minutes)
         self._periodic_flush_active = True
         self._last_flush_time = time.time()
         self.periodic_flush_thread = threading.Thread(target=self._periodic_flush, daemon=True)
@@ -724,7 +724,7 @@ class WriteManager:
                 self.current_datetime = datetime.now()
                 self._write_buffer_to_file(buf, handle, s['log'])
 
-            # Close before compressing so we never gzip/delete an open file.
+            # Close before compressing so we never compress/delete an open file.
             if handle is not None:
                 handle.close()
                 setattr(self, s['handle'], None)
@@ -746,7 +746,7 @@ class WriteManager:
             setattr(self, s['handle'], self._open_log_file(new_file, key))
             self._stream_opened[key] = time.monotonic()
             self._reset_flush_timer()
-        # Compress outside the lock: gzip + disk I/O is slow and must not block
+        # Compress outside the lock: compression + disk I/O is slow and must not block
         # the perf-callback flush or the periodic writer for this stream.
         if rotated is not None:
             self.compress_log(rotated)


### PR DESCRIPTION
## Summary

A review of the repo for inconsistencies found that the `docs/` tree describes a trace format the code no longer produces. The code recently moved to **schema v2** (CSV headers + `manifest.json` + a common `mono_ns` column on every stream), switched compression from **gzip → Zstandard (`.csv.zst`)**, and **removed the standalone `io_uring` output stream** (io_uring READ/WRITE I/O is now mirrored into the `fs/` VFS trace). Most docs were never updated. This PR brings docs (and a few stale code comments) back in sync with `src/tracer/schema.py` and `WriterManager`.

The code itself was internally consistent — `schema.py` is correctly the single source of truth — so this is almost entirely a documentation fix.

## Changes

**`docs/TRACE_FORMAT.md`** (largest change)
- Regenerated every CSV header to match `src/tracer/schema.py` exactly (adds the trailing `mono_ns` column; fixes renamed columns such as `size`→`size_requested`, `queue_time_ms`→`queue_latency_ms`, `index`→`page_index`, `dev_id`→`device_id`, `create_time`→`creation_time`, `path`→`file_path`, etc.; adds `request_id`).
- Documented `manifest.json`.
- Switched all gzip/`zcat`/`gzip.open` reading examples to Zstandard (`zstd -dc`, `zstandard`, pandas `.zst`).
- Corrected file-rotation thresholds (~80k events / 20 min / 100 MB) and removed the non-existent "Network" stream.
- Removed the `io_uring/` section and the non-existent `--cache-sample-rate` / `--page-cnt` CLI flags.

**Bucket prefix:** `linux_trace_v3_test` → `linux_trace_v4_test` across all docs (matches `ObjectStorageManager`'s default).

**Compression strings:** `.csv.gz` / "gzip" → `.csv.zst` / "Zstandard" in `MULTIPART_FILESYSTEM_SNAPSHOT.md` and the per-trace docs.

**io_uring:** `IO_URING_EVENTS.md` and `VFS_EVENTS.md` now state plainly that there is no dedicated io_uring output stream — the fs mirror is the only place those rows appear. Added a banner and clarified the internally-captured-vs-emitted fields.

**`docs/TRACE_TYPES.md` / `docs/README.md`:** fixed snapshot output names (`filesystem_snap.csv.gz`→`filesystem_snapshot/*.csv.zst`, etc.), the directory listing (dropped `io_uring/`, added `manifest.json`), and compression extensions in the architecture diagram.

**`README.md`:** fixed the usage block — `dev` is a subcommand (not a `--dev` flag) and `--no-upload` was missing.

**`FILESYSTEM_SNAPSHOT.md`:** `--anonymous` → `-a`/`--anonimize` (actual flag name); buffer threshold `8000` → `80000`.

**`src/tracer/WriterManager.py`:** fixed two stale code comments ("every 20 minutes" → 5; "gzip" → "compress" on the now-zstd path). No behavior change.

## Verification
- `python -m pytest tests/` → **58 passed**.
- Confirmed the documented CSV headers match `schema.header_line(...)` output for all six streams and `SCHEMA_VERSION == 2`.

https://claude.ai/code/session_01Fog936GXjbxSVaHgq31jeG

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fog936GXjbxSVaHgq31jeG)_