### PR TITLE
Fall back to gzip (.gz) compression when zstandard is unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ sudo pacman -S python-psutil python-requests python-zstandard
 ```
 
 `zstandard` is used to compress trace logs (`.zst`). If it is missing the
-tracer still runs and keeps traces uncompressed, but installing it is
-recommended. To run the test suite you'll also need `pytest`
-(`pip install pytest`).
+tracer still runs and falls back to gzip (`.gz`) using the Python standard
+library, but installing `zstandard` is recommended for faster, smaller output.
+To run the test suite you'll also need `pytest` (`pip install pytest`).
 
 ## Usage
 ```

--- a/docs/MULTIPART_FILESYSTEM_SNAPSHOT.md
+++ b/docs/MULTIPART_FILESYSTEM_SNAPSHOT.md
@@ -83,7 +83,7 @@ filesystem_snapshot_part0003_20260214_120000_ABC123DEF456_complete_parts3.csv.zs
 
 ## Compression
 
-Files are compressed using **Zstandard** (`.zst`) for reliable and efficient compression.
+Files are compressed using **Zstandard** (`.zst`) for reliable and efficient compression. When the optional `zstandard` library is unavailable, the tracer falls back to **gzip** (`.gz`) from the Python standard library so snapshot parts are still compressed.
 
 ## Implementation Details
 
@@ -108,9 +108,9 @@ The `filesystem_snapshot()` method now calls `mark_fs_snapshot_complete()` after
 
 ### Utils Changes
 
-Uses the existing `compress_file_zstd()` helper that:
-- Compresses files using Zstandard
-- Removes the original uncompressed file after compression
+Uses the `compress_file()` helper that:
+- Compresses files using Zstandard, falling back to gzip (`.gz`) when `zstandard` is unavailable
+- Returns the compressed output path so the caller can remove the original uncompressed file
 
 ## Buffer Flushing
 

--- a/install.sh
+++ b/install.sh
@@ -124,23 +124,23 @@ install_bcc_arch() {
 install_python_deps_apt() {
     log_info "Installing Python dependencies..."
     apt-get install -y python3-psutil python3-requests
-    # zstandard is optional: the tracer falls back to uncompressed traces when
+    # zstandard is optional: the tracer falls back to gzip (.gz) compression when
     # it is missing, so don't let an unavailable package abort the install.
-    apt-get install -y python3-zstandard || log_warning "python3-zstandard unavailable; traces will not be compressed"
+    apt-get install -y python3-zstandard || log_warning "python3-zstandard unavailable; traces will be compressed with gzip (.gz) instead"
 }
 
 install_python_deps_dnf() {
     log_info "Installing Python dependencies..."
     dnf install -y python3-psutil python3-requests
     # Optional; see install_python_deps_apt.
-    dnf install -y python3-zstandard || log_warning "python3-zstandard unavailable; traces will not be compressed"
+    dnf install -y python3-zstandard || log_warning "python3-zstandard unavailable; traces will be compressed with gzip (.gz) instead"
 }
 
 install_python_deps_pacman() {
     log_info "Installing Python dependencies..."
     pacman -S --noconfirm python-psutil python-requests
     # Optional; see install_python_deps_apt.
-    pacman -S --noconfirm python-zstandard || log_warning "python-zstandard unavailable; traces will not be compressed"
+    pacman -S --noconfirm python-zstandard || log_warning "python-zstandard unavailable; traces will be compressed with gzip (.gz) instead"
 }
 
 install_git_if_needed() {

--- a/scripts/smoke_test.sh
+++ b/scripts/smoke_test.sh
@@ -91,6 +91,8 @@ run_one() {
     local hdr
     if [[ "$fsfile" == *.zst ]]; then
       hdr="$(zstd -dc "$fsfile" 2>/dev/null | head -1)"
+    elif [[ "$fsfile" == *.gz ]]; then
+      hdr="$(gzip -dc "$fsfile" 2>/dev/null | head -1)"
     else
       hdr="$(head -1 "$fsfile")"
     fi

--- a/src/tracer/WriterManager.py
+++ b/src/tracer/WriterManager.py
@@ -5,7 +5,7 @@ This module provides the WriteManager class which handles:
 - Creating output directory structure
 - Buffering trace events for different subsystems
 - Writing events to CSV files
-- Compressing output files with Zstandard (.zst)
+- Compressing output files with Zstandard (.zst), or gzip (.gz) as a fallback
 - Optionally uploading files to cloud storage
 
 The manager uses adaptive buffering to handle high event rates and
@@ -32,7 +32,7 @@ from .ObjectStorageManager import ObjectStorageManager
 from . import schema
 from ..utility.utils import (
     logger, capture_machine_id,
-    compress_file_zstd, zstandard_available, ZSTD_LEVEL,
+    compress_file, zstandard_available, ZSTD_LEVEL, GZIP_LEVEL,
 )
 import threading
 from collections import deque
@@ -625,13 +625,13 @@ class WriteManager:
             self._fs_snap_handle.close()
             self._fs_snap_handle = None
 
-            # Compress with Zstandard. If zstandard is unavailable, keep the
-            # uncompressed part rather than losing it.
+            # Compress the part, preferring Zstandard and falling back to gzip.
             if os.path.exists(part_filepath):
                 # Don't log or count each part - we'll log when snapshot is complete
-                if compress_file_zstd(part_filepath, part_filepath + ".zst"):
+                compressed = compress_file(part_filepath)
+                if compressed is not None and compressed != part_filepath:
                     os.remove(part_filepath)
-                    part_output = part_filepath + ".zst"
+                    part_output = compressed
                 else:
                     part_output = part_filepath
 
@@ -685,9 +685,10 @@ class WriteManager:
                 self.fs_snapshot_session_active = False
                 return
 
-            # Find the last part file. It is normally compressed (.csv.zst), but
-            # when zstandard is unavailable it is left uncompressed (.csv); detect
-            # whichever actually exists so the completion rename stays correct.
+            # Find the last part file. It is normally Zstandard-compressed
+            # (.csv.zst), but with gzip fallback it is .csv.gz, and if no codec
+            # was available it stays uncompressed (.csv); detect whichever
+            # actually exists so the completion rename stays correct.
             last_part_str = f"{total_parts:04d}"
             snapshot_dir = f"{self.output_dir}/filesystem_snapshot"
             base_name = (
@@ -696,9 +697,10 @@ class WriteManager:
                 f"{self.fs_snapshot_device_id}"
             )
             suffix = ".csv.zst"
-            if (not os.path.exists(f"{snapshot_dir}/{base_name}{suffix}")
-                    and os.path.exists(f"{snapshot_dir}/{base_name}.csv")):
-                suffix = ".csv"
+            for candidate in (".csv.zst", ".csv.gz", ".csv"):
+                if os.path.exists(f"{snapshot_dir}/{base_name}{candidate}"):
+                    suffix = candidate
+                    break
             old_filepath = f"{snapshot_dir}/{base_name}{suffix}"
 
             # Construct new filename with completion marker
@@ -1053,23 +1055,26 @@ class WriteManager:
 
     def compress_log(self, input_file: str):
         """
-        Compress a log file with Zstandard and optionally upload.
+        Compress a log file and optionally upload it.
+
+        Prefers Zstandard (.zst) and falls back to gzip (.gz) when the optional
+        ``zstandard`` library is unavailable, so trace logs are always
+        compressed rather than uploaded raw.
 
         Args:
             input_file: Path to the file to compress
         """
         try:
             src = input_file
-            dst = input_file + ".zst"
 
             # Check if file exists (may already be compressed for multi-part files)
             if not os.path.exists(src):
                 return
 
-            # Fall back to the uncompressed file when zstandard is unavailable
+            compressed = compress_file(src)
+            # If compression somehow failed, fall back to the uncompressed file
             # so trace data is still uploaded rather than lost.
-            compressed = compress_file_zstd(src, dst)
-            upload_target = dst if compressed else src
+            upload_target = compressed if compressed is not None else src
 
             if self.automatic_upload:
                 self.created_files += 1
@@ -1077,14 +1082,18 @@ class WriteManager:
                 # Upload each log individually, preserving its subdirectory
                 # (fs, ds, cache, process, ...) on the backend.
                 self.upload_manager.append_object(upload_target)
-            if compressed:
+            if compressed is not None and compressed != src:
                 os.remove(src)
         except Exception as e:
             logger("error", f"Failed compressing log {input_file}: {e}")
             
     def compress_dir(self, input_dir: str):
         """
-        Compress a directory to tar.zst and optionally upload.
+        Compress a directory to a tar bundle and optionally upload.
+
+        Prefers Zstandard (.tar.zst) and falls back to gzip (.tar.gz) when the
+        optional ``zstandard`` library is unavailable, so the bundle is still
+        compressed rather than left as a plain tar.
 
         Args:
             input_dir: Path to the directory to compress
@@ -1093,8 +1102,6 @@ class WriteManager:
             src = input_dir
             base = input_dir.rstrip("/").rstrip("\\")
 
-            # Fall back to a plain (uncompressed) tar when zstandard is missing
-            # so the bundle is still produced rather than lost.
             zstandard = zstandard_available()
             if zstandard is not None:
                 dst = base + ".tar.zst"
@@ -1104,8 +1111,9 @@ class WriteManager:
                         with tarfile.open(mode="w|", fileobj=compressor) as tar:
                             tar.add(src, arcname=os.path.basename(src))
             else:
-                dst = base + ".tar"
-                with tarfile.open(dst, mode="w") as tar:
+                # gzip fallback — always available in the standard library.
+                dst = base + ".tar.gz"
+                with tarfile.open(dst, mode="w:gz", compresslevel=GZIP_LEVEL) as tar:
                     tar.add(src, arcname=os.path.basename(src))
 
             if self.automatic_upload:

--- a/src/utility/utils.py
+++ b/src/utility/utils.py
@@ -317,17 +317,31 @@ def compress_file(src: str, level: int | None = None) -> str | None:
     zstandard = zstandard_available()
     if zstandard is not None:
         dst = src + ".zst"
-        cctx = zstandard.ZstdCompressor(level=ZSTD_LEVEL if level is None else level)
-        with open(src, "rb") as f_in, open(dst, "wb") as f_out:
-            cctx.copy_stream(f_in, f_out)
+    else:
+        # gzip fallback — always available in the standard library.
+        dst = src + ".gz"
+
+    try:
+        if zstandard is not None:
+            cctx = zstandard.ZstdCompressor(level=ZSTD_LEVEL if level is None else level)
+            with open(src, "rb") as f_in, open(dst, "wb") as f_out:
+                cctx.copy_stream(f_in, f_out)
+        else:
+            with open(src, "rb") as f_in, gzip.open(
+                dst, "wb", compresslevel=GZIP_LEVEL if level is None else level
+            ) as f_out:
+                shutil.copyfileobj(f_in, f_out)
         return dst
-    # gzip fallback — always available in the standard library.
-    dst = src + ".gz"
-    with open(src, "rb") as f_in, gzip.open(
-        dst, "wb", compresslevel=GZIP_LEVEL if level is None else level
-    ) as f_out:
-        shutil.copyfileobj(f_in, f_out)
-    return dst
+    except Exception as e:
+        # Don't leave a half-written archive behind, and signal failure so the
+        # caller keeps the uncompressed source rather than losing trace data.
+        logger("error", f"Failed to compress {src}: {e}")
+        try:
+            if os.path.exists(dst):
+                os.remove(dst)
+        except OSError:
+            pass
+        return None
 
 
 def compress_log(input_file: str):

--- a/src/utility/utils.py
+++ b/src/utility/utils.py
@@ -19,8 +19,10 @@ Example:
 """
 
 import csv
+import gzip
 import io
 import itertools
+import shutil
 import sys
 import threading
 from pathlib import Path
@@ -222,9 +224,14 @@ def logger(error_scale: str, string: str, timestamp: bool = False):
 # speed/ratio tradeoff for streaming large trace logs.
 ZSTD_LEVEL = 3
 
+# gzip compression level used for the standard-library fallback when the
+# optional ``zstandard`` package is unavailable. 6 is gzip's default — a
+# reasonable speed/ratio tradeoff for streaming large trace logs.
+GZIP_LEVEL = 6
+
 
 # Set once we've reported a missing ``zstandard`` install, so the
-# uncompressed fallback is announced a single time rather than once per file
+# gzip fallback is announced a single time rather than once per file
 # across a whole trace run. Guarded by a lock because the writer's parallel
 # stream threads can reach this concurrently.
 _zstandard_missing_warned = False
@@ -254,9 +261,9 @@ def zstandard_available():
     Return the ``zstandard`` module if installed, otherwise ``None``.
 
     Unlike :func:`require_zstandard` this never raises, letting callers fall
-    back to leaving trace files uncompressed when the optional dependency is
-    missing. The first time it is found missing a single warning is logged so
-    the per-file fallback doesn't flood the logs across a trace run.
+    back to gzip (standard library) when the optional dependency is missing.
+    The first time it is found missing a single warning is logged so the
+    per-file fallback doesn't flood the logs across a trace run.
     """
     global _zstandard_missing_warned
     try:
@@ -271,48 +278,70 @@ def zstandard_available():
                 logger(
                     "warning",
                     "The 'zstandard' library is not installed; trace files will be "
-                    "kept uncompressed. Install it with 'pip install zstandard' "
-                    "(or 'pip install -r requirements.txt') to enable compression.",
+                    "compressed with gzip (.gz) instead. Install it with "
+                    "'pip install zstandard' (or 'pip install -r requirements.txt') "
+                    "for faster, smaller Zstandard (.zst) output.",
                 )
         return None
     return zstandard
 
 
-def compress_file_zstd(src: str, dst: str, level: int = ZSTD_LEVEL) -> bool:
+def compressed_suffix() -> str:
+    """Return the file extension of the active log-compression codec.
+
+    ``.zst`` when the optional ``zstandard`` library is available, otherwise
+    ``.gz`` for the gzip standard-library fallback.
     """
-    Stream-compress a file to Zstandard.
+    return ".zst" if zstandard_available() is not None else ".gz"
+
+
+def compress_file(src: str, level: int | None = None) -> str | None:
+    """
+    Stream-compress a file with the best available codec.
+
+    Prefers Zstandard (``<src>.zst``); when the optional ``zstandard`` library
+    is unavailable, falls back to gzip (``<src>.gz``) from the standard library
+    so trace files are still compressed rather than left raw. The source file
+    is left in place — callers remove it after the compressed output has been
+    handed off (e.g. queued for upload).
 
     Args:
         src: Path to the source file
-        dst: Path to write the compressed (.zst) output
-        level: Zstandard compression level
+        level: Compression level; defaults to the codec's tuned level
+            (:data:`ZSTD_LEVEL` for Zstandard, :data:`GZIP_LEVEL` for gzip).
 
     Returns:
-        ``True`` if the file was compressed to ``dst``. If the optional
-        ``zstandard`` library is unavailable nothing is written and ``False``
-        is returned, so callers can fall back to the uncompressed source.
+        Path to the compressed output, or ``None`` if compression failed (so
+        callers can fall back to the uncompressed source).
     """
     zstandard = zstandard_available()
-    if zstandard is None:
-        return False
-    cctx = zstandard.ZstdCompressor(level=level)
-    with open(src, "rb") as f_in, open(dst, "wb") as f_out:
-        cctx.copy_stream(f_in, f_out)
-    return True
+    if zstandard is not None:
+        dst = src + ".zst"
+        cctx = zstandard.ZstdCompressor(level=ZSTD_LEVEL if level is None else level)
+        with open(src, "rb") as f_in, open(dst, "wb") as f_out:
+            cctx.copy_stream(f_in, f_out)
+        return dst
+    # gzip fallback — always available in the standard library.
+    dst = src + ".gz"
+    with open(src, "rb") as f_in, gzip.open(
+        dst, "wb", compresslevel=GZIP_LEVEL if level is None else level
+    ) as f_out:
+        shutil.copyfileobj(f_in, f_out)
+    return dst
 
 
 def compress_log(input_file: str):
     """
-    Compress a log file using Zstandard.
+    Compress a log file, preferring Zstandard and falling back to gzip.
 
-    Creates ``input_file.zst`` and removes the original when compression
-    succeeds. If ``zstandard`` is unavailable the original file is left in
-    place uncompressed.
+    Creates ``input_file.zst`` (or ``input_file.gz`` when ``zstandard`` is
+    unavailable) and removes the original once compression succeeds.
 
     Args:
         input_file: Path to the file to compress
     """
-    if compress_file_zstd(input_file, input_file + ".zst"):
+    out = compress_file(input_file)
+    if out is not None and out != input_file:
         os.remove(input_file)
 
 def capture_machine_id() -> str:

--- a/tests/test_writer_upload.py
+++ b/tests/test_writer_upload.py
@@ -46,6 +46,13 @@ def _zstd_read_text(path):
         return reader.read().decode()
 
 
+def _gz_read_text(path):
+    """Decompress a .gz file to text for round-trip assertions."""
+    import gzip
+    with gzip.open(path, "rb") as f:
+        return f.read().decode()
+
+
 from src.tracer.WriterManager import WriteManager
 
 
@@ -144,9 +151,9 @@ class PerFileUploadTests(unittest.TestCase):
 
 class ZstandardMissingFallbackTests(unittest.TestCase):
     """When the optional ``zstandard`` library is unavailable, the tracer must
-    keep (and upload) trace files uncompressed rather than losing data. These
-    tests force the missing-dependency path so they run regardless of whether
-    ``zstandard`` happens to be installed.
+    fall back to gzip (.gz / .tar.gz) — using the standard library — rather than
+    leaving trace files uncompressed. These tests force the missing-dependency
+    path so they run regardless of whether ``zstandard`` happens to be installed.
     """
 
     def setUp(self):
@@ -184,25 +191,29 @@ class ZstandardMissingFallbackTests(unittest.TestCase):
             f.write(text)
         return path
 
-    def test_compress_log_uploads_uncompressed_when_zstd_missing(self):
+    def test_compress_log_uploads_gzip_when_zstd_missing(self):
         src = self._make_log("process", "process_x.csv", "a,b,c\n1,2,3\n")
         self.wm.compress_log(src)
 
-        # The uncompressed .csv is uploaded and left on disk; no .zst created.
-        self.assertEqual(self.upload.uploaded, [src])
-        self.assertTrue(os.path.exists(src))
+        # The gzip-compressed .gz is uploaded; the original .csv is removed and
+        # no .zst is created.
+        gz = src + ".gz"
+        self.assertEqual(self.upload.uploaded, [gz])
+        self.assertTrue(os.path.exists(gz))
+        self.assertFalse(os.path.exists(src))
         self.assertFalse(os.path.exists(src + ".zst"))
-        with open(src) as f:
-            self.assertEqual(f.read(), "a,b,c\n1,2,3\n")
+        # Content round-trips through gzip.
+        self.assertEqual(_gz_read_text(gz), "a,b,c\n1,2,3\n")
 
-    def test_compress_dir_falls_back_to_plain_tar(self):
+    def test_compress_dir_falls_back_to_tar_gz(self):
         self.wm.automatic_upload = False
         self._make_log("process", "process_x.csv", "row\n")
         self.wm.compress_dir(self.output_dir)
 
-        # A plain .tar bundle is produced instead of .tar.zst.
-        self.assertTrue(os.path.exists(self.output_dir.rstrip("/") + ".tar"))
+        # A gzip-compressed .tar.gz bundle is produced instead of .tar.zst.
+        self.assertTrue(os.path.exists(self.output_dir.rstrip("/") + ".tar.gz"))
         self.assertFalse(os.path.exists(self.output_dir.rstrip("/") + ".tar.zst"))
+        self.assertFalse(os.path.exists(self.output_dir.rstrip("/") + ".tar"))
 
 
 class StaleLogRotationTests(unittest.TestCase):


### PR DESCRIPTION
## Summary

When the optional `zstandard` library is missing, the tracer used to leave trace files **completely uncompressed** (and emit the warning you saw). This PR makes it fall back to **gzip (`.gz`)** using the Python standard library, so trace logs are always compressed regardless of whether `zstandard` is installed.

Zstandard remains the preferred codec (faster, smaller `.zst`); gzip is only used as the fallback.

## What changed

- **`src/utility/utils.py`**
  - New `compress_file(src)` helper: compresses to `.zst` when `zstandard` is available, otherwise `.gz` (stdlib `gzip`), returning the output path.
  - New `compressed_suffix()` helper.
  - `compress_log()` now routes through `compress_file()`.
  - Updated the "missing zstandard" warning to say it falls back to gzip instead of "kept uncompressed".
- **`src/tracer/WriterManager.py`**
  - `compress_log()`, `flush_fssnap_only()` route through the codec-agnostic helper.
  - `compress_dir()` falls back to `.tar.gz` (was a raw `.tar`).
  - Snapshot completion now detects `.csv.zst` / `.csv.gz` / `.csv`.
- **`scripts/smoke_test.sh`** — decompress `.gz` fs shards too.
- **Tests** — `ZstandardMissingFallbackTests` now assert gzip output (`.gz` / `.tar.gz`) and round-trip the content.
- **Docs** — README, install.sh warnings, and the multipart-snapshot doc updated.

## Testing

`python3 -m unittest discover -s tests` → **92 passed**, both with and without `zstandard` installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Lxz8E9ZQjwstJkfo6ccz1R)_