### PR TITLE
Align fs/ds trace schema with the Windows tracer (schema v3)

### DIFF
--- a/docs/TRACE_FORMAT.md
+++ b/docs/TRACE_FORMAT.md
@@ -34,10 +34,17 @@ Each subdirectory contains CSV files that are automatically compressed to `.csv.
 ### CSV Header
 
 ```csv
-timestamp,operation,pid,command,filename,size,inode,flags,offset,tid,mmap_prot,mmap_flags,address,cmdline,return_value,errno,bytes_completed,duration_ns,device,ppid,container_id,fs_type
+timestamp,operation,pid,tid,command,filename,size,offset,bytes_completed,inode,device,flags,duration_ns,return_value,errno,mmap_prot,mmap_flags,address,cmdline,ppid,container_id,fs_type,mono_ns
 ```
 
-`return_value`, `errno`, `bytes_completed`, and `duration_ns` are populated for `READ`/`WRITE`; `device`, `ppid`, `container_id`, and `fs_type` are populated for `READ`/`WRITE`/`OPEN`. All are empty for operations that do not carry them.
+**Schema v3 — cross-OS aligned.** Columns 1–12 (`timestamp` … `flags`) are the
+**shared prefix** emitted identically by the Windows tracer's `filesystem/`
+stream, so a single parser reads the comparable fields from either OS. The
+remaining columns are Linux-only extras. `operation` is now a **lowercase**
+canonical name (`read`, `write`, `open`, `close`, `fsync`, …). `size_requested`
+was renamed to `size`.
+
+`return_value`, `errno`, `bytes_completed`, and `duration_ns` are populated for `read`/`write`; `device`, `ppid`, `container_id`, and `fs_type` are populated for `read`/`write`/`open`. All are empty for operations that do not carry them.
 
 For operations captured and examples, see [VFS_EVENTS.md](traces/VFS_EVENTS.md).
 
@@ -52,8 +59,14 @@ For operations captured and examples, see [VFS_EVENTS.md](traces/VFS_EVENTS.md).
 ### CSV Header
 
 ```csv
-timestamp,pid,command,sector,operation,size,latency_ms,tid,cpu_id,ppid,dev,queue_time_ms,cmd_flags,op_code
+timestamp,operation,pid,tid,command,sector,size,latency_ms,device,flags,cpu_id,ppid,queue_latency_ms,command_flags,operation_code,request_id,mono_ns
 ```
+
+**Schema v3 — cross-OS aligned.** Columns 1–10 (`timestamp` … `flags`) are the
+**shared prefix** emitted identically by the Windows tracer's `ds/` stream. The
+`operation` column now holds the **base op only** (`read`, `write`, `flush`,
+`discard`, …); the rwbs sub-flags (`sync`, `meta`, `ahead`, …) that used to be
+appended to it (e.g. `write|sync`) now live in the dedicated `flags` column.
 
 For operations captured and examples, see [BLOCK_IO_EVENTS.md](traces/BLOCK_IO_EVENTS.md).
 

--- a/docs/traces/BLOCK_IO_EVENTS.md
+++ b/docs/traces/BLOCK_IO_EVENTS.md
@@ -4,6 +4,14 @@
 
 **Kernel Probes:** Attached via block layer instrumentation in the eBPF program.
 
+> **Schema v3 (cross-OS aligned).** The on-disk column order is the aligned
+> layout in [TRACE_FORMAT.md](../TRACE_FORMAT.md#2-block-device-traces)
+> (shared prefix `timestamp,operation,pid,tid,command,sector,size,latency_ms,device,flags`
+> then Linux extras). The `operation` column now holds the **base op only**
+> (`read`, `write`, `flush`, `discard`, …); the rwbs sub-flags (`sync`, `meta`,
+> `ahead`, …) that used to be pipe-appended to it now live in the dedicated
+> `flags` column.
+
 ## Data Captured
 
 | # | Field | Type | Description |

--- a/docs/traces/MANIFEST.md
+++ b/docs/traces/MANIFEST.md
@@ -18,6 +18,7 @@ adapt rather than assume a fixed layout.
 |---------|--------|
 | 1 | Headerless CSVs, no manifest, per-stream clocks. |
 | 2 | **CSV header row** on every file + this manifest + a common `mono_ns` (CLOCK_MONOTONIC) column appended to every stream. |
+| 3 | **Cross-OS aligned** `fs`/`ds` layout: a fixed shared column prefix (identical names/order to the Windows tracer), **lowercase** canonical operation names, `size_requested` renamed to `size`, and a dedicated block `flags` column (rwbs sub-flags split out of `operation`). |
 
 As of **schema_version 2**:
 

--- a/docs/traces/VFS_EVENTS.md
+++ b/docs/traces/VFS_EVENTS.md
@@ -2,6 +2,12 @@
 
 **Description:** Captures file system operations at the VFS layer, intercepting all file access operations regardless of the underlying filesystem.
 
+> **Schema v3 (cross-OS aligned).** The on-disk column order is the aligned
+> layout in [TRACE_FORMAT.md](../TRACE_FORMAT.md#1-vfs-virtual-file-system-traces)
+> (shared prefix `timestamp,operation,pid,tid,command,filename,size,offset,bytes_completed,inode,device,flags`
+> then Linux extras). The `operation` value written to the CSV is the
+> **lowercase** form of the names in the table below (e.g. `READ` → `read`).
+
 **Kernel Probes Attached:**
 - `do_sys_openat2` (entry) — Captures the user-provided filename string before kernel resolution
 - `do_sys_openat2` (return) — Captures the allocated file descriptor after a successful open

--- a/src/tracer/IOTracer.py
+++ b/src/tracer/IOTracer.py
@@ -397,12 +397,14 @@ class IOTracer:
             if getattr(event, "fs_magic", 0) else ""
         )
 
+        # Aligned schema (v3): shared cross-OS prefix first, Linux-only extras
+        # after, lowercase canonical operation name.
         output = format_csv_row(
-            timestamp, op_name, event.pid, comm, filename, size_val, inode_val,
-            flags_val, offset_val, tid_val, mmap_prot_val, mmap_flags_val,
-            address_val, cmdline,
-            return_value, errno_val, bytes_completed, duration_ns,
-            dev_val, ppid_val, container_id, fs_type_val,
+            timestamp, op_name.lower(), event.pid, tid_val, comm, filename,
+            size_val, offset_val, bytes_completed, inode_val, dev_val, flags_val,
+            duration_ns, return_value, errno_val,
+            mmap_prot_val, mmap_flags_val, address_val, cmdline,
+            ppid_val, container_id, fs_type_val,
             getattr(event, "ts", 0)
         )
         self.writer.append_fs_log(output)
@@ -706,17 +708,17 @@ class IOTracer:
         flags_val = self.flag_mapper.format_vfs_flags(op_name, event.flags)
         cmdline = self._read_cmdline_cached(event.pid)
 
-        # Emit the same 22-column schema as _print_event so the shared fs log
+        # Emit the same aligned fs schema as _print_event so the shared fs log
         # stays a well-formed CSV. Dual-path ops (RENAME/LINK/SYMLINK) do not
-        # carry offset/tid/mmap/address or the READ/WRITE/OPEN completion and
-        # provenance fields, so those columns are empty.
+        # carry size/offset/tid/mmap/address or the READ/WRITE/OPEN completion
+        # and provenance fields, so those columns are empty.
         output = format_csv_row(
-            timestamp, op_name, event.pid, comm, dual_filename, 0, inode_val,
-            flags_val, "", "", "", "",   # offset, tid, mmap_prot, mmap_flags
-            "", cmdline,                 # address, cmdline
-            "", "", "", "",              # return_value, errno, bytes_completed, duration_ns
-            "", "", "", "",              # device, ppid, container_id, fs_type
-            getattr(event, "ts", 0)      # mono_ns
+            timestamp, op_name.lower(), event.pid, "", comm, dual_filename,
+            "", "", "", inode_val, "", flags_val,   # size,offset,bytes_completed,inode,device,flags
+            "", "", "",                              # duration_ns, return_value, errno
+            "", "", "", cmdline,                     # mmap_prot, mmap_flags, address, cmdline
+            "", "", "",                              # ppid, container_id, fs_type
+            getattr(event, "ts", 0)                  # mono_ns
         )
         self.writer.append_fs_log(output)
 
@@ -794,6 +796,11 @@ class IOTracer:
         sector = event.sector
         ops_str = event.op.decode('utf-8', errors='replace')
         ops_str = self.flag_mapper.format_block_ops(ops_str)
+        # Aligned schema (v3): the base op goes in ``operation`` and the rwbs
+        # sub-flags (sync|meta|ahead|...) move to the dedicated ``flags`` column.
+        _op_parts = ops_str.split("|")
+        op_base = _op_parts[0]
+        op_flags = "|".join(_op_parts[1:])
         latency_ns = event.latency_ns
         latency_ms = latency_ns / 1_000_000.0
         cpu_id = event.cpu_id
@@ -823,7 +830,7 @@ class IOTracer:
         # Monotonic per-request id (disambiguates repeated I/O to the same sector)
         req_id = event.req_id if hasattr(event, 'req_id') else ""
 
-        output = format_csv_row(timestamp, pid, comm, sector, ops_str, bio_size, latency_ms, tid, cpu_id, ppid, dev_str, queue_time_ms, cmd_flags_str, op_code_str, req_id, getattr(event, "ts", 0))
+        output = format_csv_row(timestamp, op_base, pid, tid, comm, sector, bio_size, latency_ms, dev_str, op_flags, cpu_id, ppid, queue_time_ms, cmd_flags_str, op_code_str, req_id, getattr(event, "ts", 0))
 
 
         if sector == 0 and bio_size == 0:
@@ -977,10 +984,11 @@ class IOTracer:
         cmdline = self._read_cmdline_cached(e.pid)
 
         output = format_csv_row(
-            ts, op_name, e.pid, comm, filename, size_val, e.inode,
-            flags_val, offset_val, tid_val, "", "", "", cmdline,
-            return_value, errno_val, bytes_completed, duration_ns,
-            dev_val, "", "", fs_type_val,
+            ts, op_name.lower(), e.pid, tid_val, comm, filename,
+            size_val, offset_val, bytes_completed, e.inode, dev_val, flags_val,
+            duration_ns, return_value, errno_val,
+            "", "", "", cmdline,            # mmap_prot, mmap_flags, address, cmdline
+            "", "", fs_type_val,            # ppid, container_id, fs_type
             getattr(e, "timestamp_ns", 0)   # mono_ns
         )
         self.writer.append_fs_log(output)

--- a/src/tracer/schema.py
+++ b/src/tracer/schema.py
@@ -17,7 +17,12 @@ it from ``manifest.json`` and adapt.
 
 # v1: original headerless CSVs, no manifest, per-stream clocks.
 # v2: CSV headers + manifest.json + a common ``mono_ns`` column on every stream.
-SCHEMA_VERSION = 2
+# v3: cross-OS aligned layout for ``fs`` and ``ds`` — a fixed shared column
+#     prefix (identical names/order to the Windows tracer) followed by the
+#     Linux-only extras, lowercase canonical operation names, ``size_requested``
+#     renamed to ``size``, and a dedicated block ``flags`` column (rwbs sub-flags
+#     split out of ``operation``).
+SCHEMA_VERSION = 3
 
 
 def _col(name, ctype, unit="", desc=""):
@@ -52,25 +57,27 @@ STREAMS = {
         "mirrored rows).",
         "CLOCK_REALTIME (derived from kernel CLOCK_MONOTONIC)",
         [
+            # --- shared cross-OS prefix (columns 1-12; identical on Windows) --- #
             _col("timestamp", "datetime", "", "Event wall-clock time (YYYY-MM-DD HH:MM:SS.ffffff)."),
-            _col("operation", "string", "", "VFS operation type (READ, WRITE, OPEN, ...)."),
+            _col("operation", "string", "", "Lowercase canonical op (read, write, open, close, fsync, ...)."),
             _col("pid", "u32"),
+            _col("tid", "u32"),
             _col("command", "string", "", "Process name (<=16 chars)."),
             _col("filename", "string", "", "File path; 'old -> new' for dual-path ops."),
-            _col("size_requested", "u64", "bytes", "Requested I/O size (count arg); 0 for non-I/O ops."),
-            _col("inode", "u64"),
-            _col("flags", "string", "", "Operation-specific flags; empty when none."),
+            _col("size", "u64", "bytes", "Requested I/O size (count arg); empty for non-I/O ops."),
             _col("offset", "u64", "bytes", "File offset for positioned I/O; empty if 0."),
-            _col("tid", "u32"),
+            _col("bytes_completed", "u64", "bytes", "Actual bytes moved by READ/WRITE; empty otherwise."),
+            _col("inode", "u64", "", "File inode; empty if 0 (Windows: always empty)."),
+            _col("device", "string", "", "Backing device major:minor for READ/WRITE/OPEN (Windows: empty)."),
+            _col("flags", "string", "", "Operation-specific flags; empty when none."),
+            # --- Linux-only extras (columns 13+) --- #
+            _col("duration_ns", "u64", "nanoseconds", "READ/WRITE entry->return duration; empty otherwise."),
+            _col("return_value", "s64", "", "Raw READ/WRITE return (bytes or -errno); empty otherwise."),
+            _col("errno", "string", "", "Error name when READ/WRITE failed; empty otherwise."),
             _col("mmap_prot", "string", "", "MMAP PROT_* flags; empty for non-MMAP."),
             _col("mmap_flags", "string", "", "MMAP MAP_* flags; empty for non-MMAP."),
             _col("address", "string", "", "Mapping address (hex) for MMAP/MUNMAP/MREMAP."),
             _col("cmdline", "string", "", "Full argv of the triggering process."),
-            _col("return_value", "s64", "", "Raw READ/WRITE return (bytes or -errno); empty otherwise."),
-            _col("errno", "string", "", "Error name when READ/WRITE failed; empty otherwise."),
-            _col("bytes_completed", "u64", "bytes", "Actual bytes moved by READ/WRITE; empty otherwise."),
-            _col("duration_ns", "u64", "nanoseconds", "READ/WRITE entry->return duration; empty otherwise."),
-            _col("device", "string", "", "Backing device major:minor for READ/WRITE/OPEN."),
             _col("ppid", "u32"),
             _col("container_id", "u64", "", "cgroup v2 id (container identifier)."),
             _col("fs_type", "string", "", "Source filesystem name from superblock magic."),
@@ -81,17 +88,20 @@ STREAMS = {
         "Block-device (disk) I/O completion events.",
         "CLOCK_REALTIME (derived from kernel CLOCK_MONOTONIC)",
         [
+            # --- shared cross-OS prefix (columns 1-10; identical on Windows) --- #
             _col("timestamp", "datetime", "", "Completion wall-clock time."),
+            _col("operation", "string", "", "Base block op (read, write, flush, discard, ...)."),
             _col("pid", "u32", "", "Submitting process ID."),
+            _col("tid", "u32"),
             _col("command", "string"),
-            _col("sector", "u64", "", "Starting sector (LBA)."),
-            _col("operation", "string", "", "Block op type (read, write, discard, ...)."),
+            _col("sector", "u64", "", "Starting sector (LBA, 512-byte units)."),
             _col("size", "u64", "bytes", "I/O size."),
             _col("latency_ms", "float", "milliseconds", "Device latency (issue->completion)."),
-            _col("tid", "u32"),
+            _col("device", "string", "", "Device major:minor (Windows: disk index)."),
+            _col("flags", "string", "", "rwbs sub-flags (sync|meta|ahead|...); empty when none."),
+            # --- Linux-only extras (columns 11+) --- #
             _col("cpu_id", "u32", "", "CPU that processed completion."),
             _col("ppid", "u32"),
-            _col("device", "string", "", "Device major:minor."),
             _col("queue_latency_ms", "float", "milliseconds", "Scheduler latency (insert->issue)."),
             _col("command_flags", "string", "", "REQ_* flags; empty on kernel >=5.17."),
             _col("operation_code", "string", "", "Raw REQ_OP_* name; empty on kernel >=5.17."),

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -17,17 +17,34 @@ from src.tracer import schema
 # the number of fields each callback passes to format_csv_row.
 EXPECTED_COLUMN_COUNTS = {
     "fs": 23,                  # 22 documented + mono_ns
-    "ds": 16,                  # 15 documented + mono_ns
+    "ds": 17,                  # 16 documented (incl. aligned flags col) + mono_ns
     "cache": 11,               # 10 + mono_ns
     "pagefault": 11,           # 10 + mono_ns
     "process": 12,             # 11 + mono_ns
     "filesystem_snapshot": 7,  # 6 + mono_ns
 }
 
+# Cross-OS aligned shared column prefix (schema v3). These leading columns must
+# match the Windows tracer's fs/ds streams exactly and in the same order.
+ALIGNED_FS_PREFIX = [
+    "timestamp", "operation", "pid", "tid", "command", "filename",
+    "size", "offset", "bytes_completed", "inode", "device", "flags",
+]
+ALIGNED_DS_PREFIX = [
+    "timestamp", "operation", "pid", "tid", "command", "sector",
+    "size", "latency_ms", "device", "flags",
+]
+
 
 class SchemaShapeTests(unittest.TestCase):
-    def test_schema_version_is_2(self):
-        self.assertEqual(schema.SCHEMA_VERSION, 2)
+    def test_schema_version_is_3(self):
+        self.assertEqual(schema.SCHEMA_VERSION, 3)
+
+    def test_fs_ds_aligned_prefix(self):
+        self.assertEqual(schema.column_names("fs")[:len(ALIGNED_FS_PREFIX)],
+                         ALIGNED_FS_PREFIX)
+        self.assertEqual(schema.column_names("ds")[:len(ALIGNED_DS_PREFIX)],
+                         ALIGNED_DS_PREFIX)
 
     def test_all_streams_present(self):
         self.assertEqual(set(schema.STREAMS), set(EXPECTED_COLUMN_COUNTS))
@@ -69,7 +86,7 @@ class ManifestTests(unittest.TestCase):
         block = schema.schema_for_manifest()
         # Round-trips through JSON without error.
         restored = json.loads(json.dumps(block))
-        self.assertEqual(restored["schema_version"], 2)
+        self.assertEqual(restored["schema_version"], 3)
         self.assertEqual(set(restored["streams"]), set(EXPECTED_COLUMN_COUNTS))
 
     def test_manifest_columns_carry_type_and_unit(self):


### PR DESCRIPTION
## What

Aligns the Linux tracer's two cross-OS-comparable streams (`fs`, `ds`) with the Windows tracer so both emit a **fixed shared column prefix with identical names and order**. A single parser can now read the comparable fields from either OS. This is the Linux half of a coordinated change (see io-tracer-win#<win-pr>).

**Breaking on-disk format change — bumps `SCHEMA_VERSION` 2 → 3.**

## Shared prefix (identical on both OSes)

- **fs** (cols 1–12): `timestamp, operation, pid, tid, command, filename, size, offset, bytes_completed, inode, device, flags`
- **ds** (cols 1–10): `timestamp, operation, pid, tid, command, sector, size, latency_ms, device, flags`

Linux-only columns follow the shared prefix (unchanged set, reordered): fs → `duration_ns, return_value, errno, mmap_prot, mmap_flags, address, cmdline, ppid, container_id, fs_type, mono_ns`; ds → `cpu_id, ppid, queue_latency_ms, command_flags, operation_code, request_id, mono_ns`.

## Normalizations

- **Operation names are now lowercase canonical** (`READ` → `read`, `OPEN` → `open`, …). Internal op logic is unchanged; only the emitted value is lowercased.
- **Block `operation` holds the base op only**; the rwbs sub-flags that used to be pipe-appended (e.g. `write|sync`) now live in the new dedicated **`flags`** column.
- `size_requested` renamed to **`size`**.

## Changes

- `src/tracer/schema.py` — reordered/renamed fs & ds columns, version → 3.
- `src/tracer/IOTracer.py` — all three fs emission sites (incl. the io_uring→fs mirror) and the block emission reordered to match; op lowercasing; base-op/flags split.
- `tests/test_schema.py` — updated counts/version, added a test asserting the fs/ds aligned prefixes.
- Docs: `TRACE_FORMAT.md`, `traces/VFS_EVENTS.md`, `traces/BLOCK_IO_EVENTS.md`, `traces/MANIFEST.md`.

## Testing

`python3 -m unittest discover -s tests` → **59 passed, 6 skipped** (skips are `zstandard`-not-installed, unrelated). Field counts emitted by every callback were verified against the schema column counts (fs 23, ds 17 incl. `mono_ns`).

## Note for downstream

Consumers that parsed the old positional layout (e.g. `io-trace-analysis`) need updating for v3 — the post-processor's job now shrinks to the non-shared streams since the shared columns are aligned and self-describing.

https://claude.ai/code/session_01PZ8xwUL42pnvtXyvfFQVAi

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZ8xwUL42pnvtXyvfFQVAi)_