### PR TITLE
Fix fs request log stopping a few minutes into a trace (rw_staging map leak)

### DIFF
--- a/src/tracer/KernelProbeTracker.py
+++ b/src/tracer/KernelProbeTracker.py
@@ -87,23 +87,37 @@ class KernelProbeTracker:
             sys.exit(1)
             return False
 
+    # Number of concurrently in-flight probed-function instances a kretprobe can
+    # track. The kernel default is small (≈NR_CPUS), so for hot functions like
+    # vfs_read/vfs_write the return handler is silently missed once concurrency
+    # exceeds it ("nmissed"). Each miss leaves a staged entry uncollected; with
+    # LRU staging maps that just costs an event, but a large maxactive keeps the
+    # miss rate (and lost events) low under load.
+    KRETPROBE_MAXACTIVE = 4096
+
     def add_kretprobe(self, event: str, kprobe: str) -> bool:
         """
         Attach a kretprobe (kernel function return probe).
-        
+
         Args:
             event: Kernel function name to probe (e.g., "vfs_read")
             kprobe: Name of the BPF function to call when probe triggers
-            
+
         Returns:
             bool: True if attachment succeeded, False otherwise
-            
+
         Raises:
             SystemExit: If probe attachment fails
         """
         try:
             # logger("info", f"Attaching kprobe {event} to {kprobe}")
-            k = self.b.attach_kretprobe(event=event, fn_name=kprobe)
+            try:
+                k = self.b.attach_kretprobe(
+                    event=event, fn_name=kprobe, maxactive=self.KRETPROBE_MAXACTIVE
+                )
+            except TypeError:
+                # Older bcc without the maxactive kwarg: fall back to the default.
+                k = self.b.attach_kretprobe(event=event, fn_name=kprobe)
             self.kretprobes.append((event, k))
             return True
         except Exception as e:

--- a/src/tracer/prober/prober.c
+++ b/src/tracer/prober/prober.c
@@ -620,12 +620,15 @@ BPF_PERCPU_ARRAY(block_stats, u64, 3);
 BPF_HASH(tracer_config, u32, u32, 1);    /**< Key 0 = tracer PID to exclude */
 
 /* Direct I/O direction staged at entry (1 = write), consumed by the
- * iomap_dio_rw/__blockdev_direct_IO kretprobe. */
-BPF_HASH(dio_staging, u64, u8, 10240);
+ * iomap_dio_rw/__blockdev_direct_IO kretprobe. LRU so a missed kretprobe
+ * return (see rw_staging) evicts the oldest stale entry instead of wedging
+ * the map. */
+BPF_TABLE("lru_hash", u64, u8, dio_staging, 10240);
 
 /* vfs_fsync entry timestamp, used by trace_vfs_fsync_range to suppress the
- * duplicate event for the nested vfs_fsync -> vfs_fsync_range call. */
-BPF_HASH(fsync_inflight, u64, u64, 10240);
+ * duplicate event for the nested vfs_fsync -> vfs_fsync_range call. LRU so a
+ * missed kretprobe return cannot leak entries until the map is full. */
+BPF_TABLE("lru_hash", u64, u64, fsync_inflight, 10240);
 
 /* io_uring request tracking map. LRU because completions that bypass the
  * probed completion path (batched completions on modern kernels) would
@@ -647,21 +650,30 @@ struct open_path_t {
   s32 dfd;                     /**< openat dirfd arg (AT_FDCWD for cwd-relative) */
 };
 
+/* All of the *_staging maps below pair an entry probe (which inserts) with a
+ * kretprobe (which looks up, submits, and deletes). A kretprobe return can be
+ * silently missed when in-flight instances of a hot function exceed maxactive,
+ * which would leave the entry staged forever. A plain BPF_HASH rejects every
+ * new key once full (-E2BIG), permanently stopping the corresponding events
+ * (read/write being the highest-volume, this manifested as the fs request log
+ * dying a few minutes into a trace). LRU instead evicts the oldest stale entry
+ * so events keep flowing. Mirrors io_uring_submit_map / the block maps. */
+
 /* Staged path from trace_do_sys_openat2_entry, consumed by trace_vfs_open */
-BPF_HASH(open_path_staging, u64, struct open_path_t, 4096);
+BPF_TABLE("lru_hash", u64, struct open_path_t, open_path_staging, 4096);
 
 /* Staged event data from trace_vfs_open, completed by trace_sys_openat_ret */
-BPF_HASH(open_staging, u64, struct data_t, 4096);
+BPF_TABLE("lru_hash", u64, struct data_t, open_staging, 4096);
 
 /* Staged MMAP event from do_mmap entry, completed by the do_mmap kretprobe. */
-BPF_HASH(mmap_staging, u64, struct data_t, 4096);
+BPF_TABLE("lru_hash", u64, struct data_t, mmap_staging, 4096);
 
 /* Staged READ/WRITE event from the vfs_read/vfs_write entry probe, completed by
  * the matching kretprobe which fills in the return value and latency. */
-BPF_HASH(rw_staging, u64, struct data_t, 10240);
+BPF_TABLE("lru_hash", u64, struct data_t, rw_staging, 10240);
 
 /* Staged mremap args from sys_mremap entry, consumed by the kretprobe. */
-BPF_HASH(mremap_staging, u64, struct mremap_args, 4096);
+BPF_TABLE("lru_hash", u64, struct mremap_args, mremap_staging, 4096);
 
 /* ============================================================================
  * PERF OUTPUT BUFFERS


### PR DESCRIPTION
## Problem

The continuous fs request log (`fs/fs_*.csv`) stops emitting READ/WRITE events a few minutes into a trace, even though real I/O is still happening. Lower-volume ops (open/unlink/rename) keep trickling in, so the stream looks dead.

## Root cause

`vfs_read`/`vfs_write` are traced in two halves: an entry probe stages the event in the `rw_staging` BPF map, and a kretprobe completes it with the return value/latency, submits it, and **deletes** the staging entry.

```c
// entry
rw_staging.update(&pid_tgid, &data);
// return (kretprobe) — only runs if the return is NOT missed
events.perf_submit(ctx, data, sizeof(*data));
rw_staging.delete(&pid_tgid);
```

Two things combined to wedge it:

1. **Missed kretprobe returns leak entries.** Kretprobes were attached with no `maxactive`, so the kernel uses a small default for concurrently in-flight instances. `vfs_read`/`vfs_write` are among the hottest kernel functions, so under real concurrency some returns are silently missed (`nmissed`) — each miss leaves a `rw_staging` entry that is never deleted.
2. **A plain `BPF_HASH` rejects new keys once full.** `rw_staging` was `BPF_HASH(..., 10240)`. Once the leaked entries fill it, every new `update()` fails with `-E2BIG`, nothing is staged, the kretprobe's `lookup` returns NULL, and **no READ/WRITE event is ever emitted again.** It never recovers because nothing evicts stale entries.

The repo already uses `lru_hash` for exactly this reason on the block and io_uring maps; the VFS staging maps were just never given the same treatment.

## Fix

- Convert the leak-prone VFS staging maps (`rw_staging`, `open_staging`, `open_path_staging`, `mmap_staging`, `mremap_staging`, `dio_staging`, `fsync_inflight`) from `BPF_HASH` to `BPF_TABLE("lru_hash", ...)` so a full map evicts the oldest stale entry instead of rejecting new keys. (`tracer_config` stays a plain hash — it's a fixed config map and never leaks.)
- Attach kretprobes with a larger `maxactive` (4096) to cut the missed-return rate and lost events at the source, falling back gracefully on older bcc that lacks the kwarg.

Map APIs (`lookup`/`update`/`delete`) are unchanged, so no probe logic needed touching.

## Testing

BCC isn't available in the dev container, so the BPF was not compiled locally — the `bpf-compile` CI workflow will validate it. Python parses clean. Recommend a soak test under sustained read/write load (previously `rw_staging` filled toward 10240 and READ/WRITE events flatlined within minutes; with LRU they should keep flowing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YT6zHMcYTbbFg4Z9CUh2LW)_