### PR TITLE
feat: auto-enable page-cache tracing on capable hosts (>=8 cores, >=16 GB)

### DIFF
--- a/iotrc.py
+++ b/iotrc.py
@@ -16,9 +16,9 @@ Subcommands:
 Options:
     -v, --verbose             Print verbose output
     -a, --anonimize           Enable anonymization of process and file names
-    --cache                   Enable page-cache event tracing. High overhead
-                              (~1 CPU core on a busy host); opt-in only, never
-                              auto-enabled.
+    --cache                   Force-enable page-cache event tracing (high
+                              overhead, ~1 CPU core on a busy host). Otherwise
+                              auto-enabled on a capable host (>=8 cores, >=16 GB).
     --network                 Enable network event tracing — connection
                               lifecycle, sockopt, drops. Auto-enabled when
                               the host has enough CPU, DRAM and network.
@@ -85,7 +85,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Trace IO syscalls')
     parser.add_argument('-v', '--verbose', action='store_true', help='Print verbose output')
     parser.add_argument('-a', '--anonimize', action='store_true', help='Enable anonymization of process and file names')
-    parser.add_argument('--cache', action='store_true', help='Enable page-cache event tracing (high overhead, ~1 CPU core on a busy host; opt-in only, never auto-enabled)')
+    parser.add_argument('--cache', action='store_true', help='Force-enable page-cache event tracing (high overhead, ~1 CPU core on a busy host; otherwise auto-enabled on a capable host with >=8 cores and >=16 GB RAM)')
     parser.add_argument('--network', action='store_true', help='Force-enable network event tracing: connection lifecycle, sockopt, drops (otherwise auto-enabled when the host has enough CPU, DRAM and network)')
     parser.add_argument('--computer-id', action='store_true', help='Print this machine ID and exit')
     parser.add_argument('--reward', action='store_true', help='Show your reward code (unlocked after uploading traces)')

--- a/src/utility/utils.py
+++ b/src/utility/utils.py
@@ -576,7 +576,7 @@ def format_csv_row(*fields) -> str:
 # so they are only switched on automatically when the machine has headroom to
 # spare. Tune these in one place rather than scattering magic numbers.
 AUTO_TRACE_MIN_LOGICAL_CORES = 8      # cores needed to absorb extra probe work
-AUTO_TRACE_MIN_TOTAL_RAM_GB = 15.0    # total DRAM for the larger event buffers
+AUTO_TRACE_MIN_TOTAL_RAM_GB = 16.0    # total DRAM for the larger event buffers
 AUTO_TRACE_MIN_AVAIL_RAM_GB = 2.0     # free DRAM headroom at start-of-trace
 AUTO_TRACE_MIN_NET_SPEED_MBPS = 10    # a link fast enough (>=10 Mbps) to be worth tracing
 
@@ -657,15 +657,16 @@ def auto_select_tracing(
     trace_cache: bool, trace_network: bool, verbose: bool = False
 ) -> tuple[bool, bool]:
     """
-    Auto-enable the low-overhead network probes when the host has spare
-    resources. Page-cache tracing is NOT auto-enabled: it is by far the
-    highest-volume stream (every page add/dirty/writeback/evict) and on a busy
-    box costs ~1 full CPU core, so it stays opt-in via ``--cache``. Network
-    events are orders of magnitude rarer and remain auto-enabled on a capable,
-    fast-linked host.
+    Auto-enable cache/network tracing when the host has spare resources.
+
+    Page-cache tracing is the highest-volume stream (every page add/dirty/
+    writeback/evict) and costs ~1 CPU core on a busy box, so it is auto-enabled
+    only on a capable host — at least ``AUTO_TRACE_MIN_LOGICAL_CORES`` cores
+    (8) and ``AUTO_TRACE_MIN_TOTAL_RAM_GB`` GB RAM (16) — where that overhead is
+    affordable. Network tracing additionally requires a fast enough link.
 
     Explicit opt-ins are always honored: a flag already set to True is never
-    turned back off.
+    turned back off; this only switches a subsystem on, never off.
 
     Args:
         trace_cache: whether page-cache tracing was explicitly requested
@@ -683,8 +684,9 @@ def auto_select_tracing(
         resources["max_net_speed_mbps"],
     )
 
-    # Cache is opt-in only (high overhead); never auto-enabled from resources.
-    auto_cache = trace_cache
+    # Auto-enable cache on a capable host (>=8 cores and >=16 GB RAM); network
+    # additionally requires a fast link. Explicit flags are never turned off.
+    auto_cache = trace_cache or decision["enable_cache"]
     auto_network = trace_network or decision["enable_network"]
 
     if verbose:
@@ -704,10 +706,12 @@ def auto_select_tracing(
             logger("info", "Auto-enabled network tracing (host has enough CPU, DRAM and network).")
         if not auto_network:
             logger("info", "Network tracing left off (insufficient CPU/DRAM/network headroom).")
-        if auto_cache:
+        if auto_cache and not trace_cache:
+            logger("info", "Auto-enabled page-cache tracing (host has >=8 cores and >=16 GB RAM).")
+        elif auto_cache:
             logger("info", "Page-cache tracing enabled (--cache).")
         else:
-            logger("info", "Page-cache tracing left off (high overhead; opt-in via --cache).")
+            logger("info", "Page-cache tracing left off (insufficient CPU/DRAM headroom for the highest-volume stream).")
 
     return auto_cache, auto_network
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -198,11 +198,9 @@ class ResourceTracingTests(unittest.TestCase):
         self.assertTrue(cache)
         self.assertTrue(network)
 
-    def test_auto_select_does_not_auto_enable_cache(self):
-        # Page-cache tracing is the highest-volume stream (~1 CPU core on a busy
-        # host), so it must NEVER be auto-enabled from spare resources — only an
-        # explicit --cache turns it on. Network stays auto-enabled on a capable,
-        # fast-linked host.
+    def test_auto_select_enables_cache_on_capable_host(self):
+        # Page-cache tracing is auto-enabled on a capable host (>=8 cores and
+        # >=16 GB RAM), where its ~1-core overhead is affordable.
         big = dict(
             logical_cores=64,
             total_ram_gb=512.0,
@@ -213,11 +211,33 @@ class ResourceTracingTests(unittest.TestCase):
             "src.utility.utils.detect_host_resources", return_value=big
         ):
             cache, network = auto_select_tracing(False, False)
-            self.assertFalse(cache)   # not auto-enabled despite a huge host
-            self.assertTrue(network)  # network still auto-enabled
+            self.assertTrue(cache)    # auto-enabled on a capable host
+            self.assertTrue(network)
 
+    def test_auto_select_leaves_cache_off_on_small_host(self):
+        # Below the cache threshold (too few cores / too little RAM) it stays off
+        # unless explicitly requested.
+        small = dict(
+            logical_cores=4,            # < 8
+            total_ram_gb=8.0,           # < 16
+            available_ram_gb=4.0,
+            max_net_speed_mbps=10000,
+        )
+        with unittest.mock.patch(
+            "src.utility.utils.detect_host_resources", return_value=small
+        ):
+            cache, _ = auto_select_tracing(False, False)
+            self.assertFalse(cache)
             cache_optin, _ = auto_select_tracing(True, False)
-            self.assertTrue(cache_optin)  # explicit --cache honored
+            self.assertTrue(cache_optin)  # explicit --cache always honored
+
+    def test_cache_ram_threshold_is_16gb(self):
+        from src.utility.utils import AUTO_TRACE_MIN_TOTAL_RAM_GB, AUTO_TRACE_MIN_LOGICAL_CORES
+        self.assertEqual(AUTO_TRACE_MIN_TOTAL_RAM_GB, 16.0)
+        self.assertEqual(AUTO_TRACE_MIN_LOGICAL_CORES, 8)
+        # 8 cores + exactly 16 GB qualifies; 15.9 GB does not.
+        self.assertTrue(evaluate_resource_tracing(8, 16.0, 4.0, 100)["enable_cache"])
+        self.assertFalse(evaluate_resource_tracing(8, 15.9, 4.0, 100)["enable_cache"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What

Auto-enable **page-cache tracing** when the host has **>=8 logical cores AND >=16 GB RAM** (RAM threshold bumped 15→16 GB). Explicit `--cache` is always honored; smaller hosts still leave cache off unless asked.

```
# capable host (>=8c/>=16GB):  auto_select(False,False) -> (cache=True,  network=True)
# small host  (<8c or <16GB):  auto_select(False,False) -> (cache=False, network=True)
# explicit --cache anywhere:                              -> (cache=True,  ...)
```

## Note — this reverses the v1.2.0 cache opt-in (for capable hosts)

v1.2.0 (#74) made cache strictly opt-in after profiling showed it as the heaviest stream (~1 CPU core on a busy box). This restores resource-gated auto-enable, scoped to machines that can absorb it: on a 64-core/503 GB host that overhead is ~2% of CPU, and the cache stream is what powers hit-ratio / MRC analysis. Net effect is a middle ground: **off on small machines, on for capable ones, `--cache` to force.**

## Tests

- Flipped the v1.2.0 regression test → now asserts cache **is** auto-enabled on a capable host.
- Added a small-host case (stays off) and a 16 GB-boundary case (16.0 qualifies, 15.9 does not).
- Full suite: **102 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)