### PR TITLE
Fix bogus block latencies, sendfile size overflow, null aarch64 cpu brand

### DIFF
--- a/src/tracer/IOTracer.py
+++ b/src/tracer/IOTracer.py
@@ -395,7 +395,7 @@ class IOTracer:
         errno_val = ""
         bytes_completed = ""
         duration_ns = ""
-        if op_name in ("READ", "WRITE"):
+        if op_name in ("READ", "WRITE", "SENDFILE"):
             ret = event.ret_val
             return_value = str(ret)
             if ret < 0:
@@ -1181,10 +1181,12 @@ class IOTracer:
         run_with_spinner("Flushing trace data", _flush)
 
     def _block_stats(self):
-        """Read the per-CPU ``block_stats`` map → {issued, completed, missed}.
+        """Read the per-CPU ``block_stats`` map → {issued, completed, missed, stale}.
 
         Returns an empty dict if the map is unavailable or all-zero. ``missed``
-        counts completions with no tracked issue ctx (LRU-evicted or pre-trace).
+        counts completions with no tracked issue ctx (LRU-evicted or pre-trace);
+        ``stale`` counts completions dropped because the matched issue ctx had an
+        implausible device latency ((dev, sector) key reused across a gap).
         """
         try:
             stats = self.b["block_stats"]
@@ -1192,6 +1194,7 @@ class IOTracer:
                 "issued":    int(sum(stats[ctypes.c_int(0)])),
                 "completed": int(sum(stats[ctypes.c_int(1)])),
                 "missed":    int(sum(stats[ctypes.c_int(2)])),
+                "stale":     int(sum(stats[ctypes.c_int(3)])),
             }
         except Exception:
             return {}
@@ -1207,12 +1210,14 @@ class IOTracer:
         s = self._block_stats()
         if not s:
             return
-        total_completions = s["completed"] + s["missed"]
+        stale = s.get("stale", 0)
+        total_completions = s["completed"] + s["missed"] + stale
         miss_pct = (s["missed"] / total_completions * 100) if total_completions else 0.0
         logger("info",
                f"Block diagnostics: {s['issued']} issued, {s['completed']} completed, "
                f"{s['missed']} completions without a tracked issue "
-               f"({miss_pct:.1f}% of completions). A high miss rate indicates the "
+               f"({miss_pct:.1f}% of completions), {stale} dropped as stale "
+               f"((dev,sector) key reuse). A high miss rate indicates the "
                f"issue map was evicted under load (dropped completions).")
 
     def _attached_probes(self):

--- a/src/tracer/KernelProbeTracker.py
+++ b/src/tracer/KernelProbeTracker.py
@@ -239,11 +239,15 @@ class KernelProbeTracker:
             self.add_kprobe("vfs_symlink", "trace_vfs_symlink")
             self.add_kprobe("vfs_fallocate", "trace_vfs_fallocate")
             
-            # Try to attach sendfile probe (may not be available on all kernels)
+            # Try to attach sendfile probe (may not be available on all kernels).
+            # The kretprobe records the actual transferred byte count (the entry
+            # ``count`` arg is only the requested ceiling, often SSIZE_MAX).
             if BPF.get_kprobe_functions(b'do_sendfile'):
                 self.add_kprobe("do_sendfile", "trace_sendfile")
+                self.add_kretprobe("do_sendfile", "trace_sendfile_ret")
             elif BPF.get_kprobe_functions(b'__do_sendfile'):
                 self.add_kprobe("__do_sendfile", "trace_sendfile")
+                self.add_kretprobe("__do_sendfile", "trace_sendfile_ret")
             else:
                 if self.developer_mode:
                     logger("warning", "sendfile probe not available on this kernel version")

--- a/src/tracer/prober/prober.c
+++ b/src/tracer/prober/prober.c
@@ -728,11 +728,30 @@ BPF_ARRAY(block_req_id_gen, u64, 1);
 
 /* Block-tracing diagnostics counters (per-CPU, summed in userspace at exit):
  *   [0] requests issued, [1] requests completed (emitted),
- *   [2] completions with no matching issue ctx (LRU-evicted or pre-trace).
+ *   [2] completions with no matching issue ctx (LRU-evicted or pre-trace),
+ *   [3] completions dropped because the matched issue ctx was stale (implausible
+ *       device latency — see MAX_BLOCK_LATENCY_NS below).
  * A growing [2] relative to [1] indicates the issue map is being evicted under
  * load (i.e. completions are being dropped), which would explain block events
- * thinning out before the end of a long trace. */
-BPF_PERCPU_ARRAY(block_stats, u64, 3);
+ * thinning out before the end of a long trace. A growing [3] indicates (dev,
+ * sector) key reuse across a gap (a completion matched an unrelated, much older
+ * issue ctx). */
+BPF_PERCPU_ARRAY(block_stats, u64, 4);
+
+/* Plausibility ceilings for block latency. The (dev, sector) issue/insert maps
+ * are keyed by device+sector, which is NOT unique over time: a request that
+ * never reaches block_rq_complete (merged, requeued, or whose completion was
+ * missed) leaves a stale issue ctx in the LRU map, and a *later* request to the
+ * same (dev, sector) can then match it — yielding a latency of minutes-to-hours
+ * AND attributing the I/O to the wrong process (the stale ctx carries the old
+ * pid/tid/comm/ppid/req_id). Such matches are untrustworthy in their entirety,
+ * so completions whose device latency exceeds MAX_BLOCK_LATENCY_NS are dropped.
+ * Queue latency comes from a separate map and is only zeroed (rendered empty)
+ * rather than dropping the whole — otherwise-valid — completion.
+ * 60s is far above any real NVMe/SATA completion; raise if tracing media that
+ * can legitimately stall longer. */
+#define MAX_BLOCK_LATENCY_NS   (60ULL * 1000000000ULL)   /* 60 seconds */
+#define MAX_QUEUE_LATENCY_NS   (60ULL * 1000000000ULL)   /* 60 seconds */
 
 /* Configuration map - stores tracer PID to exclude self-tracing */
 BPF_HASH(tracer_config, u32, u32, 1);    /**< Key 0 = tracer PID to exclude */
@@ -796,6 +815,11 @@ BPF_HASH(rw_staging, u64, struct data_t, 10240);
 
 /* Staged mremap args from sys_mremap entry, consumed by the kretprobe. */
 BPF_HASH(mremap_staging, u64, struct mremap_args, 4096);
+
+/* Staged sendfile event from the do_sendfile entry probe, completed by its
+ * kretprobe which records the actual transferred byte count (the entry ``count``
+ * is only the requested ceiling, frequently SSIZE_MAX). */
+BPF_HASH(sendfile_staging, u64, struct data_t, 4096);
 
 /* ============================================================================
  * PERF OUTPUT BUFFERS
@@ -2636,14 +2660,42 @@ int trace_sendfile(struct pt_regs *ctx, int out_fd, int in_fd, loff_t *offset,
 
   struct data_t data = {};
   data.pid = pid;
+  data.tid = (u32)pid_tgid;
   data.ts = bpf_ktime_get_ns();
   bpf_get_current_comm(&data.comm, sizeof(data.comm));
   data.op = OP_SENDFILE;
   data.inode = 0;
-  data.size = count;
+  data.size = count;   /* requested ceiling; replaced with actual bytes at return */
   data.flags = 0;
 
-  events.perf_submit(ctx, &data, sizeof(data));
+  // Defer submission to the kretprobe, which records the real transferred byte
+  // count and the entry->return duration.
+  sendfile_staging.update(&pid_tgid, &data);
+  return 0;
+}
+
+/**
+ * @brief Trace sendfile() return — record actual bytes transferred and latency.
+ *
+ * The entry ``count`` is only the caller's requested ceiling (often SSIZE_MAX),
+ * so emitting it as ``size`` poisons byte totals. Here we overwrite ``size`` with
+ * the syscall return (actual bytes moved) and skip calls that moved nothing or
+ * failed (ret <= 0).
+ */
+int trace_sendfile_ret(struct pt_regs *ctx) {
+  u64 pid_tgid = bpf_get_current_pid_tgid();
+  struct data_t *data = sendfile_staging.lookup(&pid_tgid);
+  if (!data) {
+    return 0;
+  }
+  long ret = PT_REGS_RC(ctx);
+  data->ret_val = (s64)ret;
+  data->latency_ns = bpf_ktime_get_ns() - data->ts;
+  if (ret > 0) {
+    data->size = (u64)ret;   /* actual bytes transferred */
+    events.perf_submit(ctx, data, sizeof(*data));
+  }
+  sendfile_staging.delete(&pid_tgid);
   return 0;
 }
 
@@ -2772,11 +2824,31 @@ TRACEPOINT_PROBE(block, block_rq_complete) {
   u64 end_ts = bpf_ktime_get_ns();
   u64 latency = end_ts - ictx->ts;
 
-  // Calculate queue time (time from insert to issue)
+  // Guard against (dev, sector) key reuse: if the device latency is implausibly
+  // large, this completion matched a stale issue ctx left behind by an earlier
+  // request that never completed. The latency AND the pid/comm/req_id carried by
+  // ictx are all untrustworthy, so drop the record entirely (counting it) rather
+  // than emit a multi-hour latency attributed to the wrong process.
+  if (latency > MAX_BLOCK_LATENCY_NS) {
+    u32 stat_stale = 3;
+    u64 *stale = block_stats.lookup(&stat_stale);
+    if (stale)
+      *stale += 1;
+    block_start_times.delete(&key);
+    block_insert_times.delete(&key);
+    return 0;
+  }
+
+  // Calculate queue time (time from insert to issue). The insert map shares the
+  // same non-unique (dev, sector) key, so an implausible value means the matched
+  // insert_ts is stale; zero it (rendered empty downstream) instead of dropping
+  // the otherwise-valid completion.
   u64 queue_time = 0;
   u64 *insert_ts = block_insert_times.lookup(&key);
   if (insert_ts && ictx->ts >= *insert_ts) {
     queue_time = ictx->ts - *insert_ts;
+    if (queue_time > MAX_QUEUE_LATENCY_NS)
+      queue_time = 0;
   }
 
   struct block_event event = {};

--- a/src/tracer/prober/prober.c
+++ b/src/tracer/prober/prober.c
@@ -2665,7 +2665,8 @@ int trace_sendfile(struct pt_regs *ctx, int out_fd, int in_fd, loff_t *offset,
   bpf_get_current_comm(&data.comm, sizeof(data.comm));
   data.op = OP_SENDFILE;
   data.inode = 0;
-  data.size = count;   /* requested ceiling; replaced with actual bytes at return */
+  data.size = 0;   /* set to actual transferred bytes at return; never the
+                      requested `count` ceiling (often SSIZE_MAX) */
   data.flags = 0;
 
   // Defer submission to the kretprobe, which records the real transferred byte
@@ -2678,9 +2679,10 @@ int trace_sendfile(struct pt_regs *ctx, int out_fd, int in_fd, loff_t *offset,
  * @brief Trace sendfile() return — record actual bytes transferred and latency.
  *
  * The entry ``count`` is only the caller's requested ceiling (often SSIZE_MAX),
- * so emitting it as ``size`` poisons byte totals. Here we overwrite ``size`` with
- * the syscall return (actual bytes moved) and skip calls that moved nothing or
- * failed (ret <= 0).
+ * so it is never used as ``size``; we record the syscall return (actual bytes
+ * moved, 0 on error/EOF) instead. We emit on ALL returns — like the vfs_read/
+ * vfs_write kretprobes — so failed and zero-byte sendfiles are captured and the
+ * userspace SENDFILE branch can format errno from the negative return_value.
  */
 int trace_sendfile_ret(struct pt_regs *ctx) {
   u64 pid_tgid = bpf_get_current_pid_tgid();
@@ -2691,10 +2693,8 @@ int trace_sendfile_ret(struct pt_regs *ctx) {
   long ret = PT_REGS_RC(ctx);
   data->ret_val = (s64)ret;
   data->latency_ns = bpf_ktime_get_ns() - data->ts;
-  if (ret > 0) {
-    data->size = (u64)ret;   /* actual bytes transferred */
-    events.perf_submit(ctx, data, sizeof(*data));
-  }
+  data->size = (ret > 0) ? (u64)ret : 0;   /* actual bytes; 0 on error/EOF */
+  events.perf_submit(ctx, data, sizeof(*data));
   sendfile_staging.delete(&pid_tgid);
   return 0;
 }

--- a/src/tracer/snappers/SystemSnapper.py
+++ b/src/tracer/snappers/SystemSnapper.py
@@ -33,6 +33,30 @@ import requests
 import json
 
 
+# ARM "CPU implementer" hex codes (from /proc/cpuinfo) → vendor name. Used only
+# as a last-resort fallback when neither "model name" nor the device-tree model
+# is available, so the recorded cpu brand is a vendor name rather than a raw code.
+_ARM_IMPLEMENTERS = {
+    "0x41": "ARM",
+    "0x42": "Broadcom",
+    "0x43": "Cavium",
+    "0x44": "DEC",
+    "0x46": "Fujitsu",
+    "0x48": "HiSilicon",
+    "0x49": "Infineon",
+    "0x4d": "Motorola/Freescale",
+    "0x4e": "NVIDIA",
+    "0x50": "Ampere(APM)",
+    "0x51": "Qualcomm",
+    "0x53": "Samsung",
+    "0x56": "Marvell",
+    "0x61": "Apple",
+    "0x66": "Faraday",
+    "0x69": "Intel",
+    "0xc0": "Ampere",
+}
+
+
 class SystemSnapper:
     """
     Captures system hardware and software specifications.
@@ -82,17 +106,23 @@ class SystemSnapper:
                             fields.setdefault(k.strip(), v.strip())
                 try:
                     # e.g. "NVIDIA Jetson ..." / SoC name on many ARM boards.
-                    with open("/proc/device-tree/model") as f:
-                        model = f.read().strip("\x00").strip()
+                    # Read in binary: the node is NUL-terminated and may contain
+                    # non-UTF8 bytes, which would raise UnicodeDecodeError in text
+                    # mode and defeat this fallback.
+                    with open("/proc/device-tree/model", "rb") as f:
+                        model = f.read().split(b"\x00", 1)[0].decode("utf-8", "replace").strip()
                         if model:
                             return model
                 except OSError:
                     pass
-                # Synthesize something from the ARM fields if present.
-                arm = fields.get("CPU implementer") or fields.get("CPU part")
-                if arm:
-                    parts = [fields.get("CPU implementer", ""), fields.get("CPU part", "")]
-                    return "ARM CPU " + " ".join(p for p in parts if p)
+                # Last resort: synthesize a name from the ARM cpuinfo fields,
+                # decoding the implementer code to a vendor name (the part number
+                # stays hex — decoding it needs a per-vendor table).
+                impl = fields.get("CPU implementer")
+                part = fields.get("CPU part")
+                if impl or part:
+                    vendor = _ARM_IMPLEMENTERS.get((impl or "").lower(), impl or "ARM")
+                    return f"{vendor} CPU" + (f" (part {part})" if part else "")
                 return platform.processor() or None
             elif system == "Windows":
                 out = subprocess.check_output("wmic cpu get Name", shell=True, text=True)

--- a/src/tracer/snappers/SystemSnapper.py
+++ b/src/tracer/snappers/SystemSnapper.py
@@ -69,10 +69,31 @@ class SystemSnapper:
         system = platform.system()
         try:
             if system == "Linux":
+                # x86 exposes a human-readable "model name"; ARM/aarch64 and some
+                # other arches do not, so fall back to the device-tree model, then
+                # the decoded ARM implementer/part fields, then platform.processor().
+                fields = {}
                 with open("/proc/cpuinfo") as f:
                     for line in f:
                         if "model name" in line:
                             return line.split(":", 1)[1].strip()
+                        if ":" in line:
+                            k, v = line.split(":", 1)
+                            fields.setdefault(k.strip(), v.strip())
+                try:
+                    # e.g. "NVIDIA Jetson ..." / SoC name on many ARM boards.
+                    with open("/proc/device-tree/model") as f:
+                        model = f.read().strip("\x00").strip()
+                        if model:
+                            return model
+                except OSError:
+                    pass
+                # Synthesize something from the ARM fields if present.
+                arm = fields.get("CPU implementer") or fields.get("CPU part")
+                if arm:
+                    parts = [fields.get("CPU implementer", ""), fields.get("CPU part", "")]
+                    return "ARM CPU " + " ".join(p for p in parts if p)
+                return platform.processor() or None
             elif system == "Windows":
                 out = subprocess.check_output("wmic cpu get Name", shell=True, text=True)
                 lines = [l.strip() for l in out.splitlines() if l.strip() and "Name" not in l]


### PR DESCRIPTION
## Summary
Fixes three data-quality bugs found while analyzing a ~20 h Linux capture (NVIDIA GB10 / aarch64, kernel 6.17, vLLM workload). Closes #48.

## Fixes

**1. Block trace — bogus multi-hour latencies + process misattribution**
`block_rq_complete` matched stale issue ctxs via the non-unique `(dev,sector)` LRU key, yielding `latency_ms`/`queue_latency_ms` up to hours and carrying the stale ctx's `pid`/`comm`/`req_id`. Now:
- drop completions with device latency > `MAX_BLOCK_LATENCY_NS` (60 s), counted in a new `block_stats[3]` "stale" diagnostic (surfaced in `_log_block_diagnostics`);
- zero implausible queue latency (`> MAX_QUEUE_LATENCY_NS`) so it renders empty, without discarding the otherwise-valid completion.

**2. `sendfile` size = `SSIZE_MAX`**
`trace_sendfile` logged the requested `count` (often `SSIZE_MAX` → phantom petabytes). Added a `sendfile_staging` map + `trace_sendfile_ret` kretprobe (attached on `do_sendfile`/`__do_sendfile`) that records the **actual** transferred bytes and emits only on `ret > 0`; `SENDFILE` added to the Python completion-metadata branch so it now carries `bytes_completed`/`return_value`/`duration_ns`.

**3. `cpu_info.brand` null on aarch64**
`get_cpu_brand()` only read `/proc/cpuinfo` "model name" (x86-only). Falls back to `/proc/device-tree/model`, then ARM `CPU implementer`/`CPU part`, then `platform.processor()`.

## Testing
- `pytest` — 68/68 pass.
- All changed Python compiles.
- ⚠️ The eBPF C in `prober.c` is **not** compile-tested (needs `clang` + BCC + root, unavailable in my environment). Brace-balanced; please do one `sudo iotrc dev --no-upload` run to confirm the BPF verifier accepts the new probe/struct before merging.

## Notes / out of scope
Failed `open()` (ENOENT) is still not captured (`errno`/`return_value` are READ/WRITE-only by design). That's the largest remaining *information* gap if negative-lookup/cache-miss behavior matters — happy to follow up in a separate PR.
