### PR TITLE
Upload low-volume streams (network/block) mid-trace instead of only at shutdown

### DIFF
--- a/src/tracer/WriterManager.py
+++ b/src/tracer/WriterManager.py
@@ -222,7 +222,7 @@ class WriteManager:
         # queued for upload) once it is older than max_file_age or larger than
         # max_file_bytes, even if it never reaches its event-count threshold.
         # Monotonic open-times so the age check ignores wall-clock jumps.
-        self.max_file_age = 20 * 60               # 20 minutes
+        self.max_file_age = 5 * 60                # 5 minutes
         self.max_file_bytes = 100 * 1024 * 1024   # 100 MB (uncompressed on disk)
         self._stream_opened = {key: time.monotonic() for key in self._streams}
         # Per-stream rotation sequence, appended to each rotated filename so two
@@ -828,7 +828,13 @@ class WriteManager:
             setattr(self, s['file'], new_file)
             setattr(self, s['handle'], self._open_log_file(new_file, key))
             self._stream_opened[key] = time.monotonic()
-            self._reset_flush_timer()
+            # NOTE: do NOT reset the periodic-flush timer here. A single stream's
+            # count-based rotation must not defer the global periodic write_to_disk
+            # of every OTHER stream: on a busy host fs/cache rotate every few
+            # seconds, so resetting the timer here starved write_to_disk entirely,
+            # leaving low-volume buffers (network especially) unwritten — and thus
+            # unrotated/un-uploaded — until shutdown. _maybe_rotate_stale_logs is
+            # now buffer-aware so slow streams still upload mid-trace regardless.
         # Compress outside the lock: compression + disk I/O is slow and must not block
         # the perf-callback flush or the periodic writer for this stream.
         if rotated is not None:
@@ -841,18 +847,26 @@ class WriteManager:
         any stream whose current file exceeds ``max_file_bytes`` or has been
         open longer than ``max_file_age`` is rotated and queued for upload.
         ``now`` is an injectable ``time.monotonic()`` reading for testing.
+
+        Buffered-but-unwritten rows count toward "has data": a low-volume stream
+        (network especially) may hold its rows in the in-memory buffer with an
+        empty on-disk file, because the periodic disk flush can be starved on a
+        busy host. Rotating on age still flushes those rows — _rotate_stream
+        lands the buffer into the file first — so the stream uploads mid-trace
+        instead of deferring to shutdown (where a hard kill would lose it).
         """
         if now is None:
             now = time.monotonic()
         for key, s in self._streams.items():
             cur_file = getattr(self, s['file'])
             try:
-                if not os.path.exists(cur_file):
-                    continue
-                size = os.path.getsize(cur_file)
+                size = os.path.getsize(cur_file) if os.path.exists(cur_file) else 0
             except OSError:
-                continue
-            if size <= 0:
+                size = 0
+            buf = getattr(self, s['buf'], None)
+            buffered = len(buf) if buf else 0
+            # Nothing on disk and nothing buffered -> genuinely empty, skip.
+            if size <= 0 and buffered == 0:
                 continue
             age = now - self._stream_opened.get(key, now)
             if size >= self.max_file_bytes or age >= self.max_file_age:

--- a/tests/test_writer_upload.py
+++ b/tests/test_writer_upload.py
@@ -278,10 +278,48 @@ class StaleLogRotationTests(unittest.TestCase):
 
     def test_missing_or_empty_file_is_skipped(self):
         self.wm.max_file_age = 0  # treat everything as old
-        # No file written yet, and an empty one for another stream.
+        # No file written yet, and an empty one for another stream. With no
+        # buffered rows either, there is genuinely nothing to rotate.
         open(self.wm.output_cache_file, "w").close()
         self.wm._maybe_rotate_stale_logs()
         self.assertEqual(self.upload.uploaded, [])
+
+    @unittest.skipUnless(HAS_ZSTD, "zstandard not installed")
+    def test_age_rotation_uploads_buffered_rows_with_empty_file(self):
+        # Regression: a low-volume stream can hold rows only in memory while its
+        # on-disk file is still empty (the periodic write_to_disk was starved by
+        # frequent count-rotations of busy streams). Age-based rotation must
+        # still flush+upload those buffered rows mid-trace, not defer to shutdown
+        # — otherwise a hard kill loses the whole stream (the symptom seen for
+        # the network streams in live captures).
+        self.wm.max_file_bytes = 10**12  # disable size trigger
+        self.wm.nw_conn_buffer.append("ts,CONNECT,1,1,proc,AF_INET")
+        self.wm.nw_conn_buffer.append("ts,CLOSE,1,1,proc,AF_INET")
+        # Precondition: nothing on disk for this stream yet.
+        cur = self.wm.output_nw_conn_file
+        self.assertFalse(os.path.exists(cur) and os.path.getsize(cur) > 0)
+
+        now = self.wm._stream_opened["nw_conn"] + self.wm.max_file_age + 1
+        self.wm._maybe_rotate_stale_logs(now=now)
+
+        self.assertEqual(len(self.upload.uploaded), 1)
+        uploaded = self.upload.uploaded[0]
+        self.assertEqual(os.path.basename(os.path.dirname(uploaded)), "nw_conn")
+        content = _zstd_read_text(uploaded)
+        self.assertIn("CONNECT", content)
+        self.assertIn("CLOSE", content)
+        # Buffer was drained into the rotated file.
+        self.assertEqual(len(self.wm.nw_conn_buffer), 0)
+
+    def test_count_rotation_does_not_reset_periodic_flush_timer(self):
+        # Regression: a single stream's count-based rotation must not defer the
+        # global periodic write_to_disk that lands every other stream's buffer on
+        # disk. Resetting the shared flush timer on each rotation starved that
+        # flush on busy hosts (fs/cache rotate every few seconds).
+        self.wm.vfs_buffer.append("a,b,c")
+        before = self.wm._last_flush_time
+        self.wm._rotate_stream("vfs")
+        self.assertEqual(self.wm._last_flush_time, before)
 
     @unittest.skipUnless(HAS_ZSTD, "zstandard not installed")
     def test_rotate_flushes_buffered_rows(self):
@@ -297,7 +335,7 @@ class StaleLogRotationTests(unittest.TestCase):
         self.assertEqual(len(self.wm.vfs_buffer), 0)
 
     def test_rotation_defaults(self):
-        self.assertEqual(self.wm.max_file_age, 20 * 60)
+        self.assertEqual(self.wm.max_file_age, 5 * 60)
         self.assertEqual(self.wm.max_file_bytes, 100 * 1024 * 1024)
         # Snapshots must be excluded from generic rotation.
         self.assertNotIn("process", self.wm._streams)


### PR DESCRIPTION
## Problem

Low-volume continuous streams — the network streams (`nw_conn`/`nw_sockopt`/`nw_drop`), and `block` on an idle host — are **absent from live/in-progress captures** and **lost entirely on a hard kill** (SIGKILL/crash/power-loss). They only ever surface after a *clean* shutdown, as a single shard each. High-volume `fs`/`cache` are unaffected.

Observed on a ~13 h gpu1 capture: in a finished 59-minute run, `fs`/`cache` produced 9–12 shards each while `block`/`nw_*` produced **exactly 1 shard each, spanning the whole run** — i.e. no rotation ever fired despite the file being 3× older than `max_file_age`.

## Root cause

A mid-trace flush-starvation interaction in `WriteManager`:

1. `_maybe_rotate_stale_logs()` — the only path that uploads a low-volume stream mid-trace — **skipped any stream whose on-disk file was empty** (`if size <= 0: continue`), looking only at the file, not the in-memory buffer.
2. That file is populated only by the periodic `write_to_disk()` (every 300 s). But `_rotate_stream()` called `_reset_flush_timer()` on **every count-based rotation**, and on a busy host `fs`/`cache` count-rotate every few seconds — continuously resetting the timer so the 300 s gap is **never reached** and `write_to_disk()` **never runs during a trace**.

Net: a low-volume stream keeps its rows in RAM with a 0-byte file, `_maybe_rotate_stale_logs` skips it, and it is flushed only by `force_flush()` at clean shutdown. `SIGINT`/`SIGTERM` are handled (clean), but `SIGKILL`/crash loses the buffered data. This is why finished runs look complete while live ones appear to be "missing ds/nw".

## Fix

- **Make `_maybe_rotate_stale_logs()` buffer-aware** — rotate an aged/oversized stream when its file **or** its in-memory buffer has rows (`_rotate_stream` lands the buffer into the file first). This makes mid-trace upload independent of `write_to_disk`.
- **Stop `_rotate_stream()` resetting the periodic-flush timer**, so a single stream's count-rotation no longer starves the global periodic flush.
- **Lower `max_file_age` 20 m → 5 m** for timelier visibility and a 4×-smaller hard-kill loss window for slow streams.

Inherent limit: a `SIGKILL`/power-loss can still lose at most `max_file_age` of buffered low-volume data (no per-event fsync).

## Tests

- 2 new regression tests in `tests/test_writer_upload.py`:
  - a buffered-only stream with an empty file rotates + uploads on age (and drains its buffer);
  - a count-rotation does not reset the periodic-flush timer.
- Updated `test_rotation_defaults` for the new `max_file_age`.
- Full suite: **95 passed**.
- Validated end-to-end against the real `WriteManager` periodic-flush thread: a busy stream count-rotating repeatedly no longer prevents a buffered-only low-volume stream from rotating + uploading mid-trace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)