### PR TITLE
Enlarge block issue-tracking maps and split the miss diagnostic

### DIFF
--- a/src/tracer/IOTracer.py
+++ b/src/tracer/IOTracer.py
@@ -1190,22 +1190,41 @@ class IOTracer:
     def _log_block_diagnostics(self):
         """Log a summary of block-tracing health from ``block_stats``.
 
-        A high miss rate means the issue map was evicted under load (completions
-        dropped) — the likely explanation if block events appear to stop before
-        the end of a long trace.
+        Completions with no matching issue ctx (``missed``) split into two kinds
+        with different remedies:
+
+        * **structural** — completions whose issue was never seen by the trace
+          (in-flight before tracing started, or via a path that does not fire
+          ``block_rq_issue``). Bounded by ``total_completions - issued`` and
+          irreducible by map sizing.
+        * **evictable** — the remainder: an issue ctx *was* recorded but was lost
+          before its completion, via LRU eviction under load or ``(dev,sector)``
+          key overwrite by a concurrent in-flight request. A larger
+          ``block_start_times`` map reduces the eviction part.
+
+        Reporting the split avoids blaming all misses on eviction (the previous
+        behavior), which over-stated how much a bigger map can recover.
         """
         s = self._block_stats()
         if not s:
             return
         stale = s.get("stale", 0)
-        total_completions = s["completed"] + s["missed"] + stale
-        miss_pct = (s["missed"] / total_completions * 100) if total_completions else 0.0
+        missed = s["missed"]
+        total_completions = s["completed"] + missed + stale
+        miss_pct = (missed / total_completions * 100) if total_completions else 0.0
+        # Excess completions over issues had no recorded issue at all (structural,
+        # unfixable by sizing); the rest were recorded then lost (evictable).
+        structural = max(0, total_completions - s["issued"])
+        structural = min(structural, missed)
+        evictable = missed - structural
         logger("info",
                f"Block diagnostics: {s['issued']} issued, {s['completed']} completed, "
-               f"{s['missed']} completions without a tracked issue "
-               f"({miss_pct:.1f}% of completions), {stale} dropped as stale "
-               f"((dev,sector) key reuse). A high miss rate indicates the "
-               f"issue map was evicted under load (dropped completions).")
+               f"{missed} completions without a tracked issue "
+               f"({miss_pct:.1f}% of completions) — {structural} structural "
+               f"(issue never seen; pre-trace or un-issued path) and {evictable} "
+               f"evictable (issue lost to LRU eviction or (dev,sector) key reuse; "
+               f"reducible with a larger issue map). {stale} dropped as stale "
+               f"((dev,sector) key reuse).")
 
     def _attached_probes(self):
         """Sorted list of kernel functions the tracer has probes attached to."""

--- a/src/tracer/prober/prober.c
+++ b/src/tracer/prober/prober.c
@@ -691,9 +691,22 @@ struct block_rq_key_t {
 
 /* Block layer latency tracking maps. LRU so that requests that never
  * complete (e.g. merged into another request) cannot permanently fill the
- * map and starve later requests. */
-BPF_TABLE("lru_hash", struct block_rq_key_t, struct block_issue_ctx, block_start_times, 10240); /**< Issue time + submitter, keyed by dev+sector */
-BPF_TABLE("lru_hash", struct block_rq_key_t, u64, block_insert_times, 10240);  /**< Tracks block request insert time (queue latency) */
+ * map and starve later requests.
+ *
+ * Sized at 65536 (was 10240). The map holds in-flight requests plus the
+ * residue of requests that are issued but never reach block_rq_complete
+ * (merged/requeued), which accumulate until LRU-evicted. Under sustained
+ * load that residue can approach the old 10240 ceiling and start evicting
+ * still-in-flight issue contexts, so their completions arrive with no match
+ * and are dropped (the block_stats[2] "miss" counter). The larger ceiling
+ * gives ~6x headroom for the never-completing residue before eviction kicks
+ * in, recovering the evictable share of those misses. (It cannot recover
+ * completions whose issue was never seen at all — pre-trace in-flight or
+ * un-issued paths; those are a structural floor, reported separately at exit.)
+ * Cost is ~10 MB of kernel memory across both maps, well within the resource
+ * envelope that gates block tracing. */
+BPF_TABLE("lru_hash", struct block_rq_key_t, struct block_issue_ctx, block_start_times, 65536); /**< Issue time + submitter, keyed by dev+sector */
+BPF_TABLE("lru_hash", struct block_rq_key_t, u64, block_insert_times, 65536);  /**< Tracks block request insert time (queue latency) */
 
 /* Monotonic generator for per-request IDs (see block_event.req_id). A single
  * u64 bumped atomically at issue time; lets consumers disambiguate repeated


### PR DESCRIPTION
## Motivation

On a real ~18-minute capture, the exit diagnostic reported:

> 17084 issued, 12626 completed, **6678 completions without a tracked issue (34.6% of completions)**, 0 dropped as stale

A block completion that can't be matched back to its issue event is dropped — those I/Os get **no device latency (issue→completion) and no queue latency**. A 34.6% miss rate means a third of completions had no latency data.

## Root cause (two parts, not one)

The matcher `block_start_times` is an `lru_hash` keyed by `(dev, sector)`, and entries are **deleted on completion**, so it holds in-flight requests plus the residue of requests that are issued but never reach `block_rq_complete` (merged/requeued). That residue accumulates until LRU-evicted.

Decomposing the run's counters:
- 12,626 matched + 6,678 missed = **19,304 total completions**, but only **17,084 issued**.
- **2,220** completions had no issue event in the trace at all (in-flight before tracing started, or an un-issued path) — a **structural floor**, irreducible by map sizing.
- The remaining **~4,458** are issues that *were* recorded but lost before completion: **LRU eviction** under load or **`(dev,sector)` key overwrite** by a concurrent in-flight request — the **evictable** part.

The old diagnostic attributed *all* misses to eviction, over-stating what a bigger map can recover.

## Changes

1. **`prober.c`**: enlarge `block_start_times` and `block_insert_times` from **10240 → 65536** entries (matching `io_uring_submit_map`). ~6× headroom for the never-completing residue before eviction starts dropping still-in-flight issue contexts. Cost ~10 MB kernel memory, within the resource envelope that already gates block tracing.
2. **`IOTracer._log_block_diagnostics`**: split the miss count into **structural** (`total_completions - issued`, capped at `missed`) vs **evictable** (remainder), so the metric says which part a larger map can help and which is a floor.

## Expected impact

- Reduces the **evictable** share (~4,458 in the sample run) by giving the issue map far more headroom.
- The **structural** share (~2,220, ≈12% of completions) is unaffected — and now reported honestly rather than mislabeled as eviction.

## Validation

- Diagnostic arithmetic verified against the real counters: `34.6%` miss → `2220` structural + `4458` evictable.
- Full Python suite green (93 passed, 9 skipped). The `prober.c` change is covered by the BPF Compile CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y3hLsnNgvn8d4dt7LmZeB4)_