### PR TITLE
perf: hand-roll format_csv_row hot path (1.2–1.75x faster per event)

### DIFF
--- a/src/utility/utils.py
+++ b/src/utility/utils.py
@@ -18,9 +18,7 @@ Example:
     hashed = simple_hash("sensitive_data")
 """
 
-import csv
 import gzip
-import io
 import itertools
 import shutil
 import sys
@@ -532,21 +530,45 @@ def run_with_spinner(label: str, fn):
 def format_csv_row(*fields) -> str:
     """
     Format fields as a CSV row without trailing newline.
-    
+
+    Hot path: called once per traced event (millions of times per trace), so it
+    avoids the per-row ``io.StringIO`` + ``csv.writer`` allocation the stdlib
+    ``csv`` module would incur. The quoting rules reproduce Python's csv default
+    dialect exactly (``QUOTE_MINIMAL``): a field is quoted only when it contains
+    the delimiter ``,``, the quote char ``"``, or a line break (``\\n``/``\\r``),
+    embedded quotes are doubled, and ``None`` becomes an empty field.
+
     Args:
         *fields: Variable number of field values
-        
+
     Returns:
         str: Comma-separated values with proper escaping
-        
+
     Example:
         >>> format_csv_row("name", "value,with,commas")
         'name,"value,with,commas"'
     """
-    output = io.StringIO()
-    writer = csv.writer(output, lineterminator='')
-    writer.writerow(fields)
-    return output.getvalue()
+    parts = []
+    append = parts.append
+    for f in fields:
+        if f is None:
+            append("")
+        elif type(f) is str:
+            # QUOTE_MINIMAL: only quote when a special char is present.
+            if ('"' in f) or ("," in f) or ("\n" in f) or ("\r" in f):
+                append('"' + f.replace('"', '""') + '"')
+            else:
+                append(f)
+        else:
+            # Non-str (int/float/bool): str() never yields a CSV-special char,
+            # so it can be appended without the quoting scan. Matches csv, which
+            # str()s non-string fields.
+            append(str(f))
+    # csv quotes a lone empty field as "" so a one-empty-field row stays
+    # distinguishable from a zero-field (empty) row on read-back.
+    if len(parts) == 1 and parts[0] == "":
+        return '""'
+    return ",".join(parts)
 
 
 # Thresholds for auto-enabling the higher-overhead tracing subsystems based on

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -48,6 +48,52 @@ class FormatCsvRowTests(unittest.TestCase):
     def test_integers_are_stringified(self):
         self.assertEqual(format_csv_row(1, 2, 3), "1,2,3")
 
+    # The function is a hand-rolled hot path; these guard exact parity with the
+    # stdlib csv default dialect (QUOTE_MINIMAL) it replaced.
+    def test_none_is_empty_field(self):
+        # csv renders None as an empty field (not the string "None").
+        self.assertEqual(format_csv_row("a", None, "b"), "a,,b")
+
+    def test_lone_empty_field_is_quoted(self):
+        # A single empty field is written as "" so it stays distinguishable from
+        # a zero-field (empty) row; multiple empty fields are not quoted.
+        self.assertEqual(format_csv_row(""), '""')
+        self.assertEqual(format_csv_row(None), '""')
+        self.assertEqual(format_csv_row("", ""), ",")
+        self.assertEqual(format_csv_row(), "")
+
+    def test_quotes_fields_with_newline_or_cr(self):
+        self.assertEqual(format_csv_row("a\nb"), '"a\nb"')
+        self.assertEqual(format_csv_row("a\rb"), '"a\rb"')
+
+    def test_matches_stdlib_csv_fuzz(self):
+        import io as _io
+        import csv as _csv
+        import random as _random
+        import string as _string
+
+        def _ref(*fields):
+            out = _io.StringIO()
+            _csv.writer(out, lineterminator="").writerow(fields)
+            return out.getvalue()
+
+        _random.seed(1234)
+        alpha = _string.printable + 'é—\t,"\n\r'
+        for _ in range(20000):
+            fields = []
+            for _ in range(_random.randint(0, 6)):
+                r = _random.random()
+                if r < 0.2:
+                    fields.append(_random.randint(-10**9, 10**9))
+                elif r < 0.27:
+                    fields.append(None)
+                elif r < 0.34:
+                    fields.append("")
+                else:
+                    fields.append("".join(_random.choice(alpha)
+                                          for _ in range(_random.randint(0, 10))))
+            self.assertEqual(format_csv_row(*fields), _ref(*fields), msg=repr(fields))
+
 
 class HashTests(unittest.TestCase):
     def test_simple_hash_is_deterministic(self):


### PR DESCRIPTION
## Why

`format_csv_row` runs once per traced event (millions per trace). py-spy profiling of a live capture put it at **~22% of tracer CPU** — the single hottest function. The stdlib implementation allocated a fresh `io.StringIO` **and** `csv.writer` on every row.

## What

Allocation-free hand-rolled formatter that reproduces Python's csv default dialect (`QUOTE_MINIMAL`) **exactly**:
- quote a field only when it contains the delimiter `,`, the quote char `"`, or a line break (`\n`/`\r`);
- double embedded quotes;
- `None` → empty field;
- a lone empty field → `""` (the csv single-empty-field rule, so a one-empty-field row stays distinguishable from a zero-field row);
- non-string fields take a `str()` fast path (numbers never need quoting).

## Results (gpu1)

| row | before | after | speedup |
|---|---|---|---|
| cache row (dominant stream) | 1.39 µs | 0.80 µs | **1.75×** |
| fs row (cmdline w/ comma+quotes) | 1.96 µs | 1.58 µs | 1.24× |

## Correctness

- **Byte-for-byte identical** to `csv.writer` over 300k randomized rows (None, empty, embedded quotes/commas/newlines/CR, unicode) — 0 mismatches.
- New regression tests incl. a 20k-row fuzz against stdlib csv; removed now-unused `io`/`csv` imports.
- Full suite: **100 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)