### PR TITLE
Change default trace bucket to io-tracer/linux_v1

### DIFF
--- a/iotrc.py
+++ b/iotrc.py
@@ -26,7 +26,7 @@ Options:
     --no-upload               Disable automatic upload of traces
 
 Dev Options (only available with 'dev' subcommand):
-    --trace-bucket NAME       Override upload bucket name (default: linux_trace_v4_test)
+    --trace-bucket NAME       Override upload bucket name (default: io-tracer/linux_v1)
 
 Examples:
     # Run with default settings
@@ -97,7 +97,7 @@ if __name__ == "__main__":
     dev_parser.add_argument('--cache', action='store_true', help='Force-enable page-cache event tracing (higher overhead; otherwise auto-enabled when the host has enough CPU and DRAM)')
     dev_parser.add_argument('--network', action='store_true', help='Force-enable network event tracing: connection lifecycle, epoll, sockopt, drops (otherwise auto-enabled when the host has enough CPU, DRAM and network)')
     dev_parser.add_argument('--no-upload', action='store_true', help='Disable automatic upload of traces (for testing)')
-    dev_parser.add_argument('--trace-bucket', type=str, default=None, help='Override upload bucket name (default: linux_trace_v4_test)')
+    dev_parser.add_argument('--trace-bucket', type=str, default=None, help='Override upload bucket name (default: io-tracer/linux_v1)')
 
     parse_args = parser.parse_args()
     output_dir = tempfile.gettempdir()

--- a/iotrc.py
+++ b/iotrc.py
@@ -26,7 +26,7 @@ Options:
     --no-upload               Disable automatic upload of traces
 
 Dev Options (only available with 'dev' subcommand):
-    --trace-bucket NAME       Override upload bucket name (default: io-tracer/linux_v1)
+    --trace-bucket NAME       Override upload bucket name (default: linux_v1)
 
 Examples:
     # Run with default settings
@@ -97,7 +97,7 @@ if __name__ == "__main__":
     dev_parser.add_argument('--cache', action='store_true', help='Force-enable page-cache event tracing (higher overhead; otherwise auto-enabled when the host has enough CPU and DRAM)')
     dev_parser.add_argument('--network', action='store_true', help='Force-enable network event tracing: connection lifecycle, epoll, sockopt, drops (otherwise auto-enabled when the host has enough CPU, DRAM and network)')
     dev_parser.add_argument('--no-upload', action='store_true', help='Disable automatic upload of traces (for testing)')
-    dev_parser.add_argument('--trace-bucket', type=str, default=None, help='Override upload bucket name (default: io-tracer/linux_v1)')
+    dev_parser.add_argument('--trace-bucket', type=str, default=None, help='Override upload bucket name (default: linux_v1)')
 
     parse_args = parser.parse_args()
     output_dir = tempfile.gettempdir()

--- a/src/tracer/ObjectStorageManager.py
+++ b/src/tracer/ObjectStorageManager.py
@@ -51,13 +51,13 @@ class ObjectStorageManager:
         _t: List of worker threads
     """
     
-    def __init__(self, version: str = "vdev", trace_bucket: str = "linux_trace_v4_test"):
+    def __init__(self, version: str = "vdev", trace_bucket: str = "io-tracer/linux_v1"):
         """
         Initialize the ObjectStorageManager.
 
         Args:
             version: Application version string (default: "vdev")
-            trace_bucket: Storage bucket/path prefix for uploads (default: "linux_trace_v4_test")
+            trace_bucket: Storage bucket/path prefix for uploads (default: "io-tracer/linux_v1")
 
         Initializes the upload queue, counters, and prepares
         for automatic upload operations.

--- a/src/tracer/ObjectStorageManager.py
+++ b/src/tracer/ObjectStorageManager.py
@@ -51,13 +51,13 @@ class ObjectStorageManager:
         _t: List of worker threads
     """
     
-    def __init__(self, version: str = "vdev", trace_bucket: str = "io-tracer/linux_v1"):
+    def __init__(self, version: str = "vdev", trace_bucket: str = "linux_v1"):
         """
         Initialize the ObjectStorageManager.
 
         Args:
             version: Application version string (default: "vdev")
-            trace_bucket: Storage bucket/path prefix for uploads (default: "io-tracer/linux_v1")
+            trace_bucket: Storage bucket/path prefix for uploads (default: "linux_v1")
 
         Initializes the upload queue, counters, and prepares
         for automatic upload operations.


### PR DESCRIPTION
## Summary
Changes the default upload bucket from `linux_trace_v4_test` to `io-tracer/linux_v1`.

## Changes
- `src/tracer/ObjectStorageManager.py`: updated `trace_bucket` default in `__init__` and its docstring
- `iotrc.py`: updated the `--trace-bucket` help text / usage default in both the docstring and the argparse argument

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Txuf9y5xrNPPoMa2f8syXd

---
_Generated by [Claude Code](https://claude.ai/code/session_01Txuf9y5xrNPPoMa2f8syXd)_