### PR TITLE
Simplify dependency installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,26 +39,30 @@ pacman -S bcc bcc-tools python-bcc
 
 For more distros, visit the official [BCC's installation guide](https://github.com/iovisor/bcc/blob/master/INSTALL.md)
 
-3. Finally, install the remaining Python libraries!
-
-```bash
-# Ubuntu 
-sudo apt install python3-psutil
-sudo apt install python3-requests
-sudo apt install python3-pytest
-sudo apt install python3-zstandard
-
-
-# ... (adjust the package manager for other distros)
-```
-
-`zstandard` is used to compress trace logs (`.zst`). If it is missing the
-tracer still runs and keeps traces uncompressed, but installing it is
-recommended. You can also install all Python dependencies at once with:
+3. Finally, install the Python dependencies. The simplest way is to install
+them all at once from `requirements.txt`:
 
 ```bash
 pip install -r requirements.txt
 ```
+
+Or, if you prefer your distro's package manager:
+
+```bash
+# Ubuntu / Debian
+sudo apt install python3-psutil python3-requests python3-zstandard
+
+# Fedora
+sudo dnf install python3-psutil python3-requests python3-zstandard
+
+# Arch
+sudo pacman -S python-psutil python-requests python-zstandard
+```
+
+`zstandard` is used to compress trace logs (`.zst`). If it is missing the
+tracer still runs and keeps traces uncompressed, but installing it is
+recommended. To run the test suite you'll also need `pytest`
+(`pip install pytest`).
 
 ## Usage
 ```

--- a/install.sh
+++ b/install.sh
@@ -123,17 +123,17 @@ install_bcc_arch() {
 
 install_python_deps_apt() {
     log_info "Installing Python dependencies..."
-    apt-get install -y python3-psutil python3-requests
+    apt-get install -y python3-psutil python3-requests python3-zstandard
 }
 
 install_python_deps_dnf() {
     log_info "Installing Python dependencies..."
-    dnf install -y python3-psutil python3-requests
+    dnf install -y python3-psutil python3-requests python3-zstandard
 }
 
 install_python_deps_pacman() {
     log_info "Installing Python dependencies..."
-    pacman -S --noconfirm python-psutil python-requests
+    pacman -S --noconfirm python-psutil python-requests python-zstandard
 }
 
 install_git_if_needed() {

--- a/install.sh
+++ b/install.sh
@@ -123,17 +123,24 @@ install_bcc_arch() {
 
 install_python_deps_apt() {
     log_info "Installing Python dependencies..."
-    apt-get install -y python3-psutil python3-requests python3-zstandard
+    apt-get install -y python3-psutil python3-requests
+    # zstandard is optional: the tracer falls back to uncompressed traces when
+    # it is missing, so don't let an unavailable package abort the install.
+    apt-get install -y python3-zstandard || log_warning "python3-zstandard unavailable; traces will not be compressed"
 }
 
 install_python_deps_dnf() {
     log_info "Installing Python dependencies..."
-    dnf install -y python3-psutil python3-requests python3-zstandard
+    dnf install -y python3-psutil python3-requests
+    # Optional; see install_python_deps_apt.
+    dnf install -y python3-zstandard || log_warning "python3-zstandard unavailable; traces will not be compressed"
 }
 
 install_python_deps_pacman() {
     log_info "Installing Python dependencies..."
-    pacman -S --noconfirm python-psutil python-requests python-zstandard
+    pacman -S --noconfirm python-psutil python-requests
+    # Optional; see install_python_deps_apt.
+    pacman -S --noconfirm python-zstandard || log_warning "python-zstandard unavailable; traces will not be compressed"
 }
 
 install_git_if_needed() {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 # Runtime dependencies for the io-tracer userspace tooling.
 # Note: bcc (python3-bpfcc) is installed via the system package manager, not pip.
+psutil>=5.8
 requests>=2.25
 zstandard>=0.21


### PR DESCRIPTION
## Summary

Streamlines how the Python dependencies are installed and closes a gap that was the root cause of the earlier `zstandard ... is not installed` error in the field.

## Changes

- **`requirements.txt`**: added `psutil` (imported by the process/system snappers) so the file is a complete single source of truth for the Python runtime dependencies.
- **`README.md`**: collapsed the four separate `sudo apt install` lines into a single step. The primary path is now `pip install -r requirements.txt`, with one-line `apt` / `dnf` / `pacman` alternatives.
- **`install.sh`**: the automated installer now installs `zstandard` alongside `psutil`/`requests` in the apt, dnf, and pacman paths. Previously it omitted `zstandard`, so machines set up via `install.sh` ran without compression support — exactly the situation that triggered the original per-file compression error.

## Notes

The companion graceful-fallback change (PR #44) means a missing `zstandard` no longer loses data; this PR ensures the standard install paths actually provide it so compression works out of the box.

https://claude.ai/code/session_01PWSbqrYRgjtFC3hSzqwpMD

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWSbqrYRgjtFC3hSzqwpMD)_