### PR TITLE
fs_snapshot: upload only deltas after the first full snapshot

### DIFF
--- a/docs/MULTIPART_FILESYSTEM_SNAPSHOT.md
+++ b/docs/MULTIPART_FILESYSTEM_SNAPSHOT.md
@@ -4,6 +4,36 @@
 
 The filesystem snapshot feature now supports splitting large filesystem scans into multiple compressed parts to optimize memory usage.
 
+## Delta Snapshots
+
+To avoid re-uploading the entire filesystem inventory on every hourly pass, the
+snapper is **delta-based after the first run**:
+
+- The **first** snapshot of a session is a *full* inventory of every file.
+- **Every subsequent** snapshot is a *delta*: a file is recorded only if it was
+  **added** or **modified** (its size, `mtime`, or `ctime` changed) since the
+  previous completed snapshot. Access time (`atime`) is intentionally excluded
+  from the change check because it changes on every read.
+- A file that **disappeared** since the previous snapshot is recorded as a
+  *tombstone* row whose `size` is `-1` (`FilesystemSnapper.DELETED_SIZE`),
+  letting consumers distinguish removals from added/modified files (which always
+  carry a real, non-negative byte count).
+- A delta with **no changes** produces no rows, so nothing is flushed or
+  uploaded for that pass.
+
+### Baseline tracking
+
+The snapper keeps the most recent *completed* full scan in memory as the
+baseline for the next delta. An interrupted scan never advances the baseline,
+so after an interruption the next completed pass is diffed against the last
+good snapshot (and the first ever snapshot is always full).
+
+### Reconstructing state from deltas
+
+To reconstruct the filesystem state at snapshot *k*: start from the full
+inventory (snapshot 0) and apply each delta `1..k` in order — added/modified
+rows overwrite the entry for that path, tombstone rows (`size == -1`) remove it.
+
 ## How It Works
 
 ### File Naming Convention

--- a/docs/MULTIPART_FILESYSTEM_SNAPSHOT.md
+++ b/docs/MULTIPART_FILESYSTEM_SNAPSHOT.md
@@ -28,6 +28,16 @@ baseline for the next delta. An interrupted scan never advances the baseline,
 so after an interruption the next completed pass is diffed against the last
 good snapshot (and the first ever snapshot is always full).
 
+### Transient errors vs. real deletions
+
+Deletion detection distinguishes "the path is gone" from "we couldn't read it
+this pass". A file or directory that fails to `stat()`/`scandir()` with a
+*transient* error (e.g. `PermissionError`, an I/O error) has its previous state
+carried forward, so it is **not** falsely tombstoned. Only paths that are
+genuinely absent — `FileNotFoundError`/`NotADirectoryError`, or a path missing
+from a directory that *was* fully scanned — become tombstones. Removing an
+entire directory therefore still tombstones every file under it.
+
 ### Reconstructing state from deltas
 
 To reconstruct the filesystem state at snapshot *k*: start from the full

--- a/src/tracer/snappers/FilesystemSnapper.py
+++ b/src/tracer/snappers/FilesystemSnapper.py
@@ -97,6 +97,13 @@ class FilesystemSnapper:
         ``DELETED_SIZE``). access time (atime) is deliberately excluded from the
         change check since it changes on every read.
 
+        Deletion detection distinguishes a genuine removal from a transient
+        read failure: if a file or directory cannot be stat'd/scanned because of
+        a transient error (e.g. a permission error), its previous state is
+        carried forward so it is not falsely tombstoned. Only paths that are
+        actually absent (or whose containing directory was fully scanned without
+        them) become tombstones.
+
         Args:
             max_depth: Maximum directory depth to traverse (default: None = unlimited)
 
@@ -132,13 +139,37 @@ class FilesystemSnapper:
             self.wm.append_fs_snap_log(out)
             count += 1
 
+        def is_transient(exc: Exception) -> bool:
+            """True for errors that mean "couldn't read it this pass" rather than
+            "it's gone". A transient failure (e.g. PermissionError, an I/O error,
+            or a momentary lock) must not be mistaken for a deletion; an absence
+            error (the path really vanished) should fall through to a tombstone.
+            """
+            return not isinstance(exc, (FileNotFoundError, NotADirectoryError))
+
+        def carry_over_subtree(dir_path: str):
+            """Preserve the previous snapshot's entries under ``dir_path`` so a
+            directory we transiently failed to read is not mistaken for the
+            deletion of everything inside it. ``setdefault`` avoids clobbering
+            entries already captured this pass (e.g. before a mid-scan failure).
+            """
+            prefix = dir_path if dir_path.endswith(os.sep) else dir_path + os.sep
+            for p, meta in self._prev_state.items():
+                if p.startswith(prefix):
+                    new_state.setdefault(p, meta)
+
         def scan_dir(path: str, depth: int = 0):
             """Inner function for recursive directory scanning."""
             if self.interrupt or (max_depth is not None and depth > max_depth):
                 return
             try:
                 st = os.stat(path, follow_symlinks=False)
-            except Exception:
+            except Exception as e:
+                # Couldn't stat the directory itself. Only carry its contents
+                # forward when the failure is transient; if it genuinely no
+                # longer exists, let its files fall through to tombstones.
+                if is_delta and is_transient(e):
+                    carry_over_subtree(path)
                 return
 
             key = (st.st_dev, st.st_ino)
@@ -170,9 +201,21 @@ class FilesystemSnapper:
                                 emit(entry.path, size, mtime_ts, ctime_ts, atime_ts)
                             elif entry.is_dir(follow_symlinks=False):
                                 scan_dir(entry.path, depth + 1)
-                        except Exception:
+                        except Exception as e:
+                            # Couldn't read this entry. On a transient failure
+                            # keep its previous state so a file we merely failed
+                            # to stat is not reported as deleted; a genuinely
+                            # missing entry falls through to the deletion pass.
+                            if is_delta and is_transient(e):
+                                prev = self._prev_state.get(entry.path)
+                                if prev is not None:
+                                    new_state.setdefault(entry.path, prev)
                             continue
-            except Exception:
+            except Exception as e:
+                # Couldn't list the directory's contents. Same rule: carry the
+                # subtree forward on a transient failure, tombstone on absence.
+                if is_delta and is_transient(e):
+                    carry_over_subtree(path)
                 return
 
         logger("info", f"Filesystem Snapshot: session started ({'delta' if is_delta else 'full'})")

--- a/src/tracer/snappers/FilesystemSnapper.py
+++ b/src/tracer/snappers/FilesystemSnapper.py
@@ -9,6 +9,13 @@ The snapper can operate in two modes:
 - Normal: Records actual file paths
 - Anonymous: Records hashed/anonymized paths
 
+To avoid re-uploading the entire filesystem inventory on every hourly pass,
+the snapper is delta-based after the first run: the first snapshot is a full
+inventory of every file, and each subsequent snapshot records only the files
+that were added, modified, or deleted since the previous completed snapshot.
+Deleted files are recorded as a tombstone row whose size is ``DELETED_SIZE``
+(-1). A delta with no changes produces no output (and therefore no upload).
+
 Example:
     snapper = FilesystemSnapper(writer_manager=wm, anonymous=False)
     snapper.run()  # Start snapshot in background thread
@@ -22,6 +29,13 @@ import shutil
 import os
 import time
 import threading
+
+
+# Size value written for a file that disappeared since the previous snapshot.
+# In delta snapshots a deleted file is emitted as a tombstone row carrying this
+# sentinel so consumers can distinguish removals from added/modified files
+# (which always carry a real, non-negative byte count).
+DELETED_SIZE = -1
 
 
 class FilesystemSnapper:
@@ -60,18 +74,32 @@ class FilesystemSnapper:
         self.interrupt = False
         self.wm = wm
         self._visited_inodes = set()
+        # Delta tracking. After the first full snapshot, only changes are
+        # recorded. ``_prev_state`` maps real (un-anonymized) path ->
+        # (size, mtime, ctime, atime) as captured by the last completed
+        # snapshot; ``_have_full_snapshot`` flips to True once a full snapshot
+        # has finished without being interrupted.
+        self._prev_state = {}
+        self._have_full_snapshot = False
 
     def filesystem_snapshot(self, max_depth: int = None):
         """
         Perform a filesystem snapshot by walking the directory tree.
-        
+
         Recursively scans directories up to max_depth, recording information
         about each file found. Skips special filesystems and already-visited
         inodes to avoid duplicates.
-        
+
+        The first snapshot records every file (a full inventory). Every snapshot
+        after that is a delta: a file is recorded only if it is new or its
+        size/mtime/ctime changed since the previous completed snapshot, and
+        files that disappeared are recorded as tombstone rows (size ==
+        ``DELETED_SIZE``). access time (atime) is deliberately excluded from the
+        change check since it changes on every read.
+
         Args:
             max_depth: Maximum directory depth to traverse (default: None = unlimited)
-            
+
         Returns:
             bool: True if snapshot completed naturally, False if interrupted
         """
@@ -81,9 +109,31 @@ class FilesystemSnapper:
         # Common cross-stream clock, captured once for the whole snapshot.
         snapshot_mono_ns = time.monotonic_ns()
         count = 0
+        is_delta = self._have_full_snapshot
+        # Full state captured this pass: real path -> (size, mtime, ctime, atime).
+        # Built for every file (changed or not) so it becomes the baseline for
+        # the next delta and so we can detect deletions against the previous one.
+        new_state = {}
+
+        def emit(path: str, size, mtime_ts: float, ctime_ts: float, atime_ts: float):
+            """Write one snapshot row, anonymizing the path when configured."""
+            nonlocal count
+            out_path = (
+                anonymize_path(path, keep_ext=True, length=12)
+                if self.anonymous else path
+            )
+            out = format_csv_row(
+                snapshot_timestamp, out_path, size,
+                datetime.fromtimestamp(ctime_ts),
+                datetime.fromtimestamp(mtime_ts),
+                datetime.fromtimestamp(atime_ts),
+                snapshot_mono_ns,
+            )
+            self.wm.append_fs_snap_log(out)
+            count += 1
+
         def scan_dir(path: str, depth: int = 0):
             """Inner function for recursive directory scanning."""
-            nonlocal count
             if self.interrupt or (max_depth is not None and depth > max_depth):
                 return
             try:
@@ -103,28 +153,21 @@ class FilesystemSnapper:
                             return
                         try:
                             if entry.is_file(follow_symlinks=False) or entry.is_symlink():
-                                if self.anonymous:
-                                    est = entry.stat(follow_symlinks=False)  
-                                    size = est.st_size
-                                    ctime = datetime.fromtimestamp(getattr(est, "st_birthtime", est.st_mtime))
-                                    mtime = datetime.fromtimestamp(est.st_mtime)
-                                    atime = datetime.fromtimestamp(est.st_atime)
+                                est = entry.stat(follow_symlinks=False)
+                                size = est.st_size
+                                mtime_ts = est.st_mtime
+                                ctime_ts = getattr(est, "st_birthtime", est.st_mtime)
+                                atime_ts = est.st_atime
+                                new_state[entry.path] = (size, mtime_ts, ctime_ts, atime_ts)
 
-                                    # Anonymize like the live fs stream: hash every
-                                    # path component (basename included), keep depth.
-                                    hashed_path = anonymize_path(entry.path, keep_ext=True, length=12)
-                                    out = format_csv_row(snapshot_timestamp, hashed_path, size, ctime, mtime, atime, snapshot_mono_ns)
-                                    self.wm.append_fs_snap_log(out)
-                                    count += 1  
-                                else:
-                                    est = entry.stat(follow_symlinks=False)
-                                    size = est.st_size
-                                    ctime = datetime.fromtimestamp(getattr(est, "st_birthtime", est.st_mtime))
-                                    mtime = datetime.fromtimestamp(est.st_mtime)
-                                    atime = datetime.fromtimestamp(est.st_atime)
-                                    out = format_csv_row(snapshot_timestamp, entry.path, size, ctime, mtime, atime, snapshot_mono_ns)
-                                    self.wm.append_fs_snap_log(out)
-                                    count += 1     
+                                # In delta mode, skip files whose size/mtime/ctime
+                                # are unchanged from the previous snapshot.
+                                if is_delta:
+                                    prev = self._prev_state.get(entry.path)
+                                    if prev is not None and prev[:3] == (size, mtime_ts, ctime_ts):
+                                        continue
+
+                                emit(entry.path, size, mtime_ts, ctime_ts, atime_ts)
                             elif entry.is_dir(follow_symlinks=False):
                                 scan_dir(entry.path, depth + 1)
                         except Exception:
@@ -132,18 +175,34 @@ class FilesystemSnapper:
             except Exception:
                 return
 
-        logger("info", "Filesystem Snapshot: session started")
+        logger("info", f"Filesystem Snapshot: session started ({'delta' if is_delta else 'full'})")
         scan_dir(self.root_path, 0)
-        print(f"Filesystem Snapshot: {count} files captured")
-        # Only flush and mark complete if not interrupted
+
+        # Record removals: any path present last time but not seen now. Only
+        # meaningful for a delta, and only when the scan finished naturally (an
+        # interrupted scan hasn't visited every directory, so absence is not a
+        # reliable signal of deletion).
+        if is_delta and not self.interrupt:
+            for path, (size, mtime_ts, ctime_ts, atime_ts) in self._prev_state.items():
+                if self.interrupt:
+                    break
+                if path not in new_state:
+                    emit(path, DELETED_SIZE, mtime_ts, ctime_ts, atime_ts)
+
+        print(f"Filesystem Snapshot: {count} {'changes' if is_delta else 'files'} captured")
+        # Only flush, mark complete, and advance the baseline if not interrupted
         if not self.interrupt:
             self.wm.flush_fssnap_only()
             self.wm.mark_fs_snapshot_complete()
+            # This completed scan becomes the baseline for the next delta.
+            self._prev_state = new_state
+            self._have_full_snapshot = True
             # logger("info", "Filesystem snapshot completed.")
             return True
         else:
-            # Snapshot was interrupted - don't mark as complete
-            # The incomplete snapshot handling in force_flush() will clean it up
+            # Snapshot was interrupted - don't mark as complete or advance the
+            # baseline. The incomplete snapshot handling in force_flush() cleans
+            # it up; the next pass retries against the same previous baseline.
             return False
 
     def stop_snapper(self):
@@ -182,7 +241,9 @@ class FilesystemSnapper:
                 # Check if one hour has passed since last snapshot
                 time_since_last_snapshot = current_time - last_snapshot_time
                 if time_since_last_snapshot >= 3600:  # 3600 seconds = 1 hour
-                    # Reset visited inodes before new snapshot
+                    # Reset visited inodes before new snapshot (they are per
+                    # walk). _prev_state is intentionally NOT cleared: it is the
+                    # baseline the next snapshot diffs against to upload a delta.
                     self._visited_inodes.clear()
                     completed = self.filesystem_snapshot()
                     if completed:

--- a/tests/test_fs_snapshot_delta.py
+++ b/tests/test_fs_snapshot_delta.py
@@ -1,0 +1,170 @@
+"""
+Unit tests for FilesystemSnapper delta behavior.
+
+The first snapshot records a full filesystem inventory; every subsequent
+snapshot records only added / modified / deleted files (a delta), so the
+tracer no longer re-uploads the entire inventory every hour. These tests drive
+``filesystem_snapshot()`` directly against a temporary directory tree using a
+fake WriteManager that captures the rows that would be written.
+"""
+
+import csv
+import io
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from src.tracer.snappers.FilesystemSnapper import FilesystemSnapper, DELETED_SIZE
+
+
+class FakeWriteManager:
+    """Captures snapshot rows and flush/complete calls per snapshot pass."""
+
+    def __init__(self):
+        self.rows = []
+        self.flushes = 0
+        self.completes = 0
+
+    def append_fs_snap_log(self, out):
+        self.rows.append(out)
+
+    def flush_fssnap_only(self):
+        self.flushes += 1
+
+    def mark_fs_snapshot_complete(self):
+        self.completes += 1
+
+    # Test helpers -----------------------------------------------------------
+    def take(self):
+        """Return rows captured since the last take() and reset the buffer."""
+        rows = self.rows
+        self.rows = []
+        return rows
+
+
+def _paths_and_sizes(rows):
+    """Parse {path: size} out of captured CSV rows."""
+    out = {}
+    for row in rows:
+        fields = next(csv.reader(io.StringIO(row)))
+        out[fields[1]] = int(fields[2])
+    return out
+
+
+class FilesystemSnapperDeltaTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.wm = FakeWriteManager()
+        self.snapper = FilesystemSnapper(self.wm, anonymous=False)
+        self.snapper.root_path = self.tmp
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def _write(self, name, content):
+        path = os.path.join(self.tmp, name)
+        os.makedirs(os.path.dirname(path), exist_ok=True)
+        with open(path, "w") as f:
+            f.write(content)
+        return path
+
+    def _bump_mtime(self, path, content):
+        """Rewrite a file and force a clearly newer mtime."""
+        with open(path, "w") as f:
+            f.write(content)
+        st = os.stat(path)
+        os.utime(path, (st.st_atime, st.st_mtime + 100))
+
+    def test_first_snapshot_is_full(self):
+        self._write("a.txt", "a")
+        self._write("sub/b.txt", "bb")
+
+        self.assertTrue(self.snapper.filesystem_snapshot())
+        rows = _paths_and_sizes(self.wm.take())
+
+        self.assertEqual(
+            set(rows),
+            {os.path.join(self.tmp, "a.txt"), os.path.join(self.tmp, "sub/b.txt")},
+        )
+        self.assertEqual(self.wm.flushes, 1)
+        self.assertEqual(self.wm.completes, 1)
+
+    def test_unchanged_delta_is_empty(self):
+        self._write("a.txt", "a")
+        self.snapper.filesystem_snapshot()
+        self.wm.take()
+
+        # Second pass with no changes emits nothing.
+        self.snapper._visited_inodes.clear()
+        self.assertTrue(self.snapper.filesystem_snapshot())
+        self.assertEqual(self.wm.take(), [])
+
+    def test_delta_reports_added_and_modified(self):
+        a = self._write("a.txt", "a")
+        self._write("b.txt", "b")
+        self.snapper.filesystem_snapshot()
+        self.wm.take()
+
+        # Modify a.txt and add c.txt; b.txt is untouched.
+        self._bump_mtime(a, "aaaa")
+        self._write("c.txt", "c")
+
+        self.snapper._visited_inodes.clear()
+        self.snapper.filesystem_snapshot()
+        rows = _paths_and_sizes(self.wm.take())
+
+        self.assertEqual(
+            set(rows),
+            {os.path.join(self.tmp, "a.txt"), os.path.join(self.tmp, "c.txt")},
+        )
+        # Sizes reflect current state, not a tombstone.
+        self.assertEqual(rows[os.path.join(self.tmp, "a.txt")], 4)
+        self.assertEqual(rows[os.path.join(self.tmp, "c.txt")], 1)
+
+    def test_delta_reports_deletion_as_tombstone(self):
+        self._write("a.txt", "a")
+        b = self._write("b.txt", "b")
+        self.snapper.filesystem_snapshot()
+        self.wm.take()
+
+        os.remove(b)
+        self.snapper._visited_inodes.clear()
+        self.snapper.filesystem_snapshot()
+        rows = _paths_and_sizes(self.wm.take())
+
+        self.assertEqual(set(rows), {os.path.join(self.tmp, "b.txt")})
+        self.assertEqual(rows[os.path.join(self.tmp, "b.txt")], DELETED_SIZE)
+
+    def test_interrupted_snapshot_does_not_advance_baseline(self):
+        self._write("a.txt", "a")
+        # Interrupt before the first snapshot can complete.
+        self.snapper.interrupt = True
+        self.assertFalse(self.snapper.filesystem_snapshot())
+        self.assertFalse(self.snapper._have_full_snapshot)
+        self.assertEqual(self.wm.flushes, 0)
+        self.assertEqual(self.wm.completes, 0)
+
+        # Recover: the next completed pass is still a full snapshot.
+        self.snapper.interrupt = False
+        self.snapper._visited_inodes.clear()
+        self.assertTrue(self.snapper.filesystem_snapshot())
+        rows = _paths_and_sizes(self.wm.take())
+        self.assertEqual(set(rows), {os.path.join(self.tmp, "a.txt")})
+
+    def test_anonymous_delta_emits_hashed_paths(self):
+        self._write("secret.txt", "x")
+        self.snapper.anonymous = True
+        self.snapper.filesystem_snapshot()
+        rows = self.wm.take()
+        # Real path must not leak in anonymous mode.
+        self.assertTrue(rows)
+        for row in rows:
+            self.assertNotIn("secret.txt", row)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fs_snapshot_delta.py
+++ b/tests/test_fs_snapshot_delta.py
@@ -15,6 +15,7 @@ import sys
 import tempfile
 import types
 import unittest
+import unittest.mock
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -165,6 +166,117 @@ class FilesystemSnapperDeltaTests(unittest.TestCase):
         self.assertTrue(self.snapper.filesystem_snapshot())
         rows = _paths_and_sizes(self.wm.take())
         self.assertEqual(set(rows), {os.path.join(self.tmp, "a.txt")})
+
+    def test_delta_reports_subtree_removal_as_tombstones(self):
+        self._write("keep.txt", "k")
+        self._write("sub/b.txt", "b")
+        self._write("sub/c.txt", "c")
+        self.snapper.filesystem_snapshot()
+        self.wm.take()
+
+        # Remove an entire subdirectory: its files must still be tombstoned even
+        # though scan_dir is never invoked on the now-missing directory.
+        import shutil
+        shutil.rmtree(os.path.join(self.tmp, "sub"))
+
+        self.snapper._visited_inodes.clear()
+        self.snapper.filesystem_snapshot()
+        rows = _paths_and_sizes(self.wm.take())
+
+        self.assertEqual(
+            set(rows),
+            {os.path.join(self.tmp, "sub/b.txt"), os.path.join(self.tmp, "sub/c.txt")},
+        )
+        self.assertTrue(all(v == DELETED_SIZE for v in rows.values()))
+
+    def test_transient_scandir_error_does_not_tombstone(self):
+        # A directory that can't be listed this pass (e.g. PermissionError) must
+        # not have its contents reported as deleted.
+        self._write("keep.txt", "k")
+        self._write("sub/b.txt", "b")
+        self.snapper.filesystem_snapshot()
+        self.wm.take()
+
+        target = os.path.join(self.tmp, "sub")
+        real_scandir = os.scandir
+
+        def fake_scandir(path):
+            if os.path.abspath(path) == target:
+                raise PermissionError(13, "Permission denied")
+            return real_scandir(path)
+
+        self.snapper._visited_inodes.clear()
+        with unittest.mock.patch(
+            "src.tracer.snappers.FilesystemSnapper.os.scandir", side_effect=fake_scandir
+        ):
+            self.snapper.filesystem_snapshot()
+
+        # No tombstones; sub/b.txt is carried forward into the new baseline.
+        self.assertEqual(self.wm.take(), [])
+        self.assertIn(os.path.join(self.tmp, "sub/b.txt"), self.snapper._prev_state)
+
+    def test_transient_file_stat_error_carries_over(self):
+        # A single file we fail to stat (transient) is carried over, not deleted;
+        # the same failure as a genuine absence (FileNotFoundError) tombstones.
+        a_path = self._write("a.txt", "a")
+        self.snapper.filesystem_snapshot()
+        self.wm.take()
+
+        class _RaisingEntry:
+            def __init__(self, path, exc):
+                self.path = path
+                self._exc = exc
+
+            def is_file(self, follow_symlinks=True):
+                return True
+
+            def is_symlink(self):
+                return False
+
+            def is_dir(self, follow_symlinks=True):
+                return False
+
+            def stat(self, follow_symlinks=True):
+                raise self._exc
+
+        class _FakeScandirCtx:
+            def __init__(self, entries):
+                self._entries = entries
+
+            def __enter__(self):
+                return iter(self._entries)
+
+            def __exit__(self, *exc):
+                return False
+
+        real_scandir = os.scandir
+
+        def patched(exc):
+            def fake_scandir(path):
+                if os.path.abspath(path) == os.path.abspath(self.tmp):
+                    return _FakeScandirCtx([_RaisingEntry(a_path, exc)])
+                return real_scandir(path)
+            return fake_scandir
+
+        # Transient (PermissionError): carried over, no tombstone.
+        self.snapper._visited_inodes.clear()
+        with unittest.mock.patch(
+            "src.tracer.snappers.FilesystemSnapper.os.scandir",
+            side_effect=patched(PermissionError(13, "denied")),
+        ):
+            self.snapper.filesystem_snapshot()
+        self.assertEqual(self.wm.take(), [])
+        self.assertIn(a_path, self.snapper._prev_state)
+
+        # Absence (FileNotFoundError): tombstoned.
+        self.snapper._visited_inodes.clear()
+        with unittest.mock.patch(
+            "src.tracer.snappers.FilesystemSnapper.os.scandir",
+            side_effect=patched(FileNotFoundError(2, "missing")),
+        ):
+            self.snapper.filesystem_snapshot()
+        rows = _paths_and_sizes(self.wm.take())
+        self.assertEqual(rows, {a_path: DELETED_SIZE})
 
     def test_anonymous_delta_emits_hashed_paths(self):
         self._write("secret.txt", "x")

--- a/tests/test_fs_snapshot_delta.py
+++ b/tests/test_fs_snapshot_delta.py
@@ -13,9 +13,20 @@ import io
 import os
 import sys
 import tempfile
+import types
 import unittest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# Importing FilesystemSnapper pulls in WriterManager -> ObjectStorageManager,
+# which imports `requests` at module load time. These tests never touch the
+# network, and minimal CI environments do not install `requests`, so fall back
+# to a stub module when it is unavailable (mirrors test_writer_upload.py).
+if "requests" not in sys.modules:
+    try:
+        import requests  # noqa: F401
+    except ModuleNotFoundError:
+        sys.modules["requests"] = types.ModuleType("requests")
 
 from src.tracer.snappers.FilesystemSnapper import FilesystemSnapper, DELETED_SIZE
 


### PR DESCRIPTION
## Summary

The filesystem snapper walked the entire tree every hour and re-emitted **every** file, so the full inventory was compressed and uploaded on each hourly pass. This change makes the snapper **delta-based after the first run**:

- The **first** snapshot is a full inventory of every file.
- **Every subsequent** snapshot records only files that were **added**, **modified** (size/`mtime`/`ctime` changed), or **deleted** since the previous completed snapshot.
- A delta with **no changes** emits nothing, so no part file is flushed or uploaded for that pass.

## Implementation

In `FilesystemSnapper`:
- Keep the last completed scan in memory as a baseline (`path -> (size, mtime, ctime, atime)`) and diff against it on later passes. `atime` is **excluded** from the change check since it changes on every read (otherwise nearly every file would look "changed").
- Deleted files are emitted as **tombstone** rows with `size == DELETED_SIZE` (`-1`), so consumers can distinguish removals from added/modified files (which always carry a real, non‑negative byte count).
- An **interrupted** scan does not advance the baseline — the next completed pass is diffed against the last good snapshot, and the first ever snapshot is always full.
- Unified the previously duplicated anonymous / non‑anonymous emit branches into a single `emit()` helper.

No schema change: delta rows use the existing `filesystem_snapshot` columns; deletions are signalled via the `size` sentinel.

## Reconstructing state

Start from the full inventory (snapshot 0) and apply each delta in order: added/modified rows overwrite the entry for that path, tombstone rows (`size == -1`) remove it.

## Tests

Added `tests/test_fs_snapshot_delta.py` covering: full first snapshot, empty delta, additions + modifications, deletion tombstones, anonymized paths, and interrupted‑then‑recovered scans. Full suite passes (`87 tests, 9 skipped`).

Docs updated in `docs/MULTIPART_FILESYSTEM_SNAPSHOT.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_013AREwcJWWbeQb8Pg3zLQk4)_