### PR TITLE
Gracefully degrade when zstandard is missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,16 +39,25 @@ pacman -S bcc bcc-tools python-bcc
 
 For more distros, visit the official [BCC's installation guide](https://github.com/iovisor/bcc/blob/master/INSTALL.md)
 
-3. Finally, install these last two libraries!
+3. Finally, install the remaining Python libraries!
 
 ```bash
 # Ubuntu 
 sudo apt install python3-psutil
 sudo apt install python3-requests
 sudo apt install python3-pytest
+sudo apt install python3-zstandard
 
 
 # ... (adjust the package manager for other distros)
+```
+
+`zstandard` is used to compress trace logs (`.zst`). If it is missing the
+tracer still runs and keeps traces uncompressed, but installing it is
+recommended. You can also install all Python dependencies at once with:
+
+```bash
+pip install -r requirements.txt
 ```
 
 ## Usage

--- a/src/tracer/WriterManager.py
+++ b/src/tracer/WriterManager.py
@@ -610,68 +610,73 @@ class WriteManager:
         Renames the last part file to include '_complete_partsN' suffix
         indicating this is the final part and the total number of parts.
         """
-        if not self.fs_snapshot_session_active:
-            return
-        
-        total_parts = self.fs_snapshot_part_number - 1  # -1 because we increment after each flush
-        
-        if total_parts < 1:
-            # No parts were written
-            self.fs_snapshot_session_active = False
-            return
-        
-        # Find the last part file. It is normally compressed (.csv.zst), but
-        # when zstandard is unavailable it is left uncompressed (.csv); detect
-        # whichever actually exists so the completion rename stays correct.
-        last_part_str = f"{total_parts:04d}"
-        snapshot_dir = f"{self.output_dir}/filesystem_snapshot"
-        base_name = (
-            f"filesystem_snapshot_part{last_part_str}_"
-            f"{self.fs_snapshot_timestamp}_"
-            f"{self.fs_snapshot_device_id}"
-        )
-        suffix = ".csv.zst"
-        if (not os.path.exists(f"{snapshot_dir}/{base_name}{suffix}")
-                and os.path.exists(f"{snapshot_dir}/{base_name}.csv")):
-            suffix = ".csv"
-        old_filepath = f"{snapshot_dir}/{base_name}{suffix}"
+        # Hold the fs_snap stream lock for the whole operation: the parallel
+        # writer/flush threads compress and write parts under the same lock, so
+        # renaming the last part here without it could race with an in-flight
+        # write or compression.
+        with self._stream_locks['fs_snap']:
+            if not self.fs_snapshot_session_active:
+                return
 
-        # Construct new filename with completion marker
-        new_filepath = (
-            f"{snapshot_dir}/{base_name}_complete_parts{total_parts}{suffix}"
-        )
-        
-        # Rename the file (only if it still exists locally)
-        try:
-            if os.path.exists(old_filepath):
-                os.rename(old_filepath, new_filepath)
-                logger("info", f"Filesystem snapshot complete: {total_parts} parts written")
-                
-                # Update the pending upload list with the new filename
-                if self.automatic_upload and old_filepath in self.fs_snapshot_parts_pending_upload:
-                    self.fs_snapshot_parts_pending_upload.remove(old_filepath)
-                    self.fs_snapshot_parts_pending_upload.append(new_filepath)
-            else:
-                # File doesn't exist (may have been already processed)
-                logger("info", f"Filesystem snapshot complete: {total_parts} parts written")
-                
-            # Upload all parts now that snapshot is complete
-            if self.automatic_upload:
-                num_parts = len(self.fs_snapshot_parts_pending_upload)
-                if num_parts > 0:
-                    # Count each part individually to match upload counter
-                    self.created_files += num_parts
-                    logger('info', f"Files Created: {str(self.created_files)} (filesystem snapshot with {num_parts} parts)", True)
-                for part_file in self.fs_snapshot_parts_pending_upload:
-                    if os.path.exists(part_file):
-                        self.upload_manager.append_object(part_file)
-                self.fs_snapshot_parts_pending_upload.clear()
-                
-        except Exception as e:
-            logger("error", f"Failed to process final snapshot part: {e}")
-        
-        # Reset session
-        self.fs_snapshot_session_active = False
+            total_parts = self.fs_snapshot_part_number - 1  # -1 because we increment after each flush
+
+            if total_parts < 1:
+                # No parts were written
+                self.fs_snapshot_session_active = False
+                return
+
+            # Find the last part file. It is normally compressed (.csv.zst), but
+            # when zstandard is unavailable it is left uncompressed (.csv); detect
+            # whichever actually exists so the completion rename stays correct.
+            last_part_str = f"{total_parts:04d}"
+            snapshot_dir = f"{self.output_dir}/filesystem_snapshot"
+            base_name = (
+                f"filesystem_snapshot_part{last_part_str}_"
+                f"{self.fs_snapshot_timestamp}_"
+                f"{self.fs_snapshot_device_id}"
+            )
+            suffix = ".csv.zst"
+            if (not os.path.exists(f"{snapshot_dir}/{base_name}{suffix}")
+                    and os.path.exists(f"{snapshot_dir}/{base_name}.csv")):
+                suffix = ".csv"
+            old_filepath = f"{snapshot_dir}/{base_name}{suffix}"
+
+            # Construct new filename with completion marker
+            new_filepath = (
+                f"{snapshot_dir}/{base_name}_complete_parts{total_parts}{suffix}"
+            )
+
+            # Rename the file (only if it still exists locally)
+            try:
+                if os.path.exists(old_filepath):
+                    os.rename(old_filepath, new_filepath)
+                    logger("info", f"Filesystem snapshot complete: {total_parts} parts written")
+
+                    # Update the pending upload list with the new filename
+                    if self.automatic_upload and old_filepath in self.fs_snapshot_parts_pending_upload:
+                        self.fs_snapshot_parts_pending_upload.remove(old_filepath)
+                        self.fs_snapshot_parts_pending_upload.append(new_filepath)
+                else:
+                    # File doesn't exist (may have been already processed)
+                    logger("info", f"Filesystem snapshot complete: {total_parts} parts written")
+
+                # Upload all parts now that snapshot is complete
+                if self.automatic_upload:
+                    num_parts = len(self.fs_snapshot_parts_pending_upload)
+                    if num_parts > 0:
+                        # Count each part individually to match upload counter
+                        self.created_files += num_parts
+                        logger('info', f"Files Created: {str(self.created_files)} (filesystem snapshot with {num_parts} parts)", True)
+                    for part_file in self.fs_snapshot_parts_pending_upload:
+                        if os.path.exists(part_file):
+                            self.upload_manager.append_object(part_file)
+                    self.fs_snapshot_parts_pending_upload.clear()
+
+            except Exception as e:
+                logger("error", f"Failed to process final snapshot part: {e}")
+
+            # Reset session
+            self.fs_snapshot_session_active = False
 
     def start_process_snapshot_session(self):
         """Mark the beginning of a process snapshot session."""

--- a/src/tracer/WriterManager.py
+++ b/src/tracer/WriterManager.py
@@ -32,7 +32,7 @@ from .ObjectStorageManager import ObjectStorageManager
 from . import schema
 from ..utility.utils import (
     logger, capture_machine_id,
-    compress_file_zstd, require_zstandard, ZSTD_LEVEL,
+    compress_file_zstd, zstandard_available, ZSTD_LEVEL,
 )
 import threading
 from collections import deque
@@ -565,17 +565,19 @@ class WriteManager:
             self._fs_snap_handle.close()
             self._fs_snap_handle = None
 
-            # Compress with Zstandard
+            # Compress with Zstandard. If zstandard is unavailable, keep the
+            # uncompressed part rather than losing it.
             if os.path.exists(part_filepath):
                 # Don't log or count each part - we'll log when snapshot is complete
-                compress_file_zstd(part_filepath, part_filepath + ".zst")
-
-                os.remove(part_filepath)
-                compressed_file = part_filepath + ".zst"
+                if compress_file_zstd(part_filepath, part_filepath + ".zst"):
+                    os.remove(part_filepath)
+                    part_output = part_filepath + ".zst"
+                else:
+                    part_output = part_filepath
 
                 # Store for later upload (after snapshot completion and final part rename)
                 if self.automatic_upload:
-                    self.fs_snapshot_parts_pending_upload.append(compressed_file)
+                    self.fs_snapshot_parts_pending_upload.append(part_output)
             else:
                 logger("warning", f"Snapshot file not found for compression: {part_filepath}")
 
@@ -618,22 +620,26 @@ class WriteManager:
             self.fs_snapshot_session_active = False
             return
         
-        # Find the last part file (compressed)
+        # Find the last part file. It is normally compressed (.csv.zst), but
+        # when zstandard is unavailable it is left uncompressed (.csv); detect
+        # whichever actually exists so the completion rename stays correct.
         last_part_str = f"{total_parts:04d}"
-        old_filename = (
+        snapshot_dir = f"{self.output_dir}/filesystem_snapshot"
+        base_name = (
             f"filesystem_snapshot_part{last_part_str}_"
             f"{self.fs_snapshot_timestamp}_"
-            f"{self.fs_snapshot_device_id}.csv.zst"
+            f"{self.fs_snapshot_device_id}"
         )
-        old_filepath = f"{self.output_dir}/filesystem_snapshot/{old_filename}"
-        
+        suffix = ".csv.zst"
+        if (not os.path.exists(f"{snapshot_dir}/{base_name}{suffix}")
+                and os.path.exists(f"{snapshot_dir}/{base_name}.csv")):
+            suffix = ".csv"
+        old_filepath = f"{snapshot_dir}/{base_name}{suffix}"
+
         # Construct new filename with completion marker
-        new_filename = (
-            f"filesystem_snapshot_part{last_part_str}_"
-            f"{self.fs_snapshot_timestamp}_"
-            f"{self.fs_snapshot_device_id}_complete_parts{total_parts}.csv.zst"
+        new_filepath = (
+            f"{snapshot_dir}/{base_name}_complete_parts{total_parts}{suffix}"
         )
-        new_filepath = f"{self.output_dir}/filesystem_snapshot/{new_filename}"
         
         # Rename the file (only if it still exists locally)
         try:
@@ -977,15 +983,19 @@ class WriteManager:
             if not os.path.exists(src):
                 return
 
-            compress_file_zstd(src, dst)
+            # Fall back to the uncompressed file when zstandard is unavailable
+            # so trace data is still uploaded rather than lost.
+            compressed = compress_file_zstd(src, dst)
+            upload_target = dst if compressed else src
 
             if self.automatic_upload:
                 self.created_files += 1
                 logger('info', f"Files Created: {str(self.created_files)}", True)
-                # Upload each compressed log individually, preserving its
-                # subdirectory (fs, ds, cache, process, ...) on the backend.
-                self.upload_manager.append_object(dst)
-            os.remove(src)
+                # Upload each log individually, preserving its subdirectory
+                # (fs, ds, cache, process, ...) on the backend.
+                self.upload_manager.append_object(upload_target)
+            if compressed:
+                os.remove(src)
         except Exception as e:
             logger("error", f"Failed compressing log {input_file}: {e}")
             
@@ -997,15 +1007,23 @@ class WriteManager:
             input_dir: Path to the directory to compress
         """
         try:
-            zstandard = require_zstandard()
             src = input_dir
-            dst = input_dir.rstrip("/").rstrip("\\") + ".tar.zst"
+            base = input_dir.rstrip("/").rstrip("\\")
 
-            cctx = zstandard.ZstdCompressor(level=ZSTD_LEVEL)
-            with open(dst, "wb") as f_out:
-                with cctx.stream_writer(f_out) as compressor:
-                    with tarfile.open(mode="w|", fileobj=compressor) as tar:
-                        tar.add(src, arcname=os.path.basename(src))
+            # Fall back to a plain (uncompressed) tar when zstandard is missing
+            # so the bundle is still produced rather than lost.
+            zstandard = zstandard_available()
+            if zstandard is not None:
+                dst = base + ".tar.zst"
+                cctx = zstandard.ZstdCompressor(level=ZSTD_LEVEL)
+                with open(dst, "wb") as f_out:
+                    with cctx.stream_writer(f_out) as compressor:
+                        with tarfile.open(mode="w|", fileobj=compressor) as tar:
+                            tar.add(src, arcname=os.path.basename(src))
+            else:
+                dst = base + ".tar"
+                with tarfile.open(dst, mode="w") as tar:
+                    tar.add(src, arcname=os.path.basename(src))
 
             if self.automatic_upload:
                 self.created_files += 1

--- a/src/utility/utils.py
+++ b/src/utility/utils.py
@@ -198,8 +198,10 @@ ZSTD_LEVEL = 3
 
 # Set once we've reported a missing ``zstandard`` install, so the
 # uncompressed fallback is announced a single time rather than once per file
-# across a whole trace run.
+# across a whole trace run. Guarded by a lock because the writer's parallel
+# stream threads can reach this concurrently.
 _zstandard_missing_warned = False
+_zstandard_warn_lock = threading.Lock()
 
 
 def require_zstandard():
@@ -231,16 +233,20 @@ def zstandard_available():
     """
     global _zstandard_missing_warned
     try:
+        # Catch ImportError (not just ModuleNotFoundError) so a zstandard that
+        # is installed but fails to load — e.g. a broken C-extension or missing
+        # shared library — also falls back gracefully instead of crashing.
         import zstandard
-    except ModuleNotFoundError:
-        if not _zstandard_missing_warned:
-            _zstandard_missing_warned = True
-            logger(
-                "warning",
-                "The 'zstandard' library is not installed; trace files will be "
-                "kept uncompressed. Install it with 'pip install zstandard' "
-                "(or 'pip install -r requirements.txt') to enable compression.",
-            )
+    except ImportError:
+        with _zstandard_warn_lock:
+            if not _zstandard_missing_warned:
+                _zstandard_missing_warned = True
+                logger(
+                    "warning",
+                    "The 'zstandard' library is not installed; trace files will be "
+                    "kept uncompressed. Install it with 'pip install zstandard' "
+                    "(or 'pip install -r requirements.txt') to enable compression.",
+                )
         return None
     return zstandard
 

--- a/src/utility/utils.py
+++ b/src/utility/utils.py
@@ -196,6 +196,12 @@ def logger(error_scale: str, string: str, timestamp: bool = False):
 ZSTD_LEVEL = 3
 
 
+# Set once we've reported a missing ``zstandard`` install, so the
+# uncompressed fallback is announced a single time rather than once per file
+# across a whole trace run.
+_zstandard_missing_warned = False
+
+
 def require_zstandard():
     """
     Import and return the optional ``zstandard`` module.
@@ -214,7 +220,32 @@ def require_zstandard():
     return zstandard
 
 
-def compress_file_zstd(src: str, dst: str, level: int = ZSTD_LEVEL):
+def zstandard_available():
+    """
+    Return the ``zstandard`` module if installed, otherwise ``None``.
+
+    Unlike :func:`require_zstandard` this never raises, letting callers fall
+    back to leaving trace files uncompressed when the optional dependency is
+    missing. The first time it is found missing a single warning is logged so
+    the per-file fallback doesn't flood the logs across a trace run.
+    """
+    global _zstandard_missing_warned
+    try:
+        import zstandard
+    except ModuleNotFoundError:
+        if not _zstandard_missing_warned:
+            _zstandard_missing_warned = True
+            logger(
+                "warning",
+                "The 'zstandard' library is not installed; trace files will be "
+                "kept uncompressed. Install it with 'pip install zstandard' "
+                "(or 'pip install -r requirements.txt') to enable compression.",
+            )
+        return None
+    return zstandard
+
+
+def compress_file_zstd(src: str, dst: str, level: int = ZSTD_LEVEL) -> bool:
     """
     Stream-compress a file to Zstandard.
 
@@ -222,24 +253,34 @@ def compress_file_zstd(src: str, dst: str, level: int = ZSTD_LEVEL):
         src: Path to the source file
         dst: Path to write the compressed (.zst) output
         level: Zstandard compression level
+
+    Returns:
+        ``True`` if the file was compressed to ``dst``. If the optional
+        ``zstandard`` library is unavailable nothing is written and ``False``
+        is returned, so callers can fall back to the uncompressed source.
     """
-    zstandard = require_zstandard()
+    zstandard = zstandard_available()
+    if zstandard is None:
+        return False
     cctx = zstandard.ZstdCompressor(level=level)
     with open(src, "rb") as f_in, open(dst, "wb") as f_out:
         cctx.copy_stream(f_in, f_out)
+    return True
 
 
 def compress_log(input_file: str):
     """
     Compress a log file using Zstandard.
 
+    Creates ``input_file.zst`` and removes the original when compression
+    succeeds. If ``zstandard`` is unavailable the original file is left in
+    place uncompressed.
+
     Args:
         input_file: Path to the file to compress
-
-    Creates input_file.zst and removes the original.
     """
-    compress_file_zstd(input_file, input_file + ".zst")
-    os.remove(input_file)
+    if compress_file_zstd(input_file, input_file + ".zst"):
+        os.remove(input_file)
 
 def capture_machine_id() -> str:
     """

--- a/tests/test_writer_upload.py
+++ b/tests/test_writer_upload.py
@@ -16,6 +16,7 @@ import sys
 import tempfile
 import types
 import unittest
+import unittest.mock
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -139,6 +140,69 @@ class PerFileUploadTests(unittest.TestCase):
         for name, (lo, hi) in self.wm.dynamic_limits.items():
             self.assertGreaterEqual(lo, 80000, name)
             self.assertLessEqual(lo, hi, name)
+
+
+class ZstandardMissingFallbackTests(unittest.TestCase):
+    """When the optional ``zstandard`` library is unavailable, the tracer must
+    keep (and upload) trace files uncompressed rather than losing data. These
+    tests force the missing-dependency path so they run regardless of whether
+    ``zstandard`` happens to be installed.
+    """
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.output_dir = os.path.join(self.tmp, "trace")
+        self.upload = FakeUploadManager()
+        self.wm = SilentWriteManager(
+            output_dir=self.output_dir,
+            upload_manager=self.upload,
+            automatic_upload=True,
+        )
+        # Pretend zstandard is not installed everywhere it is consulted.
+        import src.utility.utils as utils_mod
+        import src.tracer.WriterManager as wm_mod
+        self._patchers = [
+            unittest.mock.patch.object(utils_mod, "zstandard_available", lambda: None),
+            unittest.mock.patch.object(wm_mod, "zstandard_available", lambda: None),
+        ]
+        for p in self._patchers:
+            p.start()
+
+    def tearDown(self):
+        for p in self._patchers:
+            p.stop()
+        import shutil
+        try:
+            self.wm.close_handles()
+        except Exception:
+            pass
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _make_log(self, subdir, name, text):
+        path = os.path.join(self.output_dir, subdir, name)
+        with open(path, "w") as f:
+            f.write(text)
+        return path
+
+    def test_compress_log_uploads_uncompressed_when_zstd_missing(self):
+        src = self._make_log("process", "process_x.csv", "a,b,c\n1,2,3\n")
+        self.wm.compress_log(src)
+
+        # The uncompressed .csv is uploaded and left on disk; no .zst created.
+        self.assertEqual(self.upload.uploaded, [src])
+        self.assertTrue(os.path.exists(src))
+        self.assertFalse(os.path.exists(src + ".zst"))
+        with open(src) as f:
+            self.assertEqual(f.read(), "a,b,c\n1,2,3\n")
+
+    def test_compress_dir_falls_back_to_plain_tar(self):
+        self.wm.automatic_upload = False
+        self._make_log("process", "process_x.csv", "row\n")
+        self.wm.compress_dir(self.output_dir)
+
+        # A plain .tar bundle is produced instead of .tar.zst.
+        self.assertTrue(os.path.exists(self.output_dir.rstrip("/") + ".tar"))
+        self.assertFalse(os.path.exists(self.output_dir.rstrip("/") + ".tar.zst"))
 
 
 class StaleLogRotationTests(unittest.TestCase):


### PR DESCRIPTION
## Problem

When the optional `zstandard` package isn't installed in the runtime environment, trace-log compression raised on **every** file:

```
[ERROR] Failed compressing log .../process_20260614_190415_050.csv: The 'zstandard' library is required for Zstandard compression but is not installed. Install it with 'pip install zstandard'.
```

The original `.csv` was left on disk but never uploaded, and the error repeated for every file across the whole trace run.

## Change

Compression now **gracefully degrades**: if `zstandard` is unavailable, the tracer keeps (and uploads) trace files **uncompressed** instead of losing them, and warns a single time rather than once per file.

- `compress_file_zstd` now returns whether it actually compressed; added a non-raising `zstandard_available()` helper that logs the missing-dependency warning exactly once.
- `WriterManager.compress_log`, the filesystem-snapshot flush, and `compress_dir` fall back to uploading the uncompressed file (or a plain `.tar` bundle) when `zstandard` is missing.
- `mark_fs_snapshot_complete` detects whether the last part is `.csv.zst` or `.csv` so the completion rename stays correct in both cases.
- **README**: added `python3-zstandard` to the install steps and documented `pip install -r requirements.txt`.
- Added tests that force the missing-dependency path so the fallback is covered regardless of whether `zstandard` is installed.

## Testing

`python3 -m unittest discover -s tests` → 62 passed (7 pre-existing round-trip tests skip only when `zstandard` is absent from the sandbox). The two new fallback tests pass.

https://claude.ai/code/session_01PWSbqrYRgjtFC3hSzqwpMD

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWSbqrYRgjtFC3hSzqwpMD)_