### PR TITLE
Fix trace-data correctness bugs (io_uring result, snapshot headers, double-upload, block queue latency)

### DIFF
--- a/src/tracer/IOTracer.py
+++ b/src/tracer/IOTracer.py
@@ -957,14 +957,20 @@ class IOTracer:
         if not op_name or not getattr(e, "inode", 0):
             return
 
-        ret = e.result
-        return_value = str(ret)
+        # On kernel >= 6.0 the completion result is not available to the kprobe
+        # (io_req_complete_post no longer passes it as an argument), so the C
+        # side leaves result unset and flags it via result_valid. Emit empty
+        # return_value/bytes_completed in that case rather than a misleading 0.
+        return_value = ""
         errno_val = ""
         bytes_completed = ""
-        if ret < 0:
-            errno_val = self.flag_mapper.format_errno(-ret)
-        else:
-            bytes_completed = str(ret)
+        if getattr(e, "result_valid", 0):
+            ret = e.result
+            return_value = str(ret)
+            if ret < 0:
+                errno_val = self.flag_mapper.format_errno(-ret)
+            else:
+                bytes_completed = str(ret)
         duration_ns = str(e.latency_ns) if e.latency_ns else ""
 
         offset_val = e.offset if e.offset else ""

--- a/src/tracer/WriterManager.py
+++ b/src/tracer/WriterManager.py
@@ -221,12 +221,17 @@ class WriteManager:
         'process': 'process', 'fs_snap': 'filesystem_snapshot',
     }
 
-    def _open_log_file(self, path: str, wm_key: str):
+    def _open_log_file(self, path: str, wm_key: str, write_header: bool = True):
         """Open a stream's CSV for appending, writing the schema header row first
-        when the file is new/empty so every (rotated) file is self-describing."""
+        when the file is new/empty so every (rotated) file is self-describing.
+
+        ``write_header`` may be set False for the 2nd+ parts of a multi-part
+        stream whose parts are meant to be concatenated back into one CSV: a
+        header in every part would otherwise land as a bogus data row mid-table.
+        """
         is_new = (not os.path.exists(path)) or os.path.getsize(path) == 0
         handle = open(path, 'a', buffering=8192)
-        if is_new:
+        if is_new and write_header:
             handle.write(schema.header_line(self._SCHEMA_KEY[wm_key]) + "\n")
         return handle
 
@@ -541,11 +546,16 @@ class WriteManager:
             )
             part_filepath = f"{self.output_dir}/filesystem_snapshot/{part_filename}"
 
-            # Open file handle for this part if needed
+            # Open file handle for this part if needed. Only the first part
+            # carries the schema header; the documented reader concatenates all
+            # parts in order, so headers on parts 2+ would corrupt the table.
             if self._fs_snap_handle is None or self.output_fs_snapshot_file != part_filepath:
                 if self._fs_snap_handle is not None:
                     self._fs_snap_handle.close()
-                self._fs_snap_handle = self._open_log_file(part_filepath, 'fs_snap')
+                self._fs_snap_handle = self._open_log_file(
+                    part_filepath, 'fs_snap',
+                    write_header=(self.fs_snapshot_part_number == 1),
+                )
                 self.output_fs_snapshot_file = part_filepath
 
             # Write buffer to file
@@ -815,7 +825,16 @@ class WriteManager:
             self.fs_snap_buffer.clear()
         
         self.compress_log(self.output_pagefault_file)
-        self.compress_dir(self.output_dir)
+
+        # In automatic_upload mode every compressed log has already been queued
+        # for individual upload (preserving its subdirectory) and the background
+        # worker is concurrently deleting those .zst files as it uploads them.
+        # Tarring the whole directory here would (a) upload every file a second
+        # time inside the bundle and (b) race the worker's deletions while
+        # tarfile walks the tree. Only bundle into a single tar.zst for the
+        # local (non-upload) case.
+        if not self.automatic_upload:
+            self.compress_dir(self.output_dir)
 
 
     def clear_events(self):

--- a/src/tracer/prober/prober.c
+++ b/src/tracer/prober/prober.c
@@ -501,6 +501,7 @@ struct io_uring_event_data {
   /* Completion fields (COMPLETE event) */
   s32 result;                   /**< Operation result (bytes or -errno) */
   u8 is_error;                  /**< 1 if result < 0 */
+  u8 result_valid;              /**< 1 if result was captured (unset on 6.0+ kprobe) */
   s32 cqe_errno;                /**< Errno if error (positive value) */
   
   /* Latency tracking */
@@ -2610,6 +2611,11 @@ TRACEPOINT_PROBE(block, block_rq_complete) {
     u64 *miss = block_stats.lookup(&stat_miss);
     if (miss)
       *miss += 1;
+    // Drop any insert timestamp for this key too — without the issue ctx we
+    // can't emit an event, and leaving it behind lets a later request that
+    // reuses the same (dev,sector) key read a stale insert_ts and report a
+    // wildly inflated queue latency.
+    block_insert_times.delete(&key);
     return 0;
   }
 
@@ -4079,6 +4085,7 @@ int trace_io_uring_complete(struct pt_regs *ctx, void *req, s32 result) {
 
 #if LINUX_VERSION_CODE < KERNEL_VERSION(6, 0, 0)
   e.result = result;
+  e.result_valid = 1;
 
   /* Check if result indicates error */
   if (result < 0) {
@@ -4259,8 +4266,9 @@ TRACEPOINT_PROBE(io_uring, io_uring_complete) {
   e.req_ptr = (u64)args->req;
   e.user_data = args->user_data;
   e.result = args->res;
+  e.result_valid = 1;
   e.complete_ts_ns = ts;
-  
+
   if (e.result < 0) {
     e.is_error = 1;
     e.cqe_errno = -e.result;

--- a/tests/test_writer_upload.py
+++ b/tests/test_writer_upload.py
@@ -229,5 +229,57 @@ class StaleLogRotationTests(unittest.TestCase):
         self.assertNotIn("fs_snap", self.wm._streams)
 
 
+class MultiPartSnapshotHeaderTests(unittest.TestCase):
+    """Multi-part filesystem snapshots are concatenated back into one CSV, so
+    only the first part may carry the schema header — a header on parts 2+ would
+    land mid-table as a bogus data row."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.output_dir = os.path.join(self.tmp, "trace")
+        self.upload = FakeUploadManager()
+        self.wm = SilentWriteManager(
+            output_dir=self.output_dir,
+            upload_manager=self.upload,
+            automatic_upload=False,
+        )
+
+    def tearDown(self):
+        import shutil
+        try:
+            self.wm.close_handles()
+        except Exception:
+            pass
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    @unittest.skipUnless(HAS_ZSTD, "zstandard not installed")
+    def test_only_first_part_has_header(self):
+        import glob
+        from src.tracer import schema
+
+        header = schema.header_line("filesystem_snapshot")
+
+        # Part 1
+        self.wm.fs_snap_buffer.append("rowA,1")
+        self.wm.flush_fssnap_only()
+        # Part 2
+        self.wm.fs_snap_buffer.append("rowB,2")
+        self.wm.flush_fssnap_only()
+
+        parts = sorted(
+            glob.glob(os.path.join(self.output_dir, "filesystem_snapshot", "*.zst"))
+        )
+        self.assertEqual(len(parts), 2)
+
+        first = _zstd_read_text(parts[0]).splitlines()
+        second = _zstd_read_text(parts[1]).splitlines()
+
+        self.assertEqual(first[0], header)
+        self.assertIn("rowA,1", first)
+        # Part 2 must NOT repeat the header; concatenation would corrupt the CSV.
+        self.assertNotIn(header, second)
+        self.assertEqual(second[0], "rowB,2")
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

A correctness review of this branch surfaced four data-integrity bugs in the retained trace paths. This commit fixes them and adds a regression test. All 59 unit tests pass.

## Fixes

**1. io_uring mirror logs every async read/write as 0 bytes on kernel ≥ 6.0 (high)**
On 6.0+, `io_req_complete_post` no longer passes the result to the kprobe, so `trace_io_uring_complete` deliberately leaves `result` unset — but the Python mirror still read `e.result` and emitted `bytes_completed=0`/`return_value=0`, silently zeroing all async-I/O byte accounting on modern kernels. Added a `result_valid` flag to the C struct (set only where the result is actually captured) and made the mirror emit empty `return_value`/`bytes_completed` when it's unavailable instead of a misleading `0`.

**2. Multi-part filesystem snapshot writes a header into every part (high)**
`_open_log_file` writes the schema header on each new file, so every snapshot part got one. But the documented reader (`MULTIPART_FILESYSTEM_SNAPSHOT.md`) concatenates parts in order, turning headers on parts 2+ into bogus data rows mid-table. Now only part 1 carries the header.

**3. `force_flush` double-uploads all trace data and races the upload worker (medium)**
Under `automatic_upload`, every compressed log was queued for individual upload *and* re-tarred into a whole-directory bundle that was also uploaded — uploading all data twice and letting `tarfile` walk the directory while the background worker concurrently deleted `.zst` files from it (FileNotFoundError → aborted bundle). The directory tarball is now only built in the local (non-upload) path.

**4. `block_rq_complete` leaks a stale insert timestamp on the miss path (medium)**
When the issue context is missing/evicted, the probe returned without deleting the `block_insert_times` entry. A later request reusing the same `(dev,sector)` key could then read that stale insert timestamp and report a wildly inflated queue latency. The entry is now deleted on the miss path.

## Tests
- Added `MultiPartSnapshotHeaderTests.test_only_first_part_has_header`.
- Existing suite: 59 tests pass.

https://claude.ai/code/session_01C8oethZL4NNrUx95G5hFyj

---
_Generated by [Claude Code](https://claude.ai/code/session_01C8oethZL4NNrUx95G5hFyj)_