### PR TITLE
Fix anonymization dir leak, fs-snapshot name hashing, ProcessSnapper row drops, arm64 --network load, +misc

### DIFF
--- a/src/tracer/IOTracer.py
+++ b/src/tracer/IOTracer.py
@@ -33,7 +33,7 @@ from datetime import datetime
 
 from . import schema
 from .ObjectStorageManager import ObjectStorageManager
-from ..utility.utils import capture_machine_id, format_csv_row, logger, hash_filename_in_path, inet6_from_event, simple_hash, run_with_spinner
+from ..utility.utils import capture_machine_id, format_csv_row, logger, hash_rel_path, inet6_from_event, simple_hash, run_with_spinner
 from .WriterManager import WriteManager
 from .FlagMapper import FlagMapper
 from .KernelProbeTracker import KernelProbeTracker
@@ -272,7 +272,7 @@ class IOTracer:
         try:
             filename = event.filename.decode()
             if self.anonymous:
-                filename = hash_filename_in_path(Path(filename))
+                filename = str(hash_rel_path(Path(filename)))
             if op_name in ['MKDIR', 'RMDIR', 'CHDIR', 'READDIR'] and filename and not filename.endswith('/'):
                 filename += '/'
         except UnicodeDecodeError:
@@ -290,7 +290,9 @@ class IOTracer:
 
         inode_val = event.inode if event.inode != 0 else ""
         
-        size_val = event.size if event.size is not None else 0
+        # Empty (not 0) for non-I/O ops, matching the schema and the
+        # offset column below; ops that carry a size set event.size > 0.
+        size_val = event.size if event.size else ""
         address_val = ""
         raw_address = event.address if hasattr(event, 'address') else 0
         if raw_address:
@@ -696,8 +698,8 @@ class IOTracer:
             filename_old = event.filename_old.decode()
             filename_new = event.filename_new.decode()
             if self.anonymous:
-                filename_old = hash_filename_in_path(Path(filename_old))
-                filename_new = hash_filename_in_path(Path(filename_new))
+                filename_old = str(hash_rel_path(Path(filename_old)))
+                filename_new = str(hash_rel_path(Path(filename_new)))
         except UnicodeDecodeError:
             filename_old = ""
             filename_new = ""
@@ -1091,7 +1093,7 @@ class IOTracer:
             if cached:
                 filename = cached
             if self.anonymous and filename:
-                filename = hash_filename_in_path(Path(filename))
+                filename = str(hash_rel_path(Path(filename)))
 
         # Mirror completed file READ/WRITE into the main fs/VFS trace stream.
         self._mirror_io_uring_to_fs(e, comm, filename, ts, dev_val, fs_type_val)

--- a/src/tracer/IOTracer.py
+++ b/src/tracer/IOTracer.py
@@ -28,12 +28,11 @@ from bcc import BPF
 import time
 import sys
 from bisect import bisect_right
-from pathlib import Path
 from datetime import datetime
 
 from . import schema
 from .ObjectStorageManager import ObjectStorageManager
-from ..utility.utils import capture_machine_id, format_csv_row, logger, hash_rel_path, inet6_from_event, simple_hash, run_with_spinner
+from ..utility.utils import capture_machine_id, format_csv_row, logger, anonymize_path, inet6_from_event, simple_hash, run_with_spinner
 from .WriterManager import WriteManager
 from .FlagMapper import FlagMapper
 from .KernelProbeTracker import KernelProbeTracker
@@ -42,6 +41,16 @@ from .PathResolver import PathResolver
 from .snappers.FilesystemSnapper import FilesystemSnapper
 from .snappers.ProcessSnapper import ProcessSnapper
 from .snappers.SystemSnapper import SystemSnapper
+
+
+# VFS ops that never carry an I/O size; their `size` column is left empty per the
+# schema ("empty for non-I/O ops"). Every other op keeps its numeric size,
+# including a legitimate 0 (e.g. an EOF read or 0-byte write).
+_NON_IO_SIZE_OPS = frozenset({
+    "OPEN", "CLOSE", "GETATTR", "SETATTR", "CHDIR", "READDIR", "UNLINK",
+    "SYNC", "RENAME", "MKDIR", "RMDIR", "LINK", "SYMLINK",
+    "PROCESS_EXEC", "PROCESS_EXIT",
+})
 
 
 class IOTracer:
@@ -272,7 +281,7 @@ class IOTracer:
         try:
             filename = event.filename.decode()
             if self.anonymous:
-                filename = str(hash_rel_path(Path(filename)))
+                filename = anonymize_path(filename)
             if op_name in ['MKDIR', 'RMDIR', 'CHDIR', 'READDIR'] and filename and not filename.endswith('/'):
                 filename += '/'
         except UnicodeDecodeError:
@@ -290,9 +299,11 @@ class IOTracer:
 
         inode_val = event.inode if event.inode != 0 else ""
         
-        # Empty (not 0) for non-I/O ops, matching the schema and the
-        # offset column below; ops that carry a size set event.size > 0.
-        size_val = event.size if event.size else ""
+        # Empty only for non-I/O ops (schema: "empty for non-I/O ops"); I/O ops
+        # keep their numeric size INCLUDING a legitimate 0 (EOF read, 0-byte
+        # write, 0-range fsync). Gating on op type — not truthiness — avoids
+        # blanking real 0-byte I/O.
+        size_val = "" if op_name in _NON_IO_SIZE_OPS else event.size
         address_val = ""
         raw_address = event.address if hasattr(event, 'address') else 0
         if raw_address:
@@ -356,9 +367,9 @@ class IOTracer:
 
         if raw_address:
             if op_name == "MMAP":
-                self._track_mmap_region(event.pid, raw_address, size_val, filename)
+                self._track_mmap_region(event.pid, raw_address, event.size, filename)
             elif op_name == "MUNMAP":
-                resolved_filename = self._resolve_munmap_filename(event.pid, raw_address, size_val)
+                resolved_filename = self._resolve_munmap_filename(event.pid, raw_address, event.size)
                 if resolved_filename:
                     filename = resolved_filename
 
@@ -371,7 +382,7 @@ class IOTracer:
             old_addr_val = event.old_addr if hasattr(event, 'old_addr') else 0
             old_size_val = event.old_size if hasattr(event, 'old_size') else 0
             resolved_filename = self._handle_mremap(
-                event.pid, old_addr_val, old_size_val, raw_address, size_val
+                event.pid, old_addr_val, old_size_val, raw_address, event.size
             )
             if resolved_filename:
                 filename = resolved_filename
@@ -698,8 +709,8 @@ class IOTracer:
             filename_old = event.filename_old.decode()
             filename_new = event.filename_new.decode()
             if self.anonymous:
-                filename_old = str(hash_rel_path(Path(filename_old)))
-                filename_new = str(hash_rel_path(Path(filename_new)))
+                filename_old = anonymize_path(filename_old)
+                filename_new = anonymize_path(filename_new)
         except UnicodeDecodeError:
             filename_old = ""
             filename_new = ""
@@ -1093,7 +1104,7 @@ class IOTracer:
             if cached:
                 filename = cached
             if self.anonymous and filename:
-                filename = str(hash_rel_path(Path(filename)))
+                filename = anonymize_path(filename)
 
         # Mirror completed file READ/WRITE into the main fs/VFS trace stream.
         self._mirror_io_uring_to_fs(e, comm, filename, ts, dev_val, fs_type_val)

--- a/src/tracer/prober/prober.c
+++ b/src/tracer/prober/prober.c
@@ -1608,9 +1608,11 @@ int trace_vfs_fsync_range(struct pt_regs *ctx, struct file *file, loff_t start,
   }
 
   if (end == LLONG_MAX) {
-    range_size = file_size - start;
+    // file_size stays 0 if file/f_inode was unreadable; guard against a
+    // negative (start > file_size) result that would wrap to a huge u64 size.
+    range_size = (file_size > start) ? file_size - start : 0;
   } else {
-    range_size = end - start;
+    range_size = (end > start) ? end - start : 0;
   }
 
   struct data_t data = {};
@@ -2020,8 +2022,13 @@ int trace_vfs_setattr(struct pt_regs *ctx) {
     return 0;
   }
 
-  /* notify_change: arg1 = mnt_idmap*, arg2 = dentry*, arg3 = iattr* */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0)
+  /* >=5.12: notify_change(struct mnt_idmap/user_namespace *, dentry *, iattr *) */
   struct dentry *dentry = (struct dentry *)PT_REGS_PARM2(ctx);
+#else
+  /* <5.12: notify_change(struct dentry *, struct iattr *, ...) — dentry is PARM1 */
+  struct dentry *dentry = (struct dentry *)PT_REGS_PARM1(ctx);
+#endif
   if (!dentry) {
     return 0;
   }
@@ -4839,6 +4846,13 @@ TRACEPOINT_PROBE(syscalls, sys_enter_epoll_ctl) {
   return 0;
 }
 
+/* The legacy select(2)/poll(2)/epoll_wait(2) syscalls (and thus their
+ * syscalls:sys_enter/exit_* tracepoints) exist only on architectures that keep
+ * the old syscall table (x86). arm64 and other asm-generic arches implement
+ * only pselect6/ppoll/epoll_pwait, so referencing these tracepoints there makes
+ * BCC fail the ENTIRE BPF load. Guard them to x86; pselect6 below is handled on
+ * all arches. */
+#if defined(__x86_64__) || defined(__i386__) || defined(bpf_target_x86)
 TRACEPOINT_PROBE(syscalls, sys_enter_epoll_wait) {
   u64 tid = bpf_get_current_pid_tgid();
   u32 pid = tid >> 32;
@@ -4933,6 +4947,7 @@ TRACEPOINT_PROBE(syscalls, sys_exit_select) {
   select_ctx.delete(&tid);
   return 0;
 }
+#endif /* x86-only legacy select/poll/epoll_wait */
 
 /* pselect6() syscall - modern libc select() uses this */
 TRACEPOINT_PROBE(syscalls, sys_enter_pselect6) {

--- a/src/tracer/prober/prober.c
+++ b/src/tracer/prober/prober.c
@@ -4976,6 +4976,79 @@ TRACEPOINT_PROBE(syscalls, sys_exit_pselect6) {
   return 0;
 }
 
+/* ppoll() syscall - modern libc poll() and the only poll on arm64/asm-generic.
+ * Mirrors the poll() handler (reuses poll_ctx); the ppoll timeout is a timespec
+ * we don't record, matching poll()'s behavior. */
+TRACEPOINT_PROBE(syscalls, sys_enter_ppoll) {
+  u64 tid = bpf_get_current_pid_tgid();
+  u32 pid = tid >> 32;
+  u32 config_key = 0;
+  u32 *tracer_pid = tracer_config.lookup(&config_key);
+  if (tracer_pid && pid == *tracer_pid) return 0;
+
+  u64 ts = bpf_ktime_get_ns();
+  poll_ctx.update(&tid, &ts);
+  return 0;
+}
+
+TRACEPOINT_PROBE(syscalls, sys_exit_ppoll) {
+  u64 tid = bpf_get_current_pid_tgid();
+  u64 *start_ts = poll_ctx.lookup(&tid);
+  if (!start_ts) return 0;
+
+  struct epoll_event_data e = {};
+  fill_epoll_common(&e, EPOLL_EV_POLL);
+  e.latency_ns = bpf_ktime_get_ns() - *start_ts;
+  e.ready_count = (s32)args->ret;
+  net_epoll_events.perf_submit(args, &e, sizeof(e));
+  poll_ctx.delete(&tid);
+  return 0;
+}
+
+/* epoll_pwait() syscall - what modern libc epoll_wait() issues, and the only
+ * epoll wait on arm64/asm-generic. Mirrors the epoll_wait() handler (reuses
+ * epoll_wait_ctx/epoll_wait_info); the leading args match epoll_wait. */
+TRACEPOINT_PROBE(syscalls, sys_enter_epoll_pwait) {
+  u64 tid = bpf_get_current_pid_tgid();
+  u32 pid = tid >> 32;
+  u32 config_key = 0;
+  u32 *tracer_pid = tracer_config.lookup(&config_key);
+  if (tracer_pid && pid == *tracer_pid) return 0;
+
+  u64 ts = bpf_ktime_get_ns();
+  epoll_wait_ctx.update(&tid, &ts);
+
+  struct epoll_event_data info = {};
+  info.epoll_fd = (u32)args->epfd;
+  info.max_events = (u32)args->maxevents;
+  info.timeout_ms = (u64)(int)args->timeout;
+  epoll_wait_info.update(&tid, &info);
+  return 0;
+}
+
+TRACEPOINT_PROBE(syscalls, sys_exit_epoll_pwait) {
+  u64 tid = bpf_get_current_pid_tgid();
+  u64 *start_ts = epoll_wait_ctx.lookup(&tid);
+  if (!start_ts) return 0;
+
+  struct epoll_event_data e = {};
+  fill_epoll_common(&e, EPOLL_EV_WAIT);
+  e.latency_ns = bpf_ktime_get_ns() - *start_ts;
+  e.ready_count = (s32)args->ret;
+
+  struct epoll_event_data *info = epoll_wait_info.lookup(&tid);
+  if (info) {
+    e.epoll_fd = info->epoll_fd;
+    e.max_events = info->max_events;
+    e.timeout_ms = info->timeout_ms;
+    epoll_wait_info.delete(&tid);
+  }
+
+  net_epoll_events.perf_submit(args, &e, sizeof(e));
+  epoll_wait_ctx.delete(&tid);
+  return 0;
+}
+
 /* ---- Socket configuration probes ---- */
 
 TRACEPOINT_PROBE(syscalls, sys_enter_setsockopt) {

--- a/src/tracer/snappers/FilesystemSnapper.py
+++ b/src/tracer/snappers/FilesystemSnapper.py
@@ -15,9 +15,8 @@ Example:
     snapper.stop_snapper()  # Stop the snapper
 """
 
-from ...utility.utils import format_csv_row, logger, compress_log, hash_rel_path
+from ...utility.utils import format_csv_row, logger, compress_log, anonymize_path
 from ..WriterManager import WriteManager
-from pathlib import Path
 from datetime import datetime
 import shutil
 import os
@@ -111,9 +110,9 @@ class FilesystemSnapper:
                                     mtime = datetime.fromtimestamp(est.st_mtime)
                                     atime = datetime.fromtimestamp(est.st_atime)
 
-                                    # Anonymize like the live fs stream: preserve
-                                    # directory structure, hash each component.
-                                    hashed_path = str(hash_rel_path(Path(entry.path), keep_ext=True, length=12))
+                                    # Anonymize like the live fs stream: hash every
+                                    # path component (basename included), keep depth.
+                                    hashed_path = anonymize_path(entry.path, keep_ext=True, length=12)
                                     out = format_csv_row(snapshot_timestamp, hashed_path, size, ctime, mtime, atime, snapshot_mono_ns)
                                     self.wm.append_fs_snap_log(out)
                                     count += 1  

--- a/src/tracer/snappers/FilesystemSnapper.py
+++ b/src/tracer/snappers/FilesystemSnapper.py
@@ -15,8 +15,7 @@ Example:
     snapper.stop_snapper()  # Stop the snapper
 """
 
-import random
-from ...utility.utils import format_csv_row, logger, compress_log, hash_rel_path, hash_filename_in_path
+from ...utility.utils import format_csv_row, logger, compress_log, hash_rel_path
 from ..WriterManager import WriteManager
 from pathlib import Path
 from datetime import datetime
@@ -86,8 +85,6 @@ class FilesystemSnapper:
         def scan_dir(path: str, depth: int = 0):
             """Inner function for recursive directory scanning."""
             nonlocal count
-            if random.random() < 0.3:
-                time.sleep(0.02)
             if self.interrupt or (max_depth is not None and depth > max_depth):
                 return
             try:
@@ -114,21 +111,19 @@ class FilesystemSnapper:
                                     mtime = datetime.fromtimestamp(est.st_mtime)
                                     atime = datetime.fromtimestamp(est.st_atime)
 
-                                    rel = Path(os.path.relpath(entry.path, start=self.root_path))
-                                    hashed_rel = hash_rel_path(rel, keep_ext=True, length=12)
-                                    hashed_path = os.path.join(os.sep, str(hashed_rel))
-                                    hashed_path = hash_filename_in_path(Path(hashed_path))
+                                    # Anonymize like the live fs stream: preserve
+                                    # directory structure, hash each component.
+                                    hashed_path = str(hash_rel_path(Path(entry.path), keep_ext=True, length=12))
                                     out = format_csv_row(snapshot_timestamp, hashed_path, size, ctime, mtime, atime, snapshot_mono_ns)
                                     self.wm.append_fs_snap_log(out)
                                     count += 1  
                                 else:
                                     est = entry.stat(follow_symlinks=False)
                                     size = est.st_size
-                                    hashed_path_str = hash_filename_in_path(Path(entry.path))
                                     ctime = datetime.fromtimestamp(getattr(est, "st_birthtime", est.st_mtime))
                                     mtime = datetime.fromtimestamp(est.st_mtime)
                                     atime = datetime.fromtimestamp(est.st_atime)
-                                    out = format_csv_row(snapshot_timestamp, hashed_path_str, size, ctime, mtime, atime, snapshot_mono_ns)
+                                    out = format_csv_row(snapshot_timestamp, entry.path, size, ctime, mtime, atime, snapshot_mono_ns)
                                     self.wm.append_fs_snap_log(out)
                                     count += 1     
                             elif entry.is_dir(follow_symlinks=False):

--- a/src/tracer/snappers/ProcessSnapper.py
+++ b/src/tracer/snappers/ProcessSnapper.py
@@ -97,20 +97,30 @@ class ProcessSnapper:
                 ts = timestamp
                 pid = proc.info['pid']
                 name = proc.info['name'] or ''
-                working_set_size = proc.info['memory_info'].rss / 1024 
-                virtual_mem = proc.info['memory_info'].vms / 1024
-                cmdline = ' '.join(proc.info['cmdline'] or [])
+                # psutil sets an individual attr to None (not raising) when only
+                # that field is unreadable. Read each defensively so a single
+                # missing field yields an empty cell instead of dropping the whole
+                # process row (name/cmdline/status would otherwise be lost too).
+                mem = proc.info.get('memory_info')
+                working_set_size = mem.rss / 1024 if mem else ''
+                virtual_mem = mem.vms / 1024 if mem else ''
+                cmdline = ' '.join(proc.info.get('cmdline') or [])
                 if self.anonymous:
                     cmdline = simple_hash(cmdline, length=12)
-                create_time = float(proc.info['create_time'])
-                status = proc.info.get('status','')
+                raw_create_time = proc.info.get('create_time')
+                create_time = float(raw_create_time) if raw_create_time is not None else None
+                status = proc.info.get('status', '') or ''
 
+                if create_time is not None:
+                    cpu_5s = self.sampler.cpu_percent_for_interval(pid, create_time, 5.0) or 0.0
+                    cpu_2m = self.sampler.cpu_percent_for_interval(pid, create_time, 120.0) or 0.0
+                    cpu_1h = self.sampler.cpu_percent_for_interval(pid, create_time, 3600.0) or 0.0
+                    create_time_str = datetime.fromtimestamp(create_time)
+                else:
+                    cpu_5s = cpu_2m = cpu_1h = 0.0
+                    create_time_str = ''
 
-                cpu_5s = self.sampler.cpu_percent_for_interval(pid, create_time, 5.0) or 0.0
-                cpu_2m = self.sampler.cpu_percent_for_interval(pid, create_time, 120.0) or 0.0
-                cpu_1h = self.sampler.cpu_percent_for_interval(pid, create_time, 3600.0) or 0.0
-
-                out = format_csv_row(ts, pid, name, cmdline, virtual_mem, working_set_size, datetime.fromtimestamp(create_time), cpu_5s, cpu_2m, cpu_1h, status, snapshot_mono_ns)
+                out = format_csv_row(ts, pid, name, cmdline, virtual_mem, working_set_size, create_time_str, cpu_5s, cpu_2m, cpu_1h, status, snapshot_mono_ns)
                 
                 self.wm.append_process_log(out)
             except (psutil.NoSuchProcess, psutil.AccessDenied, psutil.ZombieProcess) as e:

--- a/src/utility/utils.py
+++ b/src/utility/utils.py
@@ -135,6 +135,33 @@ def hash_rel_path(rel: Path, keep_ext: bool = True, length: int = 12) -> Path:
     
     return Path(*hashed_parts)
 
+def anonymize_path(path, keep_ext: bool = True, length: int = 12) -> str:
+    """Anonymize a filesystem path by hashing EVERY component.
+
+    Hashes the basename and all directory components, preserving only a leading
+    root separator ("/") and (optionally) file extensions. Unlike
+    ``hash_rel_path`` — which keeps the first two components in cleartext — this
+    never leaves a component unhashed, so bare basenames (e.g. ``"id_rsa"``) and
+    short relative paths (e.g. ``"proj/key.pem"``) are still fully anonymized.
+    Directory structure (depth) is preserved.
+
+    Example:
+        >>> anonymize_path("/home/alice/.ssh/id_rsa")
+        '/<h>/<h>/<h>/<h>'
+        >>> anonymize_path("id_rsa")
+        '<h>'
+    """
+    parts = list(Path(path).parts)
+    if not parts:
+        return path
+    out = []
+    for i, comp in enumerate(parts):
+        if i == 0 and comp == os.sep:
+            out.append(comp)  # keep the leading "/" so absolute stays absolute
+        else:
+            out.append(hash_component(comp, keep_ext=keep_ext, length=length))
+    return str(Path(*out))
+
 def simple_hash(content: str, length: int = 12) -> str:
     """
     Create a simple SHA-256 hash of a string.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -20,6 +20,7 @@ from src.utility.utils import (
     simple_hash,
     hash_component,
     hash_filename_in_path,
+    anonymize_path,
     inet4_from_event,
 )
 
@@ -65,6 +66,28 @@ class HashTests(unittest.TestCase):
         self.assertTrue(out.startswith("/home/user/"))
         self.assertTrue(out.endswith(".log"))
         self.assertNotIn("secret", out)
+
+    def test_anonymize_path_hashes_every_component(self):
+        out = anonymize_path("/home/alice/clientX/.ssh/id_rsa")
+        self.assertTrue(out.startswith("/"))
+        # No cleartext component survives — not even the first directory.
+        for leaked in ("home", "alice", "clientX", "id_rsa"):
+            self.assertNotIn(leaked, out)
+        # Directory depth (number of separators) is preserved.
+        self.assertEqual(out.count("/"), "/home/alice/clientX/.ssh/id_rsa".count("/"))
+
+    def test_anonymize_path_hashes_bare_basename(self):
+        # The bug this guards against: hash_rel_path left short paths in cleartext.
+        out = anonymize_path("id_rsa")
+        self.assertNotIn("id_rsa", out)
+        out2 = anonymize_path("proj/key.pem")
+        self.assertNotIn("proj", out2)
+        self.assertNotIn("key", out2)
+        self.assertTrue(out2.endswith(".pem"))
+
+    def test_anonymize_path_is_deterministic(self):
+        p = "/var/log/secret.log"
+        self.assertEqual(anonymize_path(p), anonymize_path(p))
 
 
 class InetTests(unittest.TestCase):


### PR DESCRIPTION
## Summary
Fixes eight bugs surfaced by a deeper audit of the eBPF prober, Python event pipeline, and snappers. Closes #50. (Independent of #49.)

| # | Bug | Severity | File |
|---|-----|----------|------|
| 1 | `-a` leaked full directory paths (only basename hashed) | high (privacy) | IOTracer.py |
| 2 | Filesystem snapshot hashed file names even in **normal** mode | high (data) | FilesystemSnapper.py |
| 3 | ProcessSnapper dropped the whole row on one unreadable psutil field | high | ProcessSnapper.py |
| 4 | `random()<0.3: sleep(0.02)` per directory in the snapshot scan | high (perf) | FilesystemSnapper.py |
| 5 | `--network` failed the entire BPF load on aarch64 | high (ARM) | prober.c |
| 6 | `size` column was `0` for non-I/O ops instead of empty | med | IOTracer.py |
| 7 | `notify_change` read wrong arg as dentry on kernels <5.12 | med | prober.c |
| 8 | `vfs_fsync_range` size could underflow to ~2^64 | low/med | prober.c |

## Details

**1.** `hash_filename_in_path` preserved `path.parent` and hashed only the stem, so under `-a` the fs/dual/io_uring streams emitted e.g. `/home/alice/clientX/.ssh/<hash>` — usernames/projects in cleartext. All sites now use `hash_rel_path` (component-wise, ext preserved), matching the snapshot stream. Verified: `/home/alice/clientX/.ssh/id_rsa` → `/home/<h>/<h>/<h>/<h>`.

**2.** The non-anonymous filesystem-snapshot branch called `hash_filename_in_path`, so normal-mode snapshots had hashed basenames (e.g. `a7d973325bfa.jsonl`) — contradicting `docs/traces/FILESYSTEM_SNAPSHOT.md` ("Full file path"). Now emits the real path in normal mode; anon mode uses `hash_rel_path` on the absolute path (dropping a redundant double-hash).

**3.** `proc.info['memory_info'].rss` / `float(proc.info['create_time'])` raised when psutil set those attrs to `None`, and the broad `except` then discarded the entire record. Each field is now read defensively, emitting empty cells for unreadable ones. (Column count unchanged.)

**4.** Removed leftover throttle that slept 20 ms on ~30% of directories — on a multi-million-dir root this added huge wall-clock time and widened the window where a stop request aborts the whole snapshot.

**5.** `sys_enter/exit_select|poll|epoll_wait` tracepoints don't exist on arm64 (asm-generic syscall table → only `pselect6`/`ppoll`/`epoll_pwait`), so BCC failed the whole `BPF()` load with `--network` on ARM. Guarded to x86. (Trade-off: arm64 `--network` loses select/poll/epoll_wait events; `pselect6` is already handled. Adding `ppoll`/`epoll_pwait` for ARM coverage is a reasonable follow-up.)

**6.** `event.size` is a ctypes int (never None) so the old `is not None else 0` always emitted the integer; non-I/O ops now emit empty per the schema, mirroring `offset`.

**7.** `trace_vfs_setattr` always read dentry from `PT_REGS_PARM2` (correct ≥5.12); `<5.12` it is PARM1. Version-guarded like the sibling VFS probes.

**8.** For `end == LLONG_MAX`, `range_size = file_size - start` underflowed to ~2^64 when `i_size` was unreadable (0) and `start>0`; clamped to 0.

## Testing
- `pytest` — 68/68 pass; all changed Python compiles.
- Anonymization fix verified manually (dir components now hashed, deterministic, ext kept).
- ⚠️ The eBPF C changes (#5, #7, #8) are **not** compile-tested — needs `clang` + BCC + root, unavailable here. They are `#if/#endif`-balanced (43→45 pairs) and brace-balanced. Please do one `sudo iotrc dev --no-upload` (and one with `--network` on both x86 and arm64) before merging.

## Not bugs (investigated, so they aren't re-chased)
dev_t decoding (correct/consistent); shutdown `os.removedirs` (only removes empty dirs, wrapped in try/except — no data deletion); process_exec ≪ process_exit (per-thread exits, expected); CSV quoting (robust via `csv.writer`); errno/fs_type fallbacks (graceful).
