### PR TITLE
docs: fix consistency drift vs code + simplify one-line install

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,10 @@ Visit [IO Tracer documentations](https://cachemon.github.io/iotracerdocs/) for m
 
 ### One-line installation
 ```bash
-curl -sSL https://raw.githubusercontent.com/cacheMon/io-tracer/refs/heads/main/install.sh | sudo bash
+curl -fsSL https://raw.githubusercontent.com/cacheMon/io-tracer-linux/main/install.sh | sudo bash
 ```
+The installer clones the repo, installs BCC + the Python dependencies, and sets
+up the `iotrc` command. Re-run it any time to update to the latest version.
 
 ### Manual Installation
 
@@ -16,8 +18,8 @@ curl -sSL https://raw.githubusercontent.com/cacheMon/io-tracer/refs/heads/main/i
 1. Clone the repo
 
 ```bash
-git clone https://github.com/cacheMon/io-tracer.git
-cd io-tracer
+git clone https://github.com/cacheMon/io-tracer-linux.git
+cd io-tracer-linux
 ```
 
 2. Install BCC
@@ -66,7 +68,7 @@ To run the test suite you'll also need `pytest` (`pip install pytest`).
 
 ## Usage
 ```
-usage: sudo iotrc [-h] [-v] [-a] [--computer-id] [--reward] [--no-upload] {dev} ...
+usage: sudo iotrc [-h] [-v] [-a] [--cache] [--network] [--computer-id] [--reward] [--no-upload] {dev} ...
 
 Trace IO syscalls
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,22 +15,27 @@ This directory contains the complete documentation for IO Tracer's trace output,
 Traces are stored in object storage with the following prefix structure:
 
 ```
-linux_trace_v4_test/{MACHINE_ID}/{YYYYMMDD_HHMMSS_mmm}/
+linux_v1/{MACHINE_ID}/{YYYYMMDD_HHMMSS_mmm}/
 ├── fs/                    # VFS traces (also receives mirrored io_uring I/O)
 ├── block/                 # Block device traces
-├── cache/                 # Page cache events (opt-in: --cache)
+├── cache/                 # Page cache events (auto-enabled on capable hosts; force with --cache)
 ├── pagefault/             # Page fault events
-├── nw_conn/               # Network connection lifecycle (opt-in: --network)
-├── nw_sockopt/            # Network socket-option events (opt-in: --network)
-├── nw_drop/               # Network drops/retransmits (opt-in: --network)
+├── nw_conn/               # Network connection lifecycle (auto-enabled on capable hosts; force with --network)
+├── nw_sockopt/            # Network socket-option events (auto-enabled on capable hosts; force with --network)
+├── nw_drop/               # Network drops/retransmits (auto-enabled on capable hosts; force with --network)
 ├── process/               # Process state snapshots
 ├── filesystem_snapshot/   # Filesystem metadata snapshots
 └── system_spec/           # System specification files
 ```
 
-Page-cache and network streams are **off by default** (enable with `--cache` /
-`--network`); when disabled their probes are never attached, so their
-directories stay empty.
+Page-cache and network streams **auto-enable on a capable host** where the
+overhead is affordable: page-cache requires >=8 logical cores and >=16 GB RAM,
+and network additionally requires a >=10 Mbps link. On smaller hosts they stay
+off. The `--cache` / `--network` flags **force** them on regardless of host
+resources (always honored). When a stream is enabled its probes attach for the
+whole session and, like the other continuous streams, it rotates and uploads
+mid-trace rather than only flushing at shutdown; only when a stream is disabled
+are its probes never attached and its directory left empty.
 
 A self-describing `manifest.json` (schema version, per-stream columns, and clock
 diagnostics) is written at the session root and delivered inside the session archive.

--- a/docs/TRACE_FORMAT.md
+++ b/docs/TRACE_FORMAT.md
@@ -12,14 +12,14 @@ below mirror that module. Bump `SCHEMA_VERSION` there whenever columns change.
 Traces are uploaded to object storage with the following prefix structure:
 
 ```
-linux_trace_v4_test/{MACHINE_ID}/{YYYYMMDD_HHMMSS_mmm}/
+linux_v1/{MACHINE_ID}/{YYYYMMDD_HHMMSS_mmm}/
 ├── fs/                    # VFS (Virtual File System) traces
 ├── block/                 # Block device traces
-├── cache/                 # Page cache events (opt-in: --cache)
+├── cache/                 # Page cache events (auto-enabled on capable hosts; force with --cache)
 ├── pagefault/             # Memory-mapped page fault events
-├── nw_conn/               # Network connection lifecycle (opt-in: --network)
-├── nw_sockopt/            # Network socket-option events (opt-in: --network)
-├── nw_drop/               # Network drops/retransmits (opt-in: --network)
+├── nw_conn/               # Network connection lifecycle (auto-enabled on capable hosts; force with --network)
+├── nw_sockopt/            # Network socket-option events (auto-enabled on capable hosts; force with --network)
+├── nw_drop/               # Network drops/retransmits (auto-enabled on capable hosts; force with --network)
 ├── process/               # Process state snapshots
 ├── filesystem_snapshot/   # Filesystem metadata snapshots
 └── system_spec/           # System specification files
@@ -53,7 +53,7 @@ than hard-coding column positions.
 
 ## 1. VFS (Virtual File System) Traces
 
-**Location:** `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/fs/fs_*.csv.zst`
+**Location:** `linux_v1/{MACHINE_ID}/{TIMESTAMP}/fs/fs_*.csv.zst`
 
 **Description:** Captures all file system operations at the VFS layer, including reads, writes, opens, closes, and metadata operations. Also receives io_uring READ/WRITE rows mirrored from the io_uring instrumentation.
 
@@ -78,7 +78,7 @@ For operations captured and examples, see [VFS_EVENTS.md](traces/VFS_EVENTS.md).
 
 ## 2. Block Device Traces
 
-**Location:** `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/block/block_*.csv.zst`
+**Location:** `linux_v1/{MACHINE_ID}/{TIMESTAMP}/block/block_*.csv.zst`
 
 **Description:** Captures block layer I/O operations with latency measurements from issue to completion.
 
@@ -102,7 +102,7 @@ For operations captured and examples, see [BLOCK_IO_EVENTS.md](traces/BLOCK_IO_E
 
 ## 3. Cache Events
 
-**Location:** `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/cache/cache_*.csv.zst`
+**Location:** `linux_v1/{MACHINE_ID}/{TIMESTAMP}/cache/cache_*.csv.zst`
 
 **Description:** Captures page cache operations including hits, misses, dirty pages, writeback, and evictions.
 
@@ -118,7 +118,7 @@ For event types and examples, see [PAGE_CACHE_EVENTS.md](traces/PAGE_CACHE_EVENT
 
 ## 4. Page Fault Events
 
-**Location:** `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/pagefault/pagefault_*.csv.zst`
+**Location:** `linux_v1/{MACHINE_ID}/{TIMESTAMP}/pagefault/pagefault_*.csv.zst`
 
 **Description:** Captures file-backed page faults from memory-mapped I/O operations. Tracks which memory accesses trigger disk reads (major faults) vs cache hits (minor faults).
 
@@ -132,12 +132,15 @@ For fault types and examples, see [PAGE_FAULT_EVENTS.md](traces/PAGE_FAULT_EVENT
 
 ---
 
-## 4b. Network Events (opt-in: `--network`)
+## 4b. Network Events (auto-enabled on capable hosts; force with `--network`)
 
-**Location:** `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/nw_conn|nw_sockopt|nw_drop/*.csv.zst`
+**Location:** `linux_v1/{MACHINE_ID}/{TIMESTAMP}/nw_conn|nw_sockopt|nw_drop/*.csv.zst`
 
 **Description:** Low-overhead network subset — connection lifecycle,
-socket options, and drops/retransmits. **Off by default**; enable with `--network`.
+socket options, and drops/retransmits. **Auto-enabled on a capable host**
+(>=8 logical cores AND >=16 GB RAM AND a >=10 Mbps link, where the overhead is
+affordable); on smaller hosts it stays off. The `--network` flag forces it on
+regardless of host resources (always honored).
 The high-frequency per-packet TCP/UDP send/recv path is intentionally not traced.
 
 ### CSV Headers
@@ -157,7 +160,7 @@ For field details and event types, see [NETWORK_EVENTS.md](traces/NETWORK_EVENTS
 
 ## 5. Process Snapshots
 
-**Location:** `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/process/process_*.csv.zst`
+**Location:** `linux_v1/{MACHINE_ID}/{TIMESTAMP}/process/process_*.csv.zst`
 
 **Description:** Periodic snapshots of all running processes (captured every 5 minutes by default).
 
@@ -173,7 +176,7 @@ For field details and examples, see [PROCESS_SNAPSHOT.md](traces/PROCESS_SNAPSHO
 
 ## 6. Filesystem Snapshots
 
-**Location:** `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/filesystem_snapshot/filesystem_snapshot_*.csv.zst`
+**Location:** `linux_v1/{MACHINE_ID}/{TIMESTAMP}/filesystem_snapshot/filesystem_snapshot_*.csv.zst`
 
 **Description:** Periodic directory tree snapshots showing file metadata (captured hourly by default). Large scans are split into multiple parts — see [MULTIPART_FILESYSTEM_SNAPSHOT.md](MULTIPART_FILESYSTEM_SNAPSHOT.md).
 
@@ -189,7 +192,7 @@ For field details and examples, see [FILESYSTEM_SNAPSHOT.md](traces/FILESYSTEM_S
 
 ## 7. System Specification Files
 
-**Location:** `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/system_spec/`
+**Location:** `linux_v1/{MACHINE_ID}/{TIMESTAMP}/system_spec/`
 
 These are JSON files capturing system hardware and configuration at trace start:
 
@@ -243,10 +246,10 @@ For field details, see [SYSTEM_SNAPSHOT.md](traces/SYSTEM_SNAPSHOT.md).
 - Final archives: `.csv.zst` format
 
 ### File Rotation
-Continuous streams (VFS, block, cache, page fault) are rotated and compressed when any
+Continuous streams (VFS, block, cache, page fault, nw_conn, nw_sockopt, nw_drop) are rotated and compressed when any
 of the following is reached (see `WriteManager` in `src/tracer/WriterManager.py`):
 - **Event count:** ~80,000–100,000 buffered events (adaptively raised under load)
-- **File age:** 20 minutes since the current file was opened
+- **File age:** 5 minutes since the current file was opened
 - **File size:** 100 MB uncompressed on disk
 
 Snapshots (process, filesystem) are written as whole units rather than rotated mid-session.

--- a/docs/TRACE_TYPES.md
+++ b/docs/TRACE_TYPES.md
@@ -6,18 +6,23 @@ IO Tracer uses eBPF/BPF technology to intercept kernel functions and collect var
 
 | # | Trace Type | Description | Output |
 |---|------------|-------------|--------|
-| 1 | [VFS Events](traces/VFS_EVENTS.md) | File system operations at the VFS layer | `fs/fs_*.csv` |
-| 2 | [Block I/O Events](traces/BLOCK_IO_EVENTS.md) | Block-level device I/O operations | `block/block_*.csv` |
-| 3 | [Page Cache Events](traces/PAGE_CACHE_EVENTS.md) | Page cache hits, misses, writebacks, evictions | `cache/cache_*.csv` |
-| 4 | [Page Fault Events](traces/PAGE_FAULT_EVENTS.md) | File-backed page faults from mmap access | `pagefault/pagefault_*.csv` |
-| 5 | [Network Events](traces/NETWORK_EVENTS.md) | Connection lifecycle, socket options, drops | `nw_conn/*.csv`, `nw_sockopt/*.csv`, `nw_drop/*.csv` |
+| 1 | [VFS Events](traces/VFS_EVENTS.md) | File system operations at the VFS layer | `fs/fs_*.csv.zst` |
+| 2 | [Block I/O Events](traces/BLOCK_IO_EVENTS.md) | Block-level device I/O operations | `block/block_*.csv.zst` |
+| 3 | [Page Cache Events](traces/PAGE_CACHE_EVENTS.md) | Page cache hits, misses, writebacks, evictions | `cache/cache_*.csv.zst` |
+| 4 | [Page Fault Events](traces/PAGE_FAULT_EVENTS.md) | File-backed page faults from mmap access | `pagefault/pagefault_*.csv.zst` |
+| 5 | [Network Events](traces/NETWORK_EVENTS.md) | Connection lifecycle, socket options, drops | `nw_conn/*.csv.zst`, `nw_sockopt/*.csv.zst`, `nw_drop/*.csv.zst` |
 
-> **Opt-in streams.** Page-cache and network tracing are **off by default** to
-> keep overhead minimal. Enable them explicitly with `--cache` and `--network`.
-> When a stream is disabled its kernel probes are never attached (network probes
-> are not even compiled in), so there is zero added overhead. The network stream
-> is a deliberately low-overhead **subset** — per-packet TCP/UDP send/recv is
-> *not* traced.
+> Per-stream files are written as `.csv.zst` (Zstandard), falling back to
+> `.csv.gz` (gzip) when the `zstandard` library is unavailable.
+
+> **Auto-enabled streams.** Page-cache and network tracing **auto-enable on a
+> capable host** where the overhead is affordable: page-cache needs >=8 logical
+> cores AND >=16 GB RAM; network additionally requires a >=10 Mbps link. On
+> smaller hosts they stay off. The `--cache` / `--network` flags **force them on
+> regardless of host resources** (always honored). When a stream is disabled its
+> kernel probes are never attached (network probes are not even compiled in), so
+> there is zero added overhead. The network stream is a deliberately low-overhead
+> **subset** — per-packet TCP/UDP send/recv is *not* traced.
 
 ## Snapshot Types
 
@@ -75,10 +80,13 @@ IO Tracer uses eBPF/BPF technology to intercept kernel functions and collect var
 
 - **VFS tracing** has moderate overhead as it captures every file operation
 - **Block tracing** is essential for understanding physical I/O patterns
-- **Cache tracing** is opt-in (`--cache`); it can generate very high event rates
+- **Cache tracing** auto-enables on a capable host (>=8 logical cores AND >=16 GB
+  RAM) and can be forced on with `--cache`; it can generate very high event rates
   (cache hit/miss fire on nearly every page access), so use `cache_sample_rate`
   sampling for long traces
-- **Network tracing** is opt-in (`--network`) and restored as a low-overhead
-  subset: connection lifecycle, socket options, and drops/retransmits. The
-  high-frequency per-packet send/recv path is omitted to keep overhead minimal
+- **Network tracing** auto-enables on a capable host (>=8 logical cores, >=16 GB
+  RAM, and a >=10 Mbps link) and can be forced on with `--network`; it is a
+  low-overhead subset: connection lifecycle, socket options, and
+  drops/retransmits. The high-frequency per-packet send/recv path is omitted to
+  keep overhead minimal
 - **Snapshots** are lightweight and only captured at trace start (except periodic process snapshots)

--- a/docs/traces/BLOCK_IO_EVENTS.md
+++ b/docs/traces/BLOCK_IO_EVENTS.md
@@ -4,11 +4,12 @@
 
 **Kernel Probes:** Attached via block layer instrumentation in the eBPF program.
 
-> **A missing or empty `ds/` stream is usually expected, not a bug.** Block
+> **A missing or empty `block/` stream is usually expected, not a bug.** Block
 > events are only produced by *physical* device I/O (`block_rq_complete`). On a
 > short or cache-served run — reads hitting the page cache, dirty-page
 > writeback not yet flushed — little or no I/O reaches the device, so the
-> lazily-created `ds/` folder may not appear at all. Block I/O shows up once
+> lazily-created `block/` folder may not appear at all (the Windows tracer calls
+> its equivalent stream `ds`). Block I/O shows up once
 > there is real device activity: cache misses, `fsync`, writeback, or direct
 > I/O. The tracer logs a `Block diagnostics: 0 block I/O events captured …`
 > line at shutdown when this happens, to distinguish it from a failed stream.
@@ -25,35 +26,36 @@
 
 | # | Field | Type | Description |
 |---|-------|------|-------------|
-| 1 | Timestamp | `datetime` | Event timestamp (`YYYY-MM-DD HH:MM:SS.ffffff`) |
-| 2 | PID | `u32` | Process ID that submitted the request |
-| 3 | Command | `string` | Process name (max 16 characters) |
-| 4 | Sector | `u64` | Starting sector number on disk (LBA) |
-| 5 | Operation | `string` | Block operation type (see table below) |
-| 6 | Size | `u64` | I/O size in bytes |
-| 7 | Latency | `float` | Device latency in milliseconds (issue → completion) |
-| 8 | TID | `u32` | Thread ID |
-| 9 | CPU ID | `u32` | CPU where completion was processed |
-| 10 | PPID | `u32` | Parent process ID |
-| 11 | Device | `string` | Device number as `major:minor` identifying the partition/device |
-| 12 | Queue Latency | `float` | Queue/scheduler latency in milliseconds (insert → issue); empty if unavailable |
-| 13 | Command Flags | `string` | Pipe-separated REQ_* flags (e.g., `REQ_SYNC\|REQ_META`); empty if no flags set or on kernel ≥ 5.17 |
-| 14 | Operation Code | `string` | Raw block operation code name (e.g., `REQ_OP_READ`, `REQ_OP_WRITE`); empty on kernel ≥ 5.17 |
-| 15 | Request ID | `u64` | Monotonic per-request id, unique within a trace session and assigned at issue time. Distinguishes separate I/Os that reuse the same `(Device, Sector)` pair, which are otherwise identical apart from their timestamps |
-| 16 | mono_ns | `u64` | Completion time in `CLOCK_MONOTONIC` nanoseconds (kernel `bpf_ktime_get_ns()`) — the common clock for correlating across streams. Add the manifest's `clock.mono_to_real_offset_ns` to recover wall-clock ns. |
+| 1 | timestamp | `datetime` | Event timestamp (`YYYY-MM-DD HH:MM:SS.ffffff`) |
+| 2 | operation | `string` | Block operation type (see table below) |
+| 3 | pid | `u32` | Process ID that submitted the request |
+| 4 | tid | `u32` | Thread ID |
+| 5 | command | `string` | Process name (max 16 characters) |
+| 6 | sector | `u64` | Starting sector number on disk (LBA) |
+| 7 | size | `u64` | I/O size in bytes |
+| 8 | latency_ms | `float` | Device latency in milliseconds (issue → completion) |
+| 9 | device | `string` | Device number as `major:minor` identifying the partition/device |
+| 10 | flags | `string` | Pipe-separated rwbs sub-flags (`sync`, `meta`, `ahead`, …) split out of the `operation` column |
+| 11 | cpu_id | `u32` | CPU where completion was processed |
+| 12 | ppid | `u32` | Parent process ID |
+| 13 | queue_latency_ms | `float` | Queue/scheduler latency in milliseconds (insert → issue); empty if unavailable |
+| 14 | command_flags | `string` | Pipe-separated REQ_* flags (e.g., `REQ_SYNC\|REQ_META`); empty if no flags set or on kernel ≥ 5.17 |
+| 15 | operation_code | `string` | Raw block operation code name (e.g., `REQ_OP_READ`, `REQ_OP_WRITE`); empty on kernel ≥ 5.17 |
+| 16 | request_id | `u64` | Monotonic per-request id, unique within a trace session and assigned at issue time. Distinguishes separate I/Os that reuse the same `(device, sector)` pair, which are otherwise identical apart from their timestamps |
+| 17 | mono_ns | `u64` | Completion time in `CLOCK_MONOTONIC` nanoseconds (kernel `bpf_ktime_get_ns()`) — the common clock for correlating across streams. Add the manifest's `clock.mono_to_real_offset_ns` to recover wall-clock ns. |
 
-> **Note:** Command Flags (field 13) and Operation Code (field 14) are only available on Linux kernel versions < 5.17. The `cmd_flags` field was removed from the `block_rq_complete` tracepoint in kernel 5.17+. On newer kernels (including 5.17, 6.x), these fields will always be empty. Use the Operation field (field 5) and RWBS flags to distinguish I/O types on newer kernels.
+> **Note:** Command Flags (field 14) and Operation Code (field 15) are only available on Linux kernel versions < 5.17. The `cmd_flags` field was removed from the `block_rq_complete` tracepoint in kernel 5.17+. On newer kernels (including 5.17, 6.x), these fields will always be empty. Use the Operation field (field 2) and RWBS flags to distinguish I/O types on newer kernels.
 
 ## Latency Measurement
 
 I/O latency is tracked across the block layer request lifecycle using kernel tracepoints. The BPF program calculates two distinct types of latency to differentiate software queueing overhead from actual hardware processing time:
 
-1. **Device Latency (Field 7)**:
+1. **Device Latency (Field 8)**:
    - **Calculation**: Time from `issue` to `completion` (`completion_time - issue_time`).
    - **Tracepoints**: `block_rq_issue` (records start time) and `block_rq_complete` (calculates final latency).
    - **Meaning**: Represents the time the request spent being processed by the device driver and the physical storage hardware.
 
-2. **Queue/Scheduler Latency (Field 12)**:
+2. **Queue/Scheduler Latency (Field 13)**:
    - **Calculation**: Time from `insert` to `issue` (`issue_time - insert_time`).
    - **Tracepoints**: `block_rq_insert` (records insert time) and `block_rq_complete` (calculates final queue latency based on issue time).
    - **Meaning**: Represents the time the request spent queued up in the OS scheduler waiting to be dispatched to the device.
@@ -102,11 +104,11 @@ Raw operation codes from the kernel block layer:
 | 35 | `REQ_OP_DRV_OUT` | Driver-specific output |
 | 36 | `REQ_OP_LAST` | Sentinel value |
 
-These raw operation codes are captured in field 14 (Operation Code) on Linux kernels < 5.17 and provide the most accurate indication of the block layer operation type. On newer kernels, use field 5 (Operation) which derives the operation type from the rwbs string.
+These raw operation codes are captured in field 15 (Operation Code) on Linux kernels < 5.17 and provide the most accurate indication of the block layer operation type. On newer kernels, use field 2 (Operation) which derives the operation type from the rwbs string.
 
 ## Block Request Flags (`REQ_*`)
 
-Command flags captured in the `Command Flags` field (field 13). Multiple flags are pipe-separated:
+Command flags captured in the `command_flags` field (field 14). Multiple flags are pipe-separated:
 
 | Bit | Name | Description |
 |-----|------|-------------|
@@ -128,7 +130,7 @@ Command flags captured in the `Command Flags` field (field 13). Multiple flags a
 
 ## RWBS Flags
 
-Character flags from the block layer tracepoint `rwbs` string. Each character in the rwbs string is decoded to its corresponding flag name, and when multiple characters are present, they are concatenated with pipes in the Operation field (field 5).
+Character flags from the block layer tracepoint `rwbs` string. Each character in the rwbs string is decoded to its corresponding flag name, and when multiple characters are present, they are concatenated with pipes in the Operation field (field 2).
 
 **Examples:**
 - `"R"` → `"read"`
@@ -150,4 +152,4 @@ Character flags from the block layer tracepoint `rwbs` string. Each character in
 | `P` | PRIO | High priority |
 | `B` | BARRIER | Barrier (legacy) |
 
-**Output File:** `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/block/block_*.csv.zst`
+**Output File:** `linux_v1/{MACHINE_ID}/{TIMESTAMP}/block/block_*.csv.zst`

--- a/docs/traces/FILESYSTEM_SNAPSHOT.md
+++ b/docs/traces/FILESYSTEM_SNAPSHOT.md
@@ -15,12 +15,12 @@
 
 | # | Field | Type | Description |
 |---|-------|------|-------------|
-| 1 | Snapshot Timestamp | `datetime` | Time when this snapshot was taken (`YYYY-MM-DD HH:MM:SS`) |
-| 2 | File Path | `string` | Full file path (or hashed path in anonymous mode) |
-| 3 | Size | `integer` | File size in bytes |
-| 4 | Creation Time | `datetime` | File creation time (`st_birthtime`); falls back to `st_mtime` if unavailable |
-| 5 | Modification Time | `datetime` | Last data modification time (`st_mtime`) |
-| 6 | Access Time | `datetime` | Last access time (`st_atime`) |
+| 1 | snapshot_timestamp | `datetime` | Time when this snapshot was taken (`YYYY-MM-DD HH:MM:SS`) |
+| 2 | file_path | `string` | Full file path (or hashed path in anonymous mode) |
+| 3 | size | `integer` | File size in bytes |
+| 4 | creation_time | `datetime` | File creation time (`st_birthtime`); falls back to `st_mtime` if unavailable |
+| 5 | modification_time | `datetime` | Last data modification time (`st_mtime`) |
+| 6 | access_time | `datetime` | Last access time (`st_atime`) |
 | 7 | mono_ns | `u64` | Snapshot time in `CLOCK_MONOTONIC` nanoseconds (`time.monotonic_ns()`, captured once per snapshot) — the common cross-stream correlation clock; add the manifest's `clock.mono_to_real_offset_ns` to recover wall-clock ns. |
 
 ## Excluded Filesystems
@@ -40,7 +40,7 @@ Files on virtual/pseudo filesystems are automatically excluded by skipping diffe
 
 When anonymization is enabled (`-a`/`--anonimize`), file paths are hashed using a deterministic hash function (12-character hash). Directory structure is preserved but individual path components are replaced with hashes. File extensions are kept for analysis purposes.
 
-**Output File:** `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/filesystem_snapshot/filesystem_snapshot_part####_TIMESTAMP_DEVICEID*.csv.zst`
+**Output File:** `linux_v1/{MACHINE_ID}/{TIMESTAMP}/filesystem_snapshot/filesystem_snapshot_part####_TIMESTAMP_DEVICEID*.csv.zst`
 
 ## Multi-Part Files
 

--- a/docs/traces/IO_URING_EVENTS.md
+++ b/docs/traces/IO_URING_EVENTS.md
@@ -215,4 +215,4 @@ The io_uring tracepoint probes (`io_uring:io_uring_submit_sqe`, `io_uring:io_uri
 
 2. If the format includes `req`, `opcode`, `user_data`, and `flags` fields, change `#if 0` to `#if 1` around line 4218 in `prober.c`.
 
-**Output File:** none — io_uring READ/WRITE I/O is mirrored into the fs/VFS trace at `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/fs/fs_*.csv.zst`. There is no standalone `io_uring/` stream.
+**Output File:** none — io_uring READ/WRITE I/O is mirrored into the fs/VFS trace at `linux_v1/{MACHINE_ID}/{TIMESTAMP}/fs/fs_*.csv.zst`. There is no standalone `io_uring/` stream.

--- a/docs/traces/MANIFEST.md
+++ b/docs/traces/MANIFEST.md
@@ -40,6 +40,7 @@ The current format (**schema_version 1**) is the **cross-OS aligned** layout:
              "wall_clock": "CLOCK_REALTIME (derived from kernel CLOCK_MONOTONIC)",
              "columns": [ { "name": "timestamp", "type": "datetime", "unit": "", "description": "..." }, ... ] },
     "block":  { ... }, "cache": { ... }, "pagefault": { ... },
+    "nw_conn": { ... }, "nw_sockopt": { ... }, "nw_drop": { ... },
     "process": { ... }, "filesystem_snapshot": { ... }
   },
   "tracer":  { "version": "..." },

--- a/docs/traces/NETWORK_EVENTS.md
+++ b/docs/traces/NETWORK_EVENTS.md
@@ -5,10 +5,12 @@ subset**: connection lifecycle, socket option changes, and packet
 drops/retransmissions. The high-frequency per-packet TCP/UDP send/receive path
 is **not** traced, which keeps kernel-side overhead minimal.
 
-**Opt-in:** Network tracing is **off by default**. Enable it with `--network`.
-The probes are only *compiled into* the eBPF program (via `-DENABLE_NETWORK`) and
-auto-attached when this flag is set, so there is zero added overhead when it is
-off.
+**Enable policy:** Network tracing **auto-enables on a capable host** — one with
+>=8 logical cores, >=16 GB RAM, and a >=10 Mbps link — where the overhead is
+affordable; on smaller hosts it stays off. The `--network` flag **forces** it on
+regardless of host resources (always honored). The probes are *compiled into* the
+eBPF program (via `-DENABLE_NETWORK`) and auto-attached whenever network tracing
+is enabled, so there is zero added overhead when it is off.
 
 All probes are syscall/event **tracepoints** (stable across kernel versions):
 
@@ -27,9 +29,9 @@ nanoseconds.
 **Output Files:** Like every other trace stream, network streams are
 Zstandard-compressed on disk and on upload:
 
-- `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/nw_conn/nw_conn_*.csv.zst`
-- `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/nw_sockopt/nw_sockopt_*.csv.zst`
-- `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/nw_drop/nw_drop_*.csv.zst`
+- `linux_v1/{MACHINE_ID}/{TIMESTAMP}/nw_conn/nw_conn_*.csv.zst`
+- `linux_v1/{MACHINE_ID}/{TIMESTAMP}/nw_sockopt/nw_sockopt_*.csv.zst`
+- `linux_v1/{MACHINE_ID}/{TIMESTAMP}/nw_drop/nw_drop_*.csv.zst`
 
 (They are left uncompressed only when the optional `zstandard` library is
 unavailable — the same fallback that applies to all streams.)

--- a/docs/traces/PAGE_CACHE_EVENTS.md
+++ b/docs/traces/PAGE_CACHE_EVENTS.md
@@ -17,16 +17,16 @@
 
 | # | Field | Type | Description |
 |---|-------|------|-------------|
-| 1 | Timestamp | `datetime` | Event timestamp (`YYYY-MM-DD HH:MM:SS.ffffff`) |
-| 2 | PID | `u32` | Process ID that triggered the event |
-| 3 | Command | `string` | Process name (max 16 characters) |
-| 4 | Event Type | `string` | Cache event type (see table below) |
-| 5 | Inode | `u64` | File inode number; empty if `0` |
-| 6 | Page Index | `u64` | Page offset within file (file offset / PAGE_SIZE); empty if `0` |
-| 7 | Size | `u32` | File size in pages (from `inode->i_size >> 12`) |
-| 8 | CPU ID | `u32` | CPU where event occurred |
-| 9 | Device ID | `u32` | Device ID from the file's superblock |
-| 10 | Count | `u32` | Number of pages affected by the operation (1 for single-page, N for bulk) |
+| 1 | timestamp | `datetime` | Event timestamp (`YYYY-MM-DD HH:MM:SS.ffffff`) |
+| 2 | pid | `u32` | Process ID that triggered the event |
+| 3 | command | `string` | Process name (max 16 characters) |
+| 4 | event_type | `string` | Cache event type (see table below) |
+| 5 | inode | `u64` | File inode number; empty if `0` |
+| 6 | page_index | `u64` | Page offset within file (file offset / PAGE_SIZE); empty if `0` |
+| 7 | size_pages | `u32` | File size in pages (from `inode->i_size >> 12`) |
+| 8 | cpu_id | `u32` | CPU where event occurred |
+| 9 | device_id | `u32` | Device ID from the file's superblock |
+| 10 | count | `u32` | Number of pages affected by the operation (1 for single-page, N for bulk) |
 | 11 | mono_ns | `u64` | Record time in `CLOCK_MONOTONIC` nanoseconds (kernel `bpf_ktime_get_ns()`) — the common cross-stream correlation clock; add the manifest's `clock.mono_to_real_offset_ns` to recover wall-clock ns. |
 
 ## Event Types
@@ -44,7 +44,7 @@
 | 8 | `READAHEAD` | Pages prefetched into cache by readahead |
 | 9 | `RECLAIM` | Pages reclaimed under memory pressure (kswapd/direct reclaim) |
 
-**Output File:** `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/cache/cache_*.csv.zst`
+**Output File:** `linux_v1/{MACHINE_ID}/{TIMESTAMP}/cache/cache_*.csv.zst` (or `.csv.gz` when zstd is unavailable and the gzip fallback is used)
 
 **Important Limitation — Filename Resolution:**
 The filename is **not captured** for cache events due to eBPF constraints. Cache events provide only: folio/page → address_space → inode. Resolving inode → filename requires traversing `inode->i_dentry` (a linked list of hard links), which is impractical in eBPF. Use inode numbers to correlate with VFS events or filesystem snapshots.

--- a/docs/traces/PAGE_FAULT_EVENTS.md
+++ b/docs/traces/PAGE_FAULT_EVENTS.md
@@ -9,16 +9,16 @@
 
 | # | Field | Type | Description |
 |---|-------|------|-------------|
-| 1 | Timestamp | `datetime` | Event timestamp (`YYYY-MM-DD HH:MM:SS.ffffff`) |
-| 2 | PID | `u32` | Process ID |
-| 3 | TID | `u32` | Thread ID |
-| 4 | Command | `string` | Process name (max 16 characters) |
-| 5 | Fault Type | `string` | Access type that triggered the fault (see table below) |
-| 6 | Severity | `string` | Fault severity (see table below) |
-| 7 | Inode | `u64` | Backing file inode number; empty if `0` (anonymous mapping) |
-| 8 | Offset | `u64` | File offset in pages (`pgoff`); empty if `0` |
-| 9 | Address | `hex string` | Faulting virtual address (e.g., `0x7f4a3b2c1000`); empty if `0` |
-| 10 | Device ID | `u32` | Device ID from the file's superblock; empty if `0` |
+| 1 | timestamp | `datetime` | Event timestamp (`YYYY-MM-DD HH:MM:SS.ffffff`) |
+| 2 | pid | `u32` | Process ID |
+| 3 | tid | `u32` | Thread ID |
+| 4 | command | `string` | Process name (max 16 characters) |
+| 5 | fault_type | `string` | Access type that triggered the fault (see table below) |
+| 6 | severity | `string` | Fault severity (see table below) |
+| 7 | inode | `u64` | Backing file inode number; empty if `0` (anonymous mapping) |
+| 8 | offset_pages | `u64` | File offset in pages (`pgoff`); empty if `0` |
+| 9 | address | `hex string` | Faulting virtual address (e.g., `0x7f4a3b2c1000`); empty if `0` |
+| 10 | device_id | `u32` | Device ID from the file's superblock; empty if `0` |
 | 11 | mono_ns | `u64` | Record time in `CLOCK_MONOTONIC` nanoseconds (kernel `bpf_ktime_get_ns()`) — the common cross-stream correlation clock; add the manifest's `clock.mono_to_real_offset_ns` to recover wall-clock ns. |
 
 ## Fault Types
@@ -35,4 +35,4 @@
 | `MAJOR` | Page not in memory — requires disk I/O to load the page |
 | `MINOR` | Page already in page cache — no disk I/O needed (soft fault) |
 
-**Output File:** `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/pagefault/pagefault_*.csv.zst`
+**Output File:** `linux_v1/{MACHINE_ID}/{TIMESTAMP}/pagefault/pagefault_*.csv.zst`

--- a/docs/traces/PROCESS_SNAPSHOT.md
+++ b/docs/traces/PROCESS_SNAPSHOT.md
@@ -38,7 +38,7 @@
 | `dead` | Process is dead (should not normally be seen) |
 | `idle` | Process is idle (kernel threads) |
 
-**Output File:** `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/process/process_*.csv.zst`
+**Output File:** `linux_v1/{MACHINE_ID}/{TIMESTAMP}/process/process_*.csv.zst`
 
 ## Incomplete Snapshot Handling
 

--- a/docs/traces/SYSTEM_SNAPSHOT.md
+++ b/docs/traces/SYSTEM_SNAPSHOT.md
@@ -2,7 +2,7 @@
 
 **Description:** Captures hardware and software specifications for trace context.
 
-**Location:** `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/system_spec/`
+**Location:** `linux_v1/{MACHINE_ID}/{TIMESTAMP}/system_spec/`
 
 **Collection Method:**
 - Queries system information once at trace start

--- a/docs/traces/VFS_EVENTS.md
+++ b/docs/traces/VFS_EVENTS.md
@@ -166,25 +166,25 @@ The path captured is relative to the mount namespace of the probed process. In c
 
 | # | Field | Type | Description |
 |---|-------|------|-------------|
-| 1 | Timestamp | `datetime` | Event timestamp (`YYYY-MM-DD HH:MM:SS.ffffff`), derived from the kernel's per-event `bpf_ktime_get_ns()` (CLOCK_MONOTONIC) converted to wall-clock. This is the time the event actually occurred, so rows are correctly ordered when sorted by this column even though the per-CPU perf buffers deliver them in batches. |
-| 2 | Operation | `string` | VFS operation type (see table below) |
-| 3 | PID | `u32` | Process ID |
-| 4 | Command | `string` | Process name (max 16 characters) |
-| 5 | Filename | `string` | File path; for dual-path operations (`RENAME`, `LINK`, `SYMLINK`) formatted as `old_path -> new_path`. For `OPEN`, the path is resolved to absolute via `/proc/<pid>/fd`; if that races (fd already closed) and the captured path was relative, it is resolved against the openat `dirfd` / process cwd as a fallback |
-| 6 | Size (requested) | `u64` | **Requested** I/O size in bytes — the `count` argument to `read`/`write` (or operation size for others); `0` for non-I/O operations. The **actual** bytes transferred are in column 17 (`bytes_completed`), which can be smaller (short read/write). |
-| 7 | Inode | `u64` | File inode number; empty if `0` |
-| 8 | Flags | `string` | Operation-specific flags for non-MMAP operations (see tables below); empty when the operation has no defined flag value to render |
-| 9 | Offset | `u64` | File offset for positioned I/O; empty if `0` |
-| 10 | TID | `u32` | Thread ID for multi-threaded correlation; empty if `0` |
-| 11 | mmap_prot | `string` | MMAP protection flags (`PROT_*`, pipe-separated); empty for non-MMAP operations |
-| 12 | mmap_flags | `string` | MMAP mapping flags (`MAP_*`, pipe-separated); empty for non-MMAP operations |
-| 13 | address | `string` | Mapping start address as hex (`0x...`) for `MMAP` and `MUNMAP`; for `MREMAP` formatted as `old_address -> new_address`; empty for other operations |
-| 14 | cmdline | `string` | Full command line (`argv` joined by spaces) of the process that triggered the event; empty if unresolvable (see below) |
-| 15 | return_value | `s64` | Raw syscall return value for `READ`/`WRITE` (bytes moved if `>= 0`, negative `errno` on failure); empty for other operations |
-| 16 | errno | `string` | Error name (e.g. `EAGAIN`) when a `READ`/`WRITE` failed (`return_value < 0`); empty on success or for other operations |
-| 17 | bytes_completed (actual) | `u64` | **Actual** bytes read/written for `READ`/`WRITE` (`return_value` when `>= 0`); compare against column 6 (`Size (requested)`) to detect short I/O. Empty on failure or for other operations |
-| 18 | duration_ns | `u64` | Operation duration in nanoseconds (entry → return) for `READ`/`WRITE`; empty for other operations |
-| 19 | device | `string` | Backing device of the file as `major:minor` (from `super_block->s_dev`); populated for `READ`/`WRITE`/`OPEN`; empty otherwise |
+| 1 | timestamp | `datetime` | Event timestamp (`YYYY-MM-DD HH:MM:SS.ffffff`), derived from the kernel's per-event `bpf_ktime_get_ns()` (CLOCK_MONOTONIC) converted to wall-clock. This is the time the event actually occurred, so rows are correctly ordered when sorted by this column even though the per-CPU perf buffers deliver them in batches. |
+| 2 | operation | `string` | VFS operation type (see table below) |
+| 3 | pid | `u32` | Process ID |
+| 4 | tid | `u32` | Thread ID for multi-threaded correlation; empty if `0` |
+| 5 | command | `string` | Process name (max 16 characters) |
+| 6 | filename | `string` | File path; for dual-path operations (`RENAME`, `LINK`, `SYMLINK`) formatted as `old_path -> new_path`. For `OPEN`, the path is resolved to absolute via `/proc/<pid>/fd`; if that races (fd already closed) and the captured path was relative, it is resolved against the openat `dirfd` / process cwd as a fallback |
+| 7 | size | `u64` | **Requested** I/O size in bytes — the `count` argument to `read`/`write` (or operation size for others); `0` for non-I/O operations. The **actual** bytes transferred are in column 9 (`bytes_completed`), which can be smaller (short read/write). |
+| 8 | offset | `u64` | File offset for positioned I/O; empty if `0` |
+| 9 | bytes_completed | `u64` | **Actual** bytes read/written for `READ`/`WRITE` (`return_value` when `>= 0`); compare against column 7 (`size`) to detect short I/O. Empty on failure or for other operations |
+| 10 | inode | `u64` | File inode number; empty if `0` |
+| 11 | device | `string` | Backing device of the file as `major:minor` (from `super_block->s_dev`); populated for `READ`/`WRITE`/`OPEN`; empty otherwise |
+| 12 | flags | `string` | Operation-specific flags for non-MMAP operations (see tables below); empty when the operation has no defined flag value to render |
+| 13 | duration_ns | `u64` | Operation duration in nanoseconds (entry → return) for `READ`/`WRITE`; empty for other operations |
+| 14 | return_value | `s64` | Raw syscall return value for `READ`/`WRITE` (bytes moved if `>= 0`, negative `errno` on failure); empty for other operations |
+| 15 | errno | `string` | Error name (e.g. `EAGAIN`) when a `READ`/`WRITE` failed (`return_value < 0`); empty on success or for other operations |
+| 16 | mmap_prot | `string` | MMAP protection flags (`PROT_*`, pipe-separated); empty for non-MMAP operations |
+| 17 | mmap_flags | `string` | MMAP mapping flags (`MAP_*`, pipe-separated); empty for non-MMAP operations |
+| 18 | address | `string` | Mapping start address as hex (`0x...`) for `MMAP` and `MUNMAP`; for `MREMAP` formatted as `old_address -> new_address`; empty for other operations |
+| 19 | cmdline | `string` | Full command line (`argv` joined by spaces) of the process that triggered the event; empty if unresolvable (see below) |
 | 20 | ppid | `u32` | Parent process ID (`real_parent->tgid`); populated for `READ`/`WRITE`/`OPEN`; empty otherwise |
 | 21 | container_id | `u64` | cgroup v2 id of the process (container identifier); populated for `READ`/`WRITE`/`OPEN`; empty otherwise |
 | 22 | fs_type | `string` | Source filesystem name derived from the superblock magic (e.g. `EXT2/3/4`, `XFS`, `BTRFS`, `OVERLAYFS`, `NFS`), letting physical-disk I/O be distinguished from network/overlay sources; populated for `READ`/`WRITE`/`OPEN`; empty otherwise |
@@ -231,7 +231,7 @@ If a process completes entirely within a single perf-buffer batch (spawned and e
 For `PROCESS_EXEC` events, if the `filename` field is empty (the eBPF probe did not capture a path), `argv[0]` from `cmdline` is used as the filename. This provides best-effort attribution of the executed binary when kernel-side resolution fails (e.g. kernel-internal `execve` calls that bypass `do_sys_openat2`).
 
 #### `comm` vs `cmdline`
-The `command` field (column 4) is the short process name captured in-kernel by eBPF (`task->comm`, max 16 chars). The `cmdline` field is the full argument vector read from `/proc` in userspace. For processes that use `prctl(PR_SET_NAME, ...)` to rename themselves, `comm` may differ from `argv[0]`.
+The `command` field (column 5) is the short process name captured in-kernel by eBPF (`task->comm`, max 16 chars). The `cmdline` field is the full argument vector read from `/proc` in userspace. For processes that use `prctl(PR_SET_NAME, ...)` to rename themselves, `comm` may differ from `argv[0]`.
 
 
 
@@ -462,4 +462,4 @@ In some cases, the filename field may be empty. This occurs when the kernel data
 - Check the inode field — if it's non-zero, the file exists but the path couldn't be resolved
 - Correlate with the operation type and process command to determine if the empty filename is expected
 
-**Output File:** `linux_trace_v4_test/{MACHINE_ID}/{TIMESTAMP}/fs/fs_*.csv.zst`
+**Output File:** `linux_v1/{MACHINE_ID}/{TIMESTAMP}/fs/fs_*.csv.zst`

--- a/install.sh
+++ b/install.sh
@@ -17,7 +17,7 @@ else
 fi
 
 INSTALL_DIR="$REAL_HOME/io-tracer"
-REPO_URL="https://github.com/cacheMon/io-tracer.git"
+REPO_URL="https://github.com/cacheMon/io-tracer-linux.git"
 RAW_URL="https://raw.githubusercontent.com/cacheMon/io-tracer-linux/main/iotrc.py"
 BIN_NAME="iotrc"
 BIN_DIR="/usr/local/bin"


### PR DESCRIPTION
Syncs the docs to the current behavior (main = v1.2.1) after the recent cache-policy, `ds`→`block`, rotation, and bucket changes, and makes the one-line install easier. Found via a per-file audit against `schema.py` / `utility/utils.py` / `WriterManager.py`.

## Consistency fixes
- **Cache/network enable policy** — no longer "off by default / opt-in only"; documented as **auto-enabled on capable hosts** (cache ≥8 cores & ≥16 GB; network also ≥10 Mbps), with `--cache`/`--network` forcing on.
- **Column tables regenerated to match `schema.py` exactly** (order + snake_case) for fs/block/cache/pagefault/filesystem_snapshot. The **fs and block tables were badly misaligned** (every fs column from #4 on was wrong) — they'd mis-map any CSV parser. Stale `field N` prose cross-refs in BLOCK fixed too.
- **`ds/` → `block/`** guidance (kept the legitimate Windows `ds` reference).
- **`max_file_age` 20 → 5 min**; added the network streams to the rotating-streams list.
- **Bucket `linux_trace_v4_test` → `linux_v1`** across all docs.
- **`.csv` → `.csv.zst`** (with `.csv.gz` gzip-fallback note); `Size`→`size_pages`, `Offset`→`offset_pages`.
- MANIFEST example streams list completed; README usage line adds `[--cache] [--network]`.

## One-line install
`curl -fsSL https://raw.githubusercontent.com/cacheMon/io-tracer-linux/main/install.sh | sudo bash` — shorter (drops `refs/heads/`), canonical repo name, `-f` to fail closed. `install.sh` REPO_URL + manual clone updated.

## Verification
All 5 stream column tables match `schema.py` exactly (programmatic check); 0 residual opt-in / 20-min / `linux_trace_v4_test` references; full suite **102 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)