### PR TITLE
prober: fix readdir verifier failure (variable-offset write to stack)

### DIFF
--- a/.github/scripts/bpf_smoke.py
+++ b/.github/scripts/bpf_smoke.py
@@ -63,6 +63,11 @@ def main():
         ("kprobe", "vfs_fsync", "trace_vfs_fsync"),
         ("kretprobe", "vfs_fsync", "trace_vfs_fsync_ret"),
         ("kprobe", "vfs_fsync_range", "trace_vfs_fsync_range"),
+        # readdir reconstructs the directory path via a bounded d_parent walk
+        # (build_dentry_path). That path is assembled with variable-offset
+        # writes, which only verify against a map value — attaching here runs
+        # the verifier on trace_readdir so a stack-buffer regression fails CI.
+        ("kprobe", "iterate_dir", "trace_readdir"),
     ]
 
     # Symbol-conditional probes. These validate that the pt_regs-unwrapping

--- a/src/tracer/prober/prober.c
+++ b/src/tracer/prober/prober.c
@@ -1084,19 +1084,35 @@ static int get_file_path_from_dentry(struct dentry *dentry, char *buf,
  * relative to the file's own mount root), and truncates to the last
  * DPATH_MAX_DEPTH components on very deep paths.
  *
- * The output buffer is always FILENAME_MAX_LEN bytes (a power of two), so the
- * write offset is masked with DPATH_MASK to keep the verifier happy. The buffer
- * size is hardcoded rather than passed in: a caller-supplied size that differed
- * from the mask would let buf[off & DPATH_MASK] index past the buffer, so the
- * two must stay coupled.
+ * The path is assembled in a per-CPU map value (sc->out) rather than directly
+ * in the caller's buffer, then copied out with a constant-size memcpy. This is
+ * required for the verifier: it rejects variable-offset writes to the *stack*
+ * outright (it tracks stack slots individually), but accepts them into a map
+ * value whose bounds it can prove. The caller's buffer (e.g. data.filename) is
+ * a stack object, so the masking trick alone is not enough — the write must
+ * land in the map value first.
+ *
+ * sc->out is deliberately oversized to DPATH_OUT_SIZE. The verifier checks a
+ * variable-offset helper write conservatively, treating the destination offset
+ * (<= DPATH_MASK) and the access size (<= DPATH_BUF_SIZE) as independent, so the
+ * destination must satisfy DPATH_MASK + DPATH_BUF_SIZE <= sizeof(sc->out). The
+ * DPATH_MASK on every write keeps the actual bytes within the first
+ * DPATH_BUF_SIZE; the slack is purely to satisfy the verifier's worst case.
  */
 #define DPATH_MAX_DEPTH 12
 #define DPATH_BUF_SIZE FILENAME_MAX_LEN
 #define DPATH_MASK (DPATH_BUF_SIZE - 1)
+/* Worst-case verifier bound: max masked offset (DPATH_MASK) + max str size
+ * (DPATH_BUF_SIZE). 2*DPATH_BUF_SIZE covers it with room to spare. */
+#define DPATH_OUT_SIZE (DPATH_BUF_SIZE * 2)
 
-/* Per-CPU scratch for the component-pointer chain — kept off the BPF stack,
- * which is only 512 bytes and already mostly consumed by struct data_t. */
-struct dpath_scratch { const unsigned char *names[DPATH_MAX_DEPTH]; };
+/* Per-CPU scratch for the component-pointer chain and the assembled path —
+ * kept off the BPF stack, which is only 512 bytes and already mostly consumed
+ * by struct data_t. */
+struct dpath_scratch {
+  const unsigned char *names[DPATH_MAX_DEPTH];
+  char out[DPATH_OUT_SIZE];
+};
 BPF_PERCPU_ARRAY(dpath_scratch_map, struct dpath_scratch, 1);
 
 static __always_inline void build_dentry_path(struct dentry *dentry,
@@ -1131,17 +1147,23 @@ static __always_inline void build_dentry_path(struct dentry *dentry,
     if (!np) continue;
 
     if (off < DPATH_BUF_SIZE - 1) {      /* component separator */
-      buf[off & DPATH_MASK] = '/';
+      sc->out[off & DPATH_MASK] = '/';
       off++;
     }
     int pos = off & DPATH_MASK;          /* 0..DPATH_BUF_SIZE-1 */
     int cap = DPATH_BUF_SIZE - pos;      /* pos + cap == DPATH_BUF_SIZE, in-bounds */
     if (cap > 1) {
-      long w = bpf_probe_read_kernel_str(&buf[pos], cap, np);
+      long w = bpf_probe_read_kernel_str(&sc->out[pos], cap, np);
       if (w > 1) off = pos + (int)(w - 1);   /* advance past name, exclude NUL */
     }
   }
-  buf[off & DPATH_MASK] = '\0';
+  sc->out[off & DPATH_MASK] = '\0';
+
+  /* Copy the assembled path back to the caller's FILENAME_MAX_LEN stack buffer
+   * with a constant size — a variable-offset write to the stack would be
+   * rejected by the verifier, but a fixed-size copy is fine. */
+  __builtin_memcpy(buf, sc->out, DPATH_BUF_SIZE);
+  buf[DPATH_BUF_SIZE - 1] = '\0';
 }
 
 /**

--- a/src/tracer/prober/prober.c
+++ b/src/tracer/prober/prober.c
@@ -1124,6 +1124,13 @@ static __always_inline void build_dentry_path(struct dentry *dentry,
   struct dpath_scratch *sc = dpath_scratch_map.lookup(&zero);
   if (!sc) return;
 
+  /* sc->out is per-CPU and persists across calls, so bytes past the path's NUL
+   * terminator would otherwise be stale data from a previous readdir on this
+   * CPU. The final memcpy copies the whole DPATH_BUF_SIZE window into the
+   * perf-submitted event, so zero that window first to avoid leaking stale
+   * path bytes to userspace. */
+  __builtin_memset(sc->out, 0, DPATH_BUF_SIZE);
+
   int n = 0;
   struct dentry *d = dentry;
 


### PR DESCRIPTION
## Problem

`trace_readdir` (kprobe on `iterate_dir`) fails to load and is silently skipped:

```
884: (85) call bpf_probe_read_kernel_str#115
invalid variable-offset write to stack R1 var_off=(0x0; 0xff) off=-416 size=256
...
[WARN] Failed to attach kprobe iterate_dir (skipping): Failed to load BPF program b'trace_readdir': Invalid argument
```

## Root cause

`build_dentry_path()` assembles the reconstructed directory path with a variable-offset write:

```c
long w = bpf_probe_read_kernel_str(&buf[pos], cap, np);   // pos is a variable
```

Its only caller, `trace_readdir()`, passes `data.filename` — a buffer that lives on the **BPF stack** (`fp-416`). The verifier rejects variable-offset writes to the stack outright, because it tracks stack slots individually. The `& DPATH_MASK` masking only keeps the verifier happy for **map-value** destinations (whose bounds it can prove), not for stack buffers. As a result this probe has never been able to attach.

## Fix

- Assemble the path in a **per-CPU map value** (`sc->out`) — variable-offset writes into a map value with provable bounds are allowed — then copy the result into the caller's stack buffer with a **constant-size** `__builtin_memcpy` (a fixed-size stack write is fine).
- `sc->out` is oversized to `2 * DPATH_BUF_SIZE`. The verifier bounds a variable-offset write conservatively, treating the destination offset (`<= DPATH_MASK`) and the access size (`<= DPATH_BUF_SIZE`) as independent ranges, so the destination must be able to hold `DPATH_MASK + DPATH_BUF_SIZE` bytes. The mask still confines the real content to the first `DPATH_BUF_SIZE` bytes; the slack only satisfies the verifier's worst case.

## Notes

- `event.filename` is read in userspace via `event.filename.decode()` (`IOTracer.py:282`). Because it is a ctypes `c_char` array, it truncates at the first NUL, so the (uncleared) per-CPU scratch tail past our NUL terminator is harmless — matching the previous behaviour.
- bcc/kernel headers aren't available in this environment, so the change was validated against the verifier's documented rules rather than by an on-box load. Worst-case destination footprint is `DPATH_MASK (255) + DPATH_BUF_SIZE (256) = 511 ≤ 512 = sizeof(sc->out)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01PWsYaEEcrmmh9CSV6p1Gbv)_