### PR TITLE
Rename block-device trace stream 'ds' -> 'block'

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -17,7 +17,7 @@ Traces are stored in object storage with the following prefix structure:
 ```
 linux_trace_v4_test/{MACHINE_ID}/{YYYYMMDD_HHMMSS_mmm}/
 ├── fs/                    # VFS traces (also receives mirrored io_uring I/O)
-├── ds/                    # Block device traces
+├── block/                 # Block device traces
 ├── cache/                 # Page cache events (opt-in: --cache)
 ├── pagefault/             # Page fault events
 ├── nw_conn/               # Network connection lifecycle (opt-in: --network)

--- a/docs/TRACE_FORMAT.md
+++ b/docs/TRACE_FORMAT.md
@@ -14,7 +14,7 @@ Traces are uploaded to object storage with the following prefix structure:
 ```
 linux_trace_v4_test/{MACHINE_ID}/{YYYYMMDD_HHMMSS_mmm}/
 ├── fs/                    # VFS (Virtual File System) traces
-├── ds/                    # Block device traces
+├── block/                 # Block device traces
 ├── cache/                 # Page cache events (opt-in: --cache)
 ├── pagefault/             # Memory-mapped page fault events
 ├── nw_conn/               # Network connection lifecycle (opt-in: --network)
@@ -78,7 +78,7 @@ For operations captured and examples, see [VFS_EVENTS.md](traces/VFS_EVENTS.md).
 
 ## 2. Block Device Traces
 
-**Location:** `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/ds/ds_*.csv.zst`
+**Location:** `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/block/block_*.csv.zst`
 
 **Description:** Captures block layer I/O operations with latency measurements from issue to completion.
 
@@ -89,7 +89,8 @@ timestamp,operation,pid,tid,command,sector,size,latency_ms,device,flags,cpu_id,p
 ```
 
 **Cross-OS aligned.** Columns 1–10 (`timestamp` … `flags`) are the
-**shared prefix** emitted identically by the Windows tracer's `ds/` stream. The
+**shared prefix** emitted identically by the Windows tracer's `ds/` stream (the
+Linux stream is named `block/`; the column layout is identical). The
 `operation` column now holds the **base op only** (`read`, `write`, `flush`,
 `discard`, …); the rwbs sub-flags (`sync`, `meta`, `ahead`, …) that used to be
 appended to it (e.g. `write|sync`) now live in the dedicated `flags` column.

--- a/docs/TRACE_TYPES.md
+++ b/docs/TRACE_TYPES.md
@@ -7,7 +7,7 @@ IO Tracer uses eBPF/BPF technology to intercept kernel functions and collect var
 | # | Trace Type | Description | Output |
 |---|------------|-------------|--------|
 | 1 | [VFS Events](traces/VFS_EVENTS.md) | File system operations at the VFS layer | `fs/fs_*.csv` |
-| 2 | [Block I/O Events](traces/BLOCK_IO_EVENTS.md) | Block-level device I/O operations | `ds/ds_*.csv` |
+| 2 | [Block I/O Events](traces/BLOCK_IO_EVENTS.md) | Block-level device I/O operations | `block/block_*.csv` |
 | 3 | [Page Cache Events](traces/PAGE_CACHE_EVENTS.md) | Page cache hits, misses, writebacks, evictions | `cache/cache_*.csv` |
 | 4 | [Page Fault Events](traces/PAGE_FAULT_EVENTS.md) | File-backed page faults from mmap access | `pagefault/pagefault_*.csv` |
 | 5 | [Network Events](traces/NETWORK_EVENTS.md) | Connection lifecycle, socket options, drops | `nw_conn/*.csv`, `nw_sockopt/*.csv`, `nw_drop/*.csv` |
@@ -61,7 +61,7 @@ IO Tracer uses eBPF/BPF technology to intercept kernel functions and collect var
 │  ┌────────▼────────┐                                           │
 │  │  WriterManager  │    Output:                               │
 │  │                  │    • fs/*.csv.zst (VFS events)          │  │
-│  │                  │    • ds/*.csv.zst (block events)        │  │
+│  │                  │    • block/*.csv.zst (block events)     │  │
 │  │                  │    • cache/*.csv.zst (cache events)     │  │
 │  │                  │    • pagefault/*.csv.zst (page faults)  │  │
 │  │                  │    • filesystem_snapshot/*.csv.zst      │  │

--- a/docs/traces/BLOCK_IO_EVENTS.md
+++ b/docs/traces/BLOCK_IO_EVENTS.md
@@ -141,4 +141,4 @@ Character flags from the block layer tracepoint `rwbs` string. Each character in
 | `P` | PRIO | High priority |
 | `B` | BARRIER | Barrier (legacy) |
 
-**Output File:** `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/ds/ds_*.csv.zst`
+**Output File:** `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/block/block_*.csv.zst`

--- a/docs/traces/MANIFEST.md
+++ b/docs/traces/MANIFEST.md
@@ -18,7 +18,7 @@ adapt rather than assume a fixed layout.
 |---------|--------|
 | 1 | Headerless CSVs, no manifest, per-stream clocks. |
 | 2 | **CSV header row** on every file + this manifest + a common `mono_ns` (CLOCK_MONOTONIC) column appended to every stream. |
-| 3 | **Cross-OS aligned** `fs`/`ds` layout: a fixed shared column prefix (identical names/order to the Windows tracer), **lowercase** canonical operation names, `size_requested` renamed to `size`, and a dedicated block `flags` column (rwbs sub-flags split out of `operation`). |
+| 3 | **Cross-OS aligned** `fs`/`block` column layout: a fixed shared column prefix (identical names/order to the Windows tracer, whose equivalent stream is named `ds`), **lowercase** canonical operation names, `size_requested` renamed to `size`, and a dedicated block `flags` column (rwbs sub-flags split out of `operation`). |
 
 As of **schema_version 2**:
 
@@ -39,7 +39,7 @@ As of **schema_version 2**:
     "fs":  { "subdir": "fs", "filename_prefix": "fs", "description": "...",
              "wall_clock": "CLOCK_REALTIME (derived from kernel CLOCK_MONOTONIC)",
              "columns": [ { "name": "timestamp", "type": "datetime", "unit": "", "description": "..." }, ... ] },
-    "ds":  { ... }, "cache": { ... }, "pagefault": { ... },
+    "block":  { ... }, "cache": { ... }, "pagefault": { ... },
     "process": { ... }, "filesystem_snapshot": { ... }
   },
   "tracer":  { "version": "..." },
@@ -54,7 +54,7 @@ As of **schema_version 2**:
   "session": { "started_at": "ISO-8601", "stopped_at": "ISO-8601", "duration_seconds": 123.4 },
   "diagnostics": {
     "attached_probes": [ "vfs_read", "vfs_write", "block_rq_complete", ... ],
-    "lost_events":     { "fs": 0, "ds": 0 },
+    "lost_events":     { "fs": 0, "block": 0 },
     "rows_written":    { "VFS": 12345, "Block": 678, ... },
     "block":           { "issued": 1000, "completed": 990, "missed": 10 }
   }

--- a/src/tracer/IOTracer.py
+++ b/src/tracer/IOTracer.py
@@ -1316,7 +1316,7 @@ class IOTracer:
         self.b["bl_events"].open_perf_buffer(
             self._print_event_block,
             page_cnt=self.page_cnt,
-            lost_cb=self._make_lost_cb("ds")
+            lost_cb=self._make_lost_cb("block")
         )
 
         # Page-cache events are opt-in (--cache). The probes are only attached

--- a/src/tracer/WriterManager.py
+++ b/src/tracer/WriterManager.py
@@ -58,7 +58,7 @@ class WriteManager:
         
     Output Files:
         fs/*.csv: File system operation traces
-        ds/*.csv: Block device traces
+        block/*.csv: Block device traces
         cache/*.csv: Page cache event traces
         process/*.csv: Process state snapshots
         filesystem_snapshot/*.csv: Filesystem snapshot
@@ -85,7 +85,7 @@ class WriteManager:
         self.status_log_interval = 60  # Log status every 60 seconds
         self.output_dir = output_dir
         self.output_vfs_file = f"{self.output_dir}/fs/fs_{self.current_datetime.strftime('%Y%m%d_%H%M%S_%f')[:-3]}.csv"
-        self.output_block_file = f"{self.output_dir}/ds/ds_{self.current_datetime.strftime('%Y%m%d_%H%M%S_%f')[:-3]}.csv"
+        self.output_block_file = f"{self.output_dir}/block/block_{self.current_datetime.strftime('%Y%m%d_%H%M%S_%f')[:-3]}.csv"
         self.output_cache_file = f"{self.output_dir}/cache/cache_{self.current_datetime.strftime('%Y%m%d_%H%M%S_%f')[:-3]}.csv"
         self.output_process_file = f"{self.output_dir}/process/process_{self.current_datetime.strftime('%Y%m%d_%H%M%S_%f')[:-3]}.csv"
         self.output_fs_snapshot_file = f"{self.output_dir}/filesystem_snapshot/filesystem_snapshot_{self.current_datetime.strftime('%Y%m%d_%H%M%S_%f')[:-3]}.csv"
@@ -99,7 +99,7 @@ class WriteManager:
         # Create output directories
         os.makedirs(f"{self.output_dir}/system_spec", exist_ok=True)
         os.makedirs(f"{self.output_dir}/fs", exist_ok=True)
-        os.makedirs(f"{self.output_dir}/ds", exist_ok=True)
+        os.makedirs(f"{self.output_dir}/block", exist_ok=True)
         os.makedirs(f"{self.output_dir}/cache", exist_ok=True)
         os.makedirs(f"{self.output_dir}/process", exist_ok=True)
         os.makedirs(f"{self.output_dir}/filesystem_snapshot", exist_ok=True)
@@ -209,7 +209,7 @@ class WriteManager:
         # and current output path, plus its output subdir/prefix and log label.
         self._streams = {
             'vfs':       {'subdir': 'fs',        'prefix': 'fs',        'buf': 'vfs_buffer',       'handle': '_vfs_handle',       'file': 'output_vfs_file',       'log': 'VFS'},
-            'block':     {'subdir': 'ds',        'prefix': 'ds',        'buf': 'block_buffer',     'handle': '_block_handle',     'file': 'output_block_file',     'log': 'Block'},
+            'block':     {'subdir': 'block',     'prefix': 'block',     'buf': 'block_buffer',     'handle': '_block_handle',     'file': 'output_block_file',     'log': 'Block'},
             'cache':     {'subdir': 'cache',     'prefix': 'cache',     'buf': 'cache_buffer',     'handle': '_cache_handle',     'file': 'output_cache_file',     'log': 'Cache'},
             'pagefault': {'subdir': 'pagefault', 'prefix': 'pagefault', 'buf': 'pagefault_buffer', 'handle': '_pagefault_handle', 'file': 'output_pagefault_file', 'log': 'PageFault'},
             'nw_conn':    {'subdir': 'nw_conn',    'prefix': 'nw_conn',    'buf': 'nw_conn_buffer',    'handle': '_nw_conn_handle',    'file': 'output_nw_conn_file',    'log': 'NetConn'},
@@ -245,7 +245,7 @@ class WriteManager:
 
     # WriteManager stream key -> schema.STREAMS key.
     _SCHEMA_KEY = {
-        'vfs': 'fs', 'block': 'ds', 'cache': 'cache', 'pagefault': 'pagefault',
+        'vfs': 'fs', 'block': 'block', 'cache': 'cache', 'pagefault': 'pagefault',
         'process': 'process', 'fs_snap': 'filesystem_snapshot',
         'nw_conn': 'nw_conn',
         'nw_sockopt': 'nw_sockopt', 'nw_drop': 'nw_drop',
@@ -1080,7 +1080,7 @@ class WriteManager:
                 self.created_files += 1
                 logger('info', f"Files Created: {str(self.created_files)}", True)
                 # Upload each log individually, preserving its subdirectory
-                # (fs, ds, cache, process, ...) on the backend.
+                # (fs, block, cache, process, ...) on the backend.
                 self.upload_manager.append_object(upload_target)
             if compressed is not None and compressed != src:
                 os.remove(src)

--- a/src/tracer/schema.py
+++ b/src/tracer/schema.py
@@ -18,13 +18,15 @@ it from ``manifest.json`` and adapt.
 # Historical format evolution (for reference only — see the note below):
 # v1: original headerless CSVs, no manifest, per-stream clocks.
 # v2: CSV headers + manifest.json + a common ``mono_ns`` column on every stream.
-# v3: cross-OS aligned layout for ``fs`` and ``ds`` — a fixed shared column
-#     prefix (identical names/order to the Windows tracer) followed by the
+# v3: cross-OS aligned column layout for ``fs`` and ``block`` — a fixed shared
+#     column prefix (identical names/order to the Windows tracer) followed by the
 #     Linux-only extras, lowercase canonical operation names, ``size_requested``
 #     renamed to ``size``, and a dedicated block ``flags`` column (rwbs sub-flags
-#     split out of ``operation``).
+#     split out of ``operation``). NOTE: the column layout still matches the
+#     Windows tracer, but this Linux stream is named ``block`` (subdir/prefix
+#     ``block``) where the Windows tracer calls the equivalent stream ``ds``.
 # Schema version stamped into manifest.json. Reset to 1 by request; the column
-# layout remains the cross-OS aligned fs/ds format described below.
+# layout remains the cross-OS aligned fs/block format described below.
 # NOTE: this overrides the historical v1–v3 numbering above — the on-disk format
 # is the aligned layout (what the changelog calls v3), not the original v1 format.
 SCHEMA_VERSION = 1
@@ -88,8 +90,8 @@ STREAMS = {
             _col("fs_type", "string", "", "Source filesystem name from superblock magic."),
         ],
     ),
-    "ds": _stream(
-        "ds", "ds",
+    "block": _stream(
+        "block", "block",
         "Block-device (disk) I/O completion events.",
         "CLOCK_REALTIME (derived from kernel CLOCK_MONOTONIC)",
         [

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -17,7 +17,7 @@ from src.tracer import schema
 # the number of fields each callback passes to format_csv_row.
 EXPECTED_COLUMN_COUNTS = {
     "fs": 23,                  # 22 documented + mono_ns
-    "ds": 17,                  # 16 documented (incl. aligned flags col) + mono_ns
+    "block": 17,               # 16 documented (incl. aligned flags col) + mono_ns
     "cache": 11,               # 10 + mono_ns
     "pagefault": 11,           # 10 + mono_ns
     "nw_conn": 18,             # 17 + mono_ns
@@ -27,8 +27,10 @@ EXPECTED_COLUMN_COUNTS = {
     "filesystem_snapshot": 7,  # 6 + mono_ns
 }
 
-# Cross-OS aligned shared column prefix. These leading columns must
-# match the Windows tracer's fs/ds streams exactly and in the same order.
+# Cross-OS aligned shared column prefix. These leading columns must match the
+# Windows tracer's fs/ds streams exactly and in the same order. (The Linux
+# block stream is named ``block``; the Windows equivalent is named ``ds``, but
+# the column layouts are identical.)
 ALIGNED_FS_PREFIX = [
     "timestamp", "operation", "pid", "tid", "command", "filename",
     "size", "offset", "bytes_completed", "inode", "device", "flags",
@@ -43,10 +45,10 @@ class SchemaShapeTests(unittest.TestCase):
     def test_schema_version_is_1(self):
         self.assertEqual(schema.SCHEMA_VERSION, 1)
 
-    def test_fs_ds_aligned_prefix(self):
+    def test_fs_block_aligned_prefix(self):
         self.assertEqual(schema.column_names("fs")[:len(ALIGNED_FS_PREFIX)],
                          ALIGNED_FS_PREFIX)
-        self.assertEqual(schema.column_names("ds")[:len(ALIGNED_DS_PREFIX)],
+        self.assertEqual(schema.column_names("block")[:len(ALIGNED_DS_PREFIX)],
                          ALIGNED_DS_PREFIX)
 
     def test_all_streams_present(self):

--- a/tests/test_writer_upload.py
+++ b/tests/test_writer_upload.py
@@ -2,7 +2,7 @@
 Unit tests for WriteManager's per-file upload behavior.
 
 Trace logs are uploaded individually (no tar bundling), each under its own
-subdirectory (fs, ds, cache, process, ...), and the per-stream flush
+subdirectory (fs, block, cache, process, ...), and the per-stream flush
 thresholds are sized so each rotated log is large. These tests use a fake
 upload manager so no network or kernel access is required.
 
@@ -121,14 +121,14 @@ class PerFileUploadTests(unittest.TestCase):
     @unittest.skipUnless(HAS_ZSTD, "zstandard not installed")
     def test_upload_preserves_subdirectory(self):
         # The backend file_type is derived from the parent directory, so each
-        # stream must stay under its own subdir (fs, ds, cache, ...).
-        for subdir in ("fs", "ds", "cache", "process"):
+        # stream must stay under its own subdir (fs, block, cache, ...).
+        for subdir in ("fs", "block", "cache", "process"):
             src = self._make_log(subdir, f"{subdir}_x.csv", "row\n")
             self.wm.compress_log(src)
 
         self.assertEqual(len(self.upload.uploaded), 4)
         parents = {os.path.basename(os.path.dirname(p)) for p in self.upload.uploaded}
-        self.assertEqual(parents, {"fs", "ds", "cache", "process"})
+        self.assertEqual(parents, {"fs", "block", "cache", "process"})
 
     @unittest.skipUnless(HAS_ZSTD, "zstandard not installed")
     def test_no_upload_when_automatic_disabled(self):
@@ -268,7 +268,7 @@ class StaleLogRotationTests(unittest.TestCase):
 
         self.assertEqual(len(self.upload.uploaded), 1)
         self.assertEqual(
-            os.path.basename(os.path.dirname(self.upload.uploaded[0])), "ds"
+            os.path.basename(os.path.dirname(self.upload.uploaded[0])), "block"
         )
 
     def test_fresh_small_log_is_not_rotated(self):


### PR DESCRIPTION
## What

Renames the block-device (disk) I/O trace stream identifier from `ds` to `block` across the schema, writer, tracer, tests, and docs. This makes the on-disk stream name match the internal `block` terminology already used throughout `WriterManager` (buffers, limits, the stream registry, the `block` WM key).

## Changes to the on-disk layout

- Output subdir `ds/` → `block/`
- File prefix `ds_*.csv` → `block_*.csv`
- Schema `STREAMS` key `"ds"` → `"block"` (`schema.py`)
- Manifest `lost_events` label `"ds"` → `"block"` (`IOTracer.py`)
- `WriterManager._streams['block']` subdir/prefix and `_SCHEMA_KEY['block']` mapping

## Cross-OS note

The **column layout is unchanged** and still matches the Windows tracer's equivalent stream byte-for-byte (`ALIGNED_DS_PREFIX` columns are untouched). Windows names that stream `ds`; only the Linux **stream name** now diverges to `block`. Comments and docs (`schema.py`, `TRACE_FORMAT.md`, `MANIFEST.md`, `test_schema.py`) are updated to record this naming difference. Per the decision to rename anyway, alignment of the *data* is preserved while the directory/stream name is changed.

## Validation

Full test suite passes locally (89 tests, `zstandard` installed so the upload-path tests run too — including the ones asserting the rotated block log lands under `block/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G3YmEijkgqUF7sPR72DpW7)_