### PR TITLE
Reconstruct readdir directory path via bounded d_parent walk (prototype)

### DIFF
--- a/src/tracer/prober/prober.c
+++ b/src/tracer/prober/prober.c
@@ -1123,12 +1123,20 @@ static int get_file_path_from_dentry(struct dentry *dentry, char *buf,
 #define DPATH_MAX_DEPTH 12
 #define DPATH_MASK (FILENAME_MAX_LEN - 1)
 
+/* Per-CPU scratch for the component-pointer chain — kept off the BPF stack,
+ * which is only 512 bytes and already mostly consumed by struct data_t. */
+struct dpath_scratch { const unsigned char *names[DPATH_MAX_DEPTH]; };
+BPF_PERCPU_ARRAY(dpath_scratch_map, struct dpath_scratch, 1);
+
 static __always_inline void build_dentry_path(struct dentry *dentry,
                                               char *buf, int buf_size) {
   buf[0] = '\0';
   if (!dentry) return;
 
-  const unsigned char *names[DPATH_MAX_DEPTH];
+  u32 zero = 0;
+  struct dpath_scratch *sc = dpath_scratch_map.lookup(&zero);
+  if (!sc) return;
+
   int n = 0;
   struct dentry *d = dentry;
 
@@ -1138,7 +1146,7 @@ static __always_inline void build_dentry_path(struct dentry *dentry,
     const unsigned char *np = NULL;
     bpf_probe_read_kernel(&parent, sizeof(parent), &d->d_parent);
     bpf_probe_read_kernel(&np, sizeof(np), &d->d_name.name);
-    names[i] = np;
+    sc->names[i] = np;
     n = i + 1;
     if (!parent || parent == d) break;   /* reached the (mount) root */
     d = parent;
@@ -1148,7 +1156,7 @@ static __always_inline void build_dentry_path(struct dentry *dentry,
 #pragma unroll
   for (int i = DPATH_MAX_DEPTH - 1; i >= 0; i--) {
     if (i >= n) continue;
-    const unsigned char *np = names[i];
+    const unsigned char *np = sc->names[i];
     if (!np) continue;
 
     if (off < buf_size - 1) {            /* component separator */

--- a/src/tracer/prober/prober.c
+++ b/src/tracer/prober/prober.c
@@ -1108,6 +1108,63 @@ static int get_file_path_from_dentry(struct dentry *dentry, char *buf,
   return 0;
 }
 
+/* Bounded reconstruction of a path by walking the dentry's d_parent chain.
+ *
+ * The kernel stores only the basename in d_name; bpf_d_path() would give the
+ * full path but is restricted to an attach-point allowlist that excludes the
+ * probes that need it (readdir/unlink/rename/...). So we walk up to
+ * DPATH_MAX_DEPTH parents and emit the deepest components as "/c1/c2/.../leaf".
+ *
+ * Limitations (documented for consumers): does NOT cross mount points (path is
+ * relative to the file's own mount root), and truncates to the last
+ * DPATH_MAX_DEPTH components on very deep paths. FILENAME_MAX_LEN is a power of
+ * two so masking the write offset keeps the verifier happy.
+ */
+#define DPATH_MAX_DEPTH 12
+#define DPATH_MASK (FILENAME_MAX_LEN - 1)
+
+static __always_inline void build_dentry_path(struct dentry *dentry,
+                                              char *buf, int buf_size) {
+  buf[0] = '\0';
+  if (!dentry) return;
+
+  const unsigned char *names[DPATH_MAX_DEPTH];
+  int n = 0;
+  struct dentry *d = dentry;
+
+#pragma unroll
+  for (int i = 0; i < DPATH_MAX_DEPTH; i++) {
+    struct dentry *parent = NULL;
+    const unsigned char *np = NULL;
+    bpf_probe_read_kernel(&parent, sizeof(parent), &d->d_parent);
+    bpf_probe_read_kernel(&np, sizeof(np), &d->d_name.name);
+    names[i] = np;
+    n = i + 1;
+    if (!parent || parent == d) break;   /* reached the (mount) root */
+    d = parent;
+  }
+
+  int off = 0;
+#pragma unroll
+  for (int i = DPATH_MAX_DEPTH - 1; i >= 0; i--) {
+    if (i >= n) continue;
+    const unsigned char *np = names[i];
+    if (!np) continue;
+
+    if (off < buf_size - 1) {            /* component separator */
+      buf[off & DPATH_MASK] = '/';
+      off++;
+    }
+    int pos = off & DPATH_MASK;          /* 0..buf_size-1 */
+    int cap = buf_size - pos;            /* pos + cap == buf_size, so in-bounds */
+    if (cap > 1) {
+      long w = bpf_probe_read_kernel_str(&buf[pos], cap, np);
+      if (w > 1) off = pos + (int)(w - 1);   /* advance past name, exclude NUL */
+    }
+  }
+  buf[off & DPATH_MASK] = '\0';
+}
+
 /**
  * @brief Populate cache event metadata from inode
  *
@@ -2155,7 +2212,11 @@ int trace_readdir(struct pt_regs *ctx, struct file *file,
   data.op = OP_READDIR;
   data.inode = get_file_inode(file);
   data.size = 0;
-  get_file_path(file, data.filename, sizeof(data.filename));
+  /* readdir only ever had the basename; reconstruct the directory path by
+   * walking d_parent so directory-traversal activity is attributable. */
+  struct dentry *rd_dentry = NULL;
+  bpf_probe_read_kernel(&rd_dentry, sizeof(rd_dentry), &file->f_path.dentry);
+  build_dentry_path(rd_dentry, data.filename, sizeof(data.filename));
   bpf_probe_read_kernel(&data.flags, sizeof(data.flags), &file->f_flags);
 
   events.perf_submit(ctx, &data, sizeof(data));


### PR DESCRIPTION
## Background
VFS records mostly **don't** carry a full path. Measured on the v4 trace: 20.8% absolute, 60.2% basename/relative, 19.1% empty — and it's per-op: `open` 99.9% full and `read` 85.9% full (via the userspace OPEN→inode cache), but `readdir` **99.8% basename-only**, and `unlink`/`rename`/`mkdir`/`setattr`/`link` ~100% basename. Root cause: the in-kernel helpers (`get_file_path`, `get_file_path_from_dentry`) read only `dentry->d_name.name` (the basename).

## Feasibility findings
- **`bpf_d_path()` is not usable here.** It would give the full path in-kernel, but the kernel restricts it to an attach-point allowlist (`vfs_getattr`/`vfs_truncate`/`filp_close`/`dentry_open`/security hooks) that **excludes `iterate_dir`, `vfs_read`/`vfs_write`, `vfs_unlink`/`vfs_rename`/`vfs_mkdir`** — exactly the probes that lack a path. So it can't help the weak spots.
- **A bounded `d_parent` walk works in any kprobe** (no allowlist) and the eBPF verifier accepts it — validated by the `bpf-compile` CI here.

## This PR (prototype, scoped to readdir)
Adds `build_dentry_path()`: walks up to `DPATH_MAX_DEPTH` (12) `d_parent` levels and emits the deepest components as `/c1/.../leaf`. Wired into `trace_readdir` (the worst case: 99.8% basename). Scratch component-chain is held in a **per-cpu array map**, not on the stack (the first CI run caught a 512-byte stack overflow on top of `struct data_t` — fixed).

### Limitations (intentional, documented in-code)
- **Does not cross mount points** — the path is relative to the file's own mount root (e.g. a file on a separate `/home` or `/netscratch` mount yields the in-mount path, not the global path). Crossing mounts needs `vfsmount`/`mnt_parent` walking like `bpf_d_path` does.
- **Truncates to the last 12 components** on very deep paths.
- Root component may render as a leading `//`; trivially normalized in userspace.

## Validation
- `bpf-compile` CI: **compiles + verifier-loads on a real kernel** ✅
- `unit-tests` ✅

## If this looks good, next steps (separate PRs)
1. Apply `build_dentry_path()` to the namespace ops (`unlink`/`rename`/`mkdir`/`rmdir`/`link`/`setattr`) which today get only the basename via `get_file_path_from_dentry`.
2. Optionally use it as the `read`/`write` fallback when the userspace inode-cache misses (the ~14% of reads with no path).
3. Consider mount-crossing (walk `vfsmount`) if global paths are needed for multi-mount hosts like this one.

Deliberately kept to `readdir` only so the verifier/throughput impact of the walk can be evaluated on a real run before expanding.
