### PR TITLE
Fix periodic-flush event-loss race, unbounded upload requeue, fatal probe-attach; add smoke test

### DIFF
--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+#
+# smoke_test.sh — verify the eBPF program compiles, loads, and produces output.
+#
+# The tracer's BPF C cannot be statically verified; the only real check is to
+# load it on the target kernel/arch. This runs iotrc briefly (no upload) in a
+# few configurations, generates some I/O, then confirms:
+#   * the BPF program compiled and attached (no verifier/attach errors), and
+#   * trace shards were written with the expected CSV header.
+#
+# Run on BOTH x86_64 and aarch64, since several probes/tracepoints are
+# arch-specific (legacy select/poll/epoll_wait vs pselect6/ppoll/epoll_pwait,
+# openat/mremap syscall wrappers, etc.).
+#
+# Usage:  sudo bash scripts/smoke_test.sh [run_seconds]
+#
+set -u
+
+RUN_SECONDS="${1:-20}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PYTHON="${PYTHON:-python3}"
+ARCH="$(uname -m)"
+KREL="$(uname -r)"
+FAIL=0
+
+if [[ "$(id -u)" -ne 0 ]]; then
+  echo "ERROR: must run as root (sudo)." >&2
+  exit 1
+fi
+
+echo "=== io-tracer smoke test ==="
+echo "arch=$ARCH kernel=$KREL repo=$REPO_ROOT run_seconds=$RUN_SECONDS"
+
+# Prerequisite: bcc must be importable, else nothing can load.
+if ! "$PYTHON" -c "import bcc" 2>/dev/null; then
+  echo "ERROR: python module 'bcc' not importable — install bpfcc-tools/python3-bpfcc." >&2
+  exit 1
+fi
+
+# Generate filesystem + block + sendfile activity while the tracer runs.
+generate_io() {
+  local d; d="$(mktemp -d)"
+  ( for i in $(seq 1 "$RUN_SECONDS"); do
+      ls -R /usr >/dev/null 2>&1
+      dd if=/dev/zero of="$d/f" bs=1M count=8 oflag=direct 2>/dev/null
+      cat "$d/f" >/dev/null 2>&1
+      cp "$d/f" "$d/f.copy" 2>/dev/null   # may use sendfile/copy_file_range
+      sync
+      rm -f "$d/f.copy"
+      sleep 1
+    done; rm -rf "$d" ) &
+  echo $!
+}
+
+# run_one <label> <extra iotrc flags...>
+run_one() {
+  local label="$1"; shift
+  local out; out="$(mktemp)"
+  local tmphome; tmphome="$(mktemp -d)"   # iotrc writes under $TMPDIR/linux_trace
+  echo
+  echo "--- config: $label  (flags: $* ) ---"
+
+  # Run the tracer in its own session so we can signal it cleanly.
+  TMPDIR="$tmphome" setsid "$PYTHON" "$REPO_ROOT/iotrc.py" --no-upload "$@" \
+      >"$out" 2>&1 &
+  local pid=$!
+
+  local iopid; iopid="$(generate_io)"
+  sleep "$RUN_SECONDS"
+
+  # Ask the tracer to stop (it installs SIGINT/SIGTERM handlers to flush).
+  kill -INT "-$pid" 2>/dev/null || kill -INT "$pid" 2>/dev/null
+  for _ in $(seq 1 30); do kill -0 "$pid" 2>/dev/null || break; sleep 1; done
+  kill -KILL "$pid" 2>/dev/null
+  wait "$iopid" 2>/dev/null
+
+  local ok=1
+
+  # 1) BPF must have compiled & attached — look for the telltale failures.
+  if grep -Eiq "failed to (load|attach|compile)|Traceback|verifier|Invalid argument|No such file or directory.*kprobe|Exception" "$out"; then
+    echo "  [FAIL] error signatures in tracer output:"
+    grep -Ei "failed to (load|attach|compile)|Traceback|verifier|Invalid argument|Exception" "$out" | sed 's/^/      /' | head -8
+    ok=0
+  else
+    echo "  [ok] no load/attach/verifier errors"
+  fi
+
+  # 2) Trace shards must exist with the right header.
+  local fsfile
+  fsfile="$(find "$tmphome" -path '*/fs/fs_*' 2>/dev/null | head -1)"
+  if [[ -n "$fsfile" ]]; then
+    local hdr
+    if [[ "$fsfile" == *.zst ]]; then
+      hdr="$(zstd -dc "$fsfile" 2>/dev/null | head -1)"
+    else
+      hdr="$(head -1 "$fsfile")"
+    fi
+    if [[ "$hdr" == timestamp,operation,pid,* ]]; then
+      echo "  [ok] fs shard written, header looks correct"
+    else
+      echo "  [FAIL] fs shard header unexpected: ${hdr:0:60}"
+      ok=0
+    fi
+  else
+    echo "  [FAIL] no fs trace shard produced under $tmphome"
+    ok=0
+  fi
+
+  # Network config: confirm at least one nw_* shard appeared.
+  if [[ "$*" == *--network* ]]; then
+    if find "$tmphome" -path '*/nw_*' | grep -q .; then
+      echo "  [ok] network shards produced"
+    else
+      echo "  [warn] --network set but no nw_* shards (may just be no traffic)"
+    fi
+  fi
+
+  [[ "$ok" -eq 1 ]] && echo "  RESULT: PASS ($label)" || { echo "  RESULT: FAIL ($label)"; FAIL=1; }
+  echo "  (tracer log: $out)"
+  rm -rf "$tmphome"
+}
+
+run_one "default"
+run_one "network"  --network
+run_one "cache"    --cache
+
+echo
+if [[ "$FAIL" -eq 0 ]]; then
+  echo "=== SMOKE TEST PASSED on $ARCH ($KREL) ==="
+  exit 0
+else
+  echo "=== SMOKE TEST FAILED on $ARCH ($KREL) — inspect the tracer logs above ==="
+  exit 1
+fi

--- a/src/tracer/KernelProbeTracker.py
+++ b/src/tracer/KernelProbeTracker.py
@@ -76,10 +76,8 @@ class KernelProbeTracker:
             kprobe: Name of the BPF function to call when probe triggers
             
         Returns:
-            bool: True if attachment succeeded, False otherwise
-            
-        Raises:
-            SystemExit: If probe attachment fails
+            bool: True if attachment succeeded, False otherwise (best-effort —
+            a probe that cannot attach is skipped, not fatal).
         """
         try:
             # logger("info", f"Attaching kprobe {event} to {kprobe}")
@@ -87,8 +85,11 @@ class KernelProbeTracker:
             self.kprobes.append((event, k))
             return True
         except Exception as e:
-            logger("error", f"Failed to attach kprobe {event}: {e}")
-            sys.exit(1)
+            # Best-effort: a single missing/un-kprobe-able symbol (inlined, or
+            # renamed across kernels/arches — many call sites here have no arch
+            # fallback) must not abort the whole tracer. Skip it and continue;
+            # attach_probes() aborts only if NOTHING attached (see its tail).
+            logger("warning", f"Failed to attach kprobe {event} (skipping): {e}")
             return False
 
     def add_kretprobe(self, event: str, kprobe: str) -> bool:
@@ -100,10 +101,8 @@ class KernelProbeTracker:
             kprobe: Name of the BPF function to call when probe triggers
             
         Returns:
-            bool: True if attachment succeeded, False otherwise
-            
-        Raises:
-            SystemExit: If probe attachment fails
+            bool: True if attachment succeeded, False otherwise (best-effort —
+            a probe that cannot attach is skipped, not fatal).
         """
         try:
             # logger("info", f"Attaching kprobe {event} to {kprobe}")
@@ -111,8 +110,9 @@ class KernelProbeTracker:
             self.kretprobes.append((event, k))
             return True
         except Exception as e:
-            logger("error", f"Failed to attach kretprobe {event}: {e}")
-            sys.exit(1)
+            # Best-effort, as in add_kprobe: skip a probe that can't attach on
+            # this kernel/arch rather than killing the entire tracing session.
+            logger("warning", f"Failed to attach kretprobe {event} (skipping): {e}")
             return False
         
     def detach_kprobes(self):

--- a/src/tracer/ObjectStorageManager.py
+++ b/src/tracer/ObjectStorageManager.py
@@ -72,6 +72,12 @@ class ObjectStorageManager:
         self.successful_upload = 0
         self.app_version = version
         self.trace_bucket = trace_bucket
+        # Per-file upload attempt counts. A permanently-failing ("poison") shard
+        # is dropped after MAX_UPLOAD_ATTEMPTS instead of being requeued forever
+        # — an unbounded requeue both hot-spins the worker and prevents
+        # clean_queue()/stop_worker() from ever draining the queue.
+        self._attempts: dict[str, int] = {}
+        self.MAX_UPLOAD_ATTEMPTS = 5
 
 
     def test_connection(self) -> bool:
@@ -195,14 +201,29 @@ class ObjectStorageManager:
             try:
                 self.put_object(fp)
                 backoff = 1  # Reset backoff after success
+                self._attempts.pop(fp, None)
             except FileNotFoundError as e:
                 # File was already uploaded and deleted, don't requeue
                 logger("debug", f"File already uploaded: {str(e)}")
+                self._attempts.pop(fp, None)
             except Exception as e:
-                logger("warn", f"Upload error: {str(e)}. Requeueing.")
-                self.file_queue.put(fp)
-                self._stop.wait(backoff)
-                backoff = min(backoff * 2, 10)
+                attempts = self._attempts.get(fp, 0) + 1
+                self._attempts[fp] = attempts
+                if attempts >= self.MAX_UPLOAD_ATTEMPTS:
+                    # Give up on this shard rather than requeue forever (which
+                    # would spin the worker and block queue drain on shutdown).
+                    # The local file is left on disk for a later manual retry.
+                    self._attempts.pop(fp, None)
+                    logger("error",
+                           f"Upload of {fp} failed {attempts} times; giving up "
+                           f"(kept locally): {str(e)}")
+                else:
+                    logger("warn",
+                           f"Upload error ({attempts}/{self.MAX_UPLOAD_ATTEMPTS}): "
+                           f"{str(e)}. Requeueing.")
+                    self.file_queue.put(fp)
+                    self._stop.wait(backoff)
+                    backoff = min(backoff * 2, 10)
             finally:
                 self.file_queue.task_done()
 

--- a/src/tracer/WriterManager.py
+++ b/src/tracer/WriterManager.py
@@ -930,20 +930,6 @@ class WriteManager:
             self.compress_dir(self.output_dir)
 
 
-    def clear_events(self):
-        """Clear all event buffers."""
-        print("Clear initiated")
-        self.vfs_buffer.clear()
-        self.block_buffer.clear() 
-        self.cache_buffer.clear()
-        self.process_buffer.clear()
-        self.fs_snap_buffer.clear()
-        self.pagefault_buffer.clear()
-        self.nw_conn_buffer.clear()
-        self.nw_epoll_buffer.clear()
-        self.nw_sockopt_buffer.clear()
-        self.nw_drop_buffer.clear()
-
     def _write_buffer_to_file(self, buffer, file_handle, buffer_name: str):
         """
         Write buffer contents to a file handle.
@@ -1078,7 +1064,11 @@ class WriteManager:
         for thread in threads:
             thread.join()
 
-        self.clear_events()
+        # NOTE: do NOT clear_events() here. Each write_*() above already drained
+        # its buffer (popleft under the stream lock). A blanket buffer.clear()
+        # would additionally wipe rows appended by the lock-free append_*() path
+        # in the window between a stream's drain and the clear — silently losing
+        # events on every periodic flush. The drain is the only emptying needed.
 
     def compress_log(self, input_file: str):
         """


### PR DESCRIPTION
## Summary
Fixes three issues found auditing the modules **not** touched by #49/#51, plus a smoke-test script to validate that the eBPF actually loads. Closes #52. All changes are pure-Python (no eBPF C touched). `pytest`: 71 passed.

| # | Fix | Severity | File |
|---|-----|----------|------|
| 1 | Periodic flush silently dropped events (lock-free `clear_events` race) | high | WriterManager.py |
| 2 | Failing upload requeued forever → worker spin + shutdown hang | med | ObjectStorageManager.py |
| 3 | One un-attachable probe `sys.exit(1)`'d the whole tracer | high (esp. aarch64) | KernelProbeTracker.py |

### 1 — WriterManager event-loss race
`write_to_disk()` drains every buffer under its per-stream lock, then called `clear_events()` (a lock-free `buffer.clear()` on all 10 buffers). `append_*_log()` appends **lock-free** from the perf-callback thread, so any row appended between a stream's drain and the clear was wiped — steady loss on every 5-min `_periodic_flush`. The clear was also redundant (drain already empties via `popleft`). Removed the call and the dead method.

### 2 — ObjectStorageManager unbounded requeue
On any upload exception the worker did `file_queue.put(fp)` with no cap → a poison shard loops forever, hot-spinning and keeping `unfinished_tasks > 0` so `clean_queue()`/`stop_worker(server_mode=True)` blocks the whole shutdown. Added a per-file attempt counter; after `MAX_UPLOAD_ATTEMPTS` (5) the shard is dropped (left on disk for manual retry) instead of requeued.

### 3 — KernelProbeTracker best-effort attach
`add_kprobe`/`add_kretprobe` called `sys.exit(1)` on **any** attach failure. Many core probes (`do_truncate`, `vfs_fallocate`, `notify_change`, `__vm_munmap`, …) have no arch/kernel fallback, so one inlined/renamed/arch-absent symbol killed the entire session — contradicting the **unreachable** best-effort guard `if not self.kprobes: sys.exit(1)` at the end of `attach_probes()`. Made the helpers best-effort (warn + return False); the tail guard still aborts only if nothing attached. (Behavior change: the tracer now degrades gracefully instead of aborting — relevant on aarch64 where the x64-only fallback chains can miss.)

### scripts/smoke_test.sh
`sudo bash scripts/smoke_test.sh` loads the BPF (default, `--network`, `--cache`), generates I/O, and confirms shards are written with the correct header — the only real check for eBPF that can't be statically verified. **Run on x86_64 and aarch64.** This is the verification step the prior PRs (#49/#51) asked for.

## Reported (not fixed here — need a real run / backend / redesign), see #52
- OSM deletes the local shard on any 2xx with no size/ETag check (durability hole on truncated PUTs).
- kretprobes attached with no `maxactive` → dropped completions under load (one-liner, but changes the attach call → wants a real run).
- Periodic flush drains snapshot buffers mid-session (snapshot-splitting; removing `clear_events` stops the loss but not the split).
- Lock-free `append_*`/`should_flush` check-then-act; PollingThread hot-spin on persistent error; KPT `__arm64_sys_*` fallback gap.
