### PR TITLE
Reset trace schema version to 1

### DIFF
--- a/docs/TRACE_FORMAT.md
+++ b/docs/TRACE_FORMAT.md
@@ -60,7 +60,7 @@ than hard-coding column positions.
 timestamp,operation,pid,tid,command,filename,size,offset,bytes_completed,inode,device,flags,duration_ns,return_value,errno,mmap_prot,mmap_flags,address,cmdline,ppid,container_id,fs_type,mono_ns
 ```
 
-**Schema v3 — cross-OS aligned.** Columns 1–12 (`timestamp` … `flags`) are the
+**Cross-OS aligned.** Columns 1–12 (`timestamp` … `flags`) are the
 **shared prefix** emitted identically by the Windows tracer's `filesystem/`
 stream, so a single parser reads the comparable fields from either OS. The
 remaining columns are Linux-only extras. `operation` is now a **lowercase**
@@ -85,7 +85,7 @@ For operations captured and examples, see [VFS_EVENTS.md](traces/VFS_EVENTS.md).
 timestamp,operation,pid,tid,command,sector,size,latency_ms,device,flags,cpu_id,ppid,queue_latency_ms,command_flags,operation_code,request_id,mono_ns
 ```
 
-**Schema v3 — cross-OS aligned.** Columns 1–10 (`timestamp` … `flags`) are the
+**Cross-OS aligned.** Columns 1–10 (`timestamp` … `flags`) are the
 **shared prefix** emitted identically by the Windows tracer's `ds/` stream. The
 `operation` column now holds the **base op only** (`read`, `write`, `flush`,
 `discard`, …); the rwbs sub-flags (`sync`, `meta`, `ahead`, …) that used to be
@@ -290,7 +290,7 @@ events in the kernel buffer.
 ## Version Information
 
 This documentation applies to:
-- **Trace schema:** version 2 (`SCHEMA_VERSION` in `src/tracer/schema.py`)
+- **Trace schema:** version 1 (`SCHEMA_VERSION` in `src/tracer/schema.py`)
 - **Kernel:** Linux 5.4+
 - **BCC:** 0.18.0+
 

--- a/docs/traces/BLOCK_IO_EVENTS.md
+++ b/docs/traces/BLOCK_IO_EVENTS.md
@@ -4,7 +4,7 @@
 
 **Kernel Probes:** Attached via block layer instrumentation in the eBPF program.
 
-> **Schema v3 (cross-OS aligned).** The on-disk column order is the aligned
+> **Cross-OS aligned.** The on-disk column order is the aligned
 > layout in [TRACE_FORMAT.md](../TRACE_FORMAT.md#2-block-device-traces)
 > (shared prefix `timestamp,operation,pid,tid,command,sector,size,latency_ms,device,flags`
 > then Linux extras). The `operation` column now holds the **base op only**

--- a/docs/traces/VFS_EVENTS.md
+++ b/docs/traces/VFS_EVENTS.md
@@ -2,7 +2,7 @@
 
 **Description:** Captures file system operations at the VFS layer, intercepting all file access operations regardless of the underlying filesystem.
 
-> **Schema v3 (cross-OS aligned).** The on-disk column order is the aligned
+> **Cross-OS aligned.** The on-disk column order is the aligned
 > layout in [TRACE_FORMAT.md](../TRACE_FORMAT.md#1-vfs-virtual-file-system-traces)
 > (shared prefix `timestamp,operation,pid,tid,command,filename,size,offset,bytes_completed,inode,device,flags`
 > then Linux extras). The `operation` value written to the CSV is the

--- a/src/tracer/schema.py
+++ b/src/tracer/schema.py
@@ -22,7 +22,9 @@ it from ``manifest.json`` and adapt.
 #     Linux-only extras, lowercase canonical operation names, ``size_requested``
 #     renamed to ``size``, and a dedicated block ``flags`` column (rwbs sub-flags
 #     split out of ``operation``).
-SCHEMA_VERSION = 3
+# Schema version stamped into manifest.json. Reset to 1 by request; the column
+# layout remains the cross-OS aligned fs/ds format described below.
+SCHEMA_VERSION = 1
 
 
 def _col(name, ctype, unit="", desc=""):

--- a/src/tracer/schema.py
+++ b/src/tracer/schema.py
@@ -15,6 +15,7 @@ Bump ``SCHEMA_VERSION`` whenever a stream's columns change; consumers should rea
 it from ``manifest.json`` and adapt.
 """
 
+# Historical format evolution (for reference only — see the note below):
 # v1: original headerless CSVs, no manifest, per-stream clocks.
 # v2: CSV headers + manifest.json + a common ``mono_ns`` column on every stream.
 # v3: cross-OS aligned layout for ``fs`` and ``ds`` — a fixed shared column
@@ -24,6 +25,8 @@ it from ``manifest.json`` and adapt.
 #     split out of ``operation``).
 # Schema version stamped into manifest.json. Reset to 1 by request; the column
 # layout remains the cross-OS aligned fs/ds format described below.
+# NOTE: this overrides the historical v1–v3 numbering above — the on-disk format
+# is the aligned layout (what the changelog calls v3), not the original v1 format.
 SCHEMA_VERSION = 1
 
 

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -24,7 +24,7 @@ EXPECTED_COLUMN_COUNTS = {
     "filesystem_snapshot": 7,  # 6 + mono_ns
 }
 
-# Cross-OS aligned shared column prefix (schema v3). These leading columns must
+# Cross-OS aligned shared column prefix. These leading columns must
 # match the Windows tracer's fs/ds streams exactly and in the same order.
 ALIGNED_FS_PREFIX = [
     "timestamp", "operation", "pid", "tid", "command", "filename",
@@ -37,8 +37,8 @@ ALIGNED_DS_PREFIX = [
 
 
 class SchemaShapeTests(unittest.TestCase):
-    def test_schema_version_is_3(self):
-        self.assertEqual(schema.SCHEMA_VERSION, 3)
+    def test_schema_version_is_1(self):
+        self.assertEqual(schema.SCHEMA_VERSION, 1)
 
     def test_fs_ds_aligned_prefix(self):
         self.assertEqual(schema.column_names("fs")[:len(ALIGNED_FS_PREFIX)],
@@ -86,7 +86,7 @@ class ManifestTests(unittest.TestCase):
         block = schema.schema_for_manifest()
         # Round-trips through JSON without error.
         restored = json.loads(json.dumps(block))
-        self.assertEqual(restored["schema_version"], 3)
+        self.assertEqual(restored["schema_version"], 1)
         self.assertEqual(set(restored["streams"]), set(EXPECTED_COLUMN_COUNTS))
 
     def test_manifest_columns_carry_type_and_unit(self):


### PR DESCRIPTION
## What

Resets the trace schema **version identifier to `1`** (`SCHEMA_VERSION = 1` in `src/tracer/schema.py`, stamped into `manifest.json`).

This is a **version-number-only** change as requested — the cross-OS aligned `fs`/`ds` column layout, CSV header rows, `mono_ns` clock, and manifest are all **unchanged**.

## Changes
- `src/tracer/schema.py` — `SCHEMA_VERSION` 3 → 1.
- `tests/test_schema.py` — assertion updated to 1.
- Docs — dropped the specific version number from the aligned-format notes; fixed one stale "version 2" reference.

> Note: in this repo's history, `v1` originally denoted the headerless/no-manifest format. This change only relabels the current (aligned) format's version number to 1; it does **not** restore that old on-disk layout.

## Testing
`python3 -m unittest tests.test_schema` → 11 passed.

https://claude.ai/code/session_01PZ8xwUL42pnvtXyvfFQVAi

---
_Generated by [Claude Code](https://claude.ai/code/session_01PZ8xwUL42pnvtXyvfFQVAi)_