### PR TITLE
docs: reset manifest schema_version to 1

### DIFF
--- a/docs/traces/MANIFEST.md
+++ b/docs/traces/MANIFEST.md
@@ -12,16 +12,15 @@ and rewritten at shutdown with the stop time and final diagnostics.
 ## Schema versioning
 
 `schema_version` identifies the on-disk format. Consumers should read it and
-adapt rather than assume a fixed layout.
+adapt rather than assume a fixed layout. The current value is **`1`**
+(`SCHEMA_VERSION` in `src/tracer/schema.py`).
 
-| Version | Format |
-|---------|--------|
-| 1 | Headerless CSVs, no manifest, per-stream clocks. |
-| 2 | **CSV header row** on every file + this manifest + a common `mono_ns` (CLOCK_MONOTONIC) column appended to every stream. |
-| 3 | **Cross-OS aligned** `fs`/`ds` layout: a fixed shared column prefix (identical names/order to the Windows tracer), **lowercase** canonical operation names, `size_requested` renamed to `size`, and a dedicated block `flags` column (rwbs sub-flags split out of `operation`). |
+The current format (**schema_version 1**) is the **cross-OS aligned** layout:
 
-As of **schema_version 2**:
-
+- The `fs`/`ds` streams use a fixed shared column prefix (identical names/order
+  to the Windows tracer), **lowercase** canonical operation names, `size`
+  (formerly `size_requested`), and a dedicated block `flags` column (rwbs
+  sub-flags split out of `operation`).
 - Every CSV file (including rotated parts) begins with a **header row** naming
   its columns — the same names listed under `streams.<key>.columns` here.
 - Every record carries a trailing **`mono_ns`** column: `CLOCK_MONOTONIC`
@@ -34,7 +33,7 @@ As of **schema_version 2**:
 
 ```jsonc
 {
-  "schema_version": 2,
+  "schema_version": 1,
   "streams": {
     "fs":  { "subdir": "fs", "filename_prefix": "fs", "description": "...",
              "wall_clock": "CLOCK_REALTIME (derived from kernel CLOCK_MONOTONIC)",


### PR DESCRIPTION
## Summary

`SCHEMA_VERSION` in `src/tracer/schema.py` is already **1** (the cross-OS aligned `fs`/`ds` layout), and the test suite asserts this. However, `docs/traces/MANIFEST.md` still documented the format as **schema_version 2** — both in the JSON example (`"schema_version": 2`) and in the versioning narrative.

This PR brings the doc in sync with the code:

- The example manifest now shows `"schema_version": 1`.
- The "Schema versioning" section now describes schema_version 1 as the current cross-OS aligned layout, matching the framing already in `schema.py` (which notes the reset-to-1 overrides the historical v1–v3 numbering).

## Testing

- `python -m unittest tests.test_schema -v` — all 11 tests pass, including `test_schema_version_is_1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_0126Cvw7k9YPKr3txk6tbKdp)_