### PR TITLE
Make page-cache tracing opt-in (don't auto-enable the heaviest stream)

### DIFF
--- a/iotrc.py
+++ b/iotrc.py
@@ -16,8 +16,9 @@ Subcommands:
 Options:
     -v, --verbose             Print verbose output
     -a, --anonimize           Enable anonymization of process and file names
-    --cache                   Enable page-cache event tracing (higher overhead).
-                              Auto-enabled when the host has enough CPU and DRAM.
+    --cache                   Enable page-cache event tracing. High overhead
+                              (~1 CPU core on a busy host); opt-in only, never
+                              auto-enabled.
     --network                 Enable network event tracing — connection
                               lifecycle, sockopt, drops. Auto-enabled when
                               the host has enough CPU, DRAM and network.
@@ -84,7 +85,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Trace IO syscalls')
     parser.add_argument('-v', '--verbose', action='store_true', help='Print verbose output')
     parser.add_argument('-a', '--anonimize', action='store_true', help='Enable anonymization of process and file names')
-    parser.add_argument('--cache', action='store_true', help='Force-enable page-cache event tracing (higher overhead; otherwise auto-enabled when the host has enough CPU and DRAM)')
+    parser.add_argument('--cache', action='store_true', help='Enable page-cache event tracing (high overhead, ~1 CPU core on a busy host; opt-in only, never auto-enabled)')
     parser.add_argument('--network', action='store_true', help='Force-enable network event tracing: connection lifecycle, sockopt, drops (otherwise auto-enabled when the host has enough CPU, DRAM and network)')
     parser.add_argument('--computer-id', action='store_true', help='Print this machine ID and exit')
     parser.add_argument('--reward', action='store_true', help='Show your reward code (unlocked after uploading traces)')

--- a/src/utility/utils.py
+++ b/src/utility/utils.py
@@ -635,11 +635,15 @@ def auto_select_tracing(
     trace_cache: bool, trace_network: bool, verbose: bool = False
 ) -> tuple[bool, bool]:
     """
-    Auto-enable cache/network tracing when the host has spare resources.
+    Auto-enable the low-overhead network probes when the host has spare
+    resources. Page-cache tracing is NOT auto-enabled: it is by far the
+    highest-volume stream (every page add/dirty/writeback/evict) and on a busy
+    box costs ~1 full CPU core, so it stays opt-in via ``--cache``. Network
+    events are orders of magnitude rarer and remain auto-enabled on a capable,
+    fast-linked host.
 
     Explicit opt-ins are always honored: a flag already set to True is never
-    turned back off. A feature is only flipped on when the host clears the
-    resource thresholds (see ``evaluate_resource_tracing``).
+    turned back off.
 
     Args:
         trace_cache: whether page-cache tracing was explicitly requested
@@ -657,7 +661,8 @@ def auto_select_tracing(
         resources["max_net_speed_mbps"],
     )
 
-    auto_cache = trace_cache or decision["enable_cache"]
+    # Cache is opt-in only (high overhead); never auto-enabled from resources.
+    auto_cache = trace_cache
     auto_network = trace_network or decision["enable_network"]
 
     if verbose:
@@ -673,14 +678,14 @@ def auto_select_tracing(
             f">={AUTO_TRACE_MIN_AVAIL_RAM_GB:.0f} GB free, "
             f">={AUTO_TRACE_MIN_NET_SPEED_MBPS} Mbps).",
         )
-        if auto_cache and not trace_cache:
-            logger("info", "Auto-enabled page-cache tracing (host has enough CPU and DRAM).")
         if auto_network and not trace_network:
             logger("info", "Auto-enabled network tracing (host has enough CPU, DRAM and network).")
-        if not auto_cache:
-            logger("info", "Page-cache tracing left off (insufficient CPU/DRAM headroom).")
         if not auto_network:
             logger("info", "Network tracing left off (insufficient CPU/DRAM/network headroom).")
+        if auto_cache:
+            logger("info", "Page-cache tracing enabled (--cache).")
+        else:
+            logger("info", "Page-cache tracing left off (high overhead; opt-in via --cache).")
 
     return auto_cache, auto_network
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,7 @@ Written with stdlib unittest so they run via either:
 import os
 import sys
 import unittest
+import unittest.mock
 from pathlib import Path
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -150,6 +151,27 @@ class ResourceTracingTests(unittest.TestCase):
         cache, network = auto_select_tracing(True, True)
         self.assertTrue(cache)
         self.assertTrue(network)
+
+    def test_auto_select_does_not_auto_enable_cache(self):
+        # Page-cache tracing is the highest-volume stream (~1 CPU core on a busy
+        # host), so it must NEVER be auto-enabled from spare resources — only an
+        # explicit --cache turns it on. Network stays auto-enabled on a capable,
+        # fast-linked host.
+        big = dict(
+            logical_cores=64,
+            total_ram_gb=512.0,
+            available_ram_gb=256.0,
+            max_net_speed_mbps=10000,
+        )
+        with unittest.mock.patch(
+            "src.utility.utils.detect_host_resources", return_value=big
+        ):
+            cache, network = auto_select_tracing(False, False)
+            self.assertFalse(cache)   # not auto-enabled despite a huge host
+            self.assertTrue(network)  # network still auto-enabled
+
+            cache_optin, _ = auto_select_tracing(True, False)
+            self.assertTrue(cache_optin)  # explicit --cache honored
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Problem

`auto_select_tracing` auto-enables **page-cache tracing** on any host clearing the CPU/RAM thresholds (≥8 cores, ≥15 GB) — i.e. essentially everywhere. But page-cache is by far the highest-volume stream (it fires on every page add / dirty / writeback / evict), and on a busy host its perf-buffer consumer costs **~1 full CPU core**.

Measured on a 64-core / 503 GB GPU workstation: `iotrc.py` was the single largest CPU process (~1.3 cores), with ~90% of that in the cache event-processing thread — competing with the actual GPU workload. (It uses **no GPU**; the cost is pure CPU.)

## Fix

Make page-cache tracing **opt-in via `--cache` only** — never auto-enabled from spare resources. Network tracing (orders of magnitude rarer) stays auto-enabled on a capable, fast-linked host. Explicit `--cache` is still honored.

```
# 64c/503G host, before:  auto_select(False, False) -> (cache=True,  network=True)
# 64c/503G host, after:   auto_select(False, False) -> (cache=False, network=True)
#                         auto_select(True,  False) -> (cache=True,  network=True)  # --cache honored
```

This roughly **halves the tracer's CPU** on a busy host by dropping the cache thread. Pass `--cache` when you want page-cache analysis (hit ratio / MRC).

## Scope

- Policy change localized to `auto_select_tracing`; `evaluate_resource_tracing` is unchanged (it still reports host *capability*).
- Updated `iotrc.py` `--cache` help text.
- New regression test (mocked big host) asserting cache is **not** auto-enabled while network is, and that `--cache` is honored.
- Full suite: **96 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)