### PR TITLE
fix: never silently drop or over-count rows on a failed buffer write (CRITICAL)

### DIFF
--- a/src/tracer/IOTracer.py
+++ b/src/tracer/IOTracer.py
@@ -1289,6 +1289,7 @@ class IOTracer:
                 "attached_probes": self._attached_probes(),
                 "lost_events": dict(self._lost_counts),
                 "rows_written": dict(self.writer.rows_written),
+                "write_dropped": dict(getattr(self.writer, "write_dropped", {})),
                 "block": self._block_stats(),
             },
         })

--- a/src/tracer/WriterManager.py
+++ b/src/tracer/WriterManager.py
@@ -24,7 +24,6 @@ Example:
 import os
 import sys
 import json
-import io
 from datetime import datetime
 import tarfile
 
@@ -81,6 +80,16 @@ class WriteManager:
         # session manifest — lets a consumer spot a stream whose probes attached
         # but produced no events.
         self.rows_written = {}
+        # Rows that could NOT be persisted (write/flush raised — e.g. ENOSPC /
+        # EDQUOT / closed handle) and were dropped after exceeding the on-error
+        # retry cap. Surfaced in the manifest so a consumer can tell honest data
+        # loss apart from a complete stream — never silently swallowed.
+        self.write_dropped = {}
+        # Cap on rows re-queued for retry after a failed write, so a persistently
+        # full/over-quota disk re-queues for transient errors but cannot grow the
+        # in-memory buffers without bound (OOM). Oldest rows past the cap are
+        # dropped and counted in ``write_dropped``.
+        self._max_buffered_rows_on_error = 500_000
         self.last_status_log_time = time.time()
         self.status_log_interval = 60  # Log status every 60 seconds
         self.output_dir = output_dir
@@ -938,26 +947,46 @@ class WriteManager:
         """
         if not buffer:
             return
-            
+
+        # Drain the buffer into a local batch first, then write. We advance
+        # rows_written (the manifest's "rows persisted" counter) ONLY after the
+        # write+flush succeed, and we put the batch back on failure — so a write
+        # error (ENOSPC / EDQUOT / a handle closed by a concurrent shutdown)
+        # neither silently drops rows nor over-reports them as written. The old
+        # code popped every row and bumped the counter *before* writing, so any
+        # write error lost the whole batch while the manifest still counted it.
+        drained = []
+        while buffer:
+            drained.append(buffer.popleft())
+        if not drained:
+            return
+        complete_data = "".join(event + "\n" for event in drained)
+
         try:
-            string_buffer = io.StringIO()
-
-            n = 0
-            while buffer:
-                event = buffer.popleft()
-                string_buffer.write(event)
-                string_buffer.write('\n')
-                n += 1
-            self.rows_written[buffer_name] = self.rows_written.get(buffer_name, 0) + n
-
-            complete_data = string_buffer.getvalue()
             file_handle.write(complete_data)
             file_handle.flush()
-            
-            string_buffer.close()
-            
         except Exception as e:
-            logger("error", f"Error writing {buffer_name} buffer: {e}")
+            # Re-queue the un-persisted rows at the FRONT (preserving order) so
+            # the next periodic flush / shutdown force_flush retries them. Bound
+            # the retained rows so a persistently full/over-quota disk can't grow
+            # the buffers without limit; oldest rows past the cap are dropped and
+            # recorded in write_dropped (honest loss, not a silent drop).
+            buffer.extendleft(reversed(drained))
+            dropped = 0
+            while len(buffer) > self._max_buffered_rows_on_error:
+                buffer.popleft()
+                dropped += 1
+            if dropped:
+                self.write_dropped[buffer_name] = (
+                    self.write_dropped.get(buffer_name, 0) + dropped
+                )
+            logger("error", f"Error writing {buffer_name} buffer: {e}"
+                   + (f" — dropped {dropped} rows past retry cap" if dropped else ""))
+            return
+
+        self.rows_written[buffer_name] = (
+            self.rows_written.get(buffer_name, 0) + len(drained)
+        )
 
     def write_to_disk(self):
         """Write all buffered data to disk using parallel threads."""

--- a/tests/test_writer_upload.py
+++ b/tests/test_writer_upload.py
@@ -456,5 +456,97 @@ class NetworkStreamCompressionTests(unittest.TestCase):
             self.assertEqual(os.path.basename(os.path.dirname(p)), "nw_conn")
 
 
+class WriteBufferErrorHandlingTests(unittest.TestCase):
+    """A failed write/flush (ENOSPC, EDQUOT, a handle closed by a concurrent
+    shutdown) must NOT silently drop rows nor over-report them in the manifest.
+    Regression for the bug where _write_buffer_to_file popped the whole buffer
+    and bumped rows_written *before* writing, so any error lost the batch while
+    the manifest still counted it as persisted."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.output_dir = os.path.join(self.tmp, "trace")
+        self.upload = FakeUploadManager()
+        self.wm = SilentWriteManager(
+            output_dir=self.output_dir,
+            upload_manager=self.upload,
+            automatic_upload=True,
+        )
+
+    def tearDown(self):
+        import shutil
+        try:
+            self.wm.close_handles()
+        except Exception:
+            pass
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    class _FailingHandle:
+        def __init__(self, exc):
+            self.exc = exc
+        def write(self, data):
+            raise self.exc
+        def flush(self):
+            pass
+
+    def test_write_error_does_not_lose_rows_or_overcount(self):
+        import errno
+        from collections import deque
+        buf = deque(["r1", "r2", "r3"])
+        handle = self._FailingHandle(OSError(errno.EDQUOT, "Disk quota exceeded"))
+
+        self.wm._write_buffer_to_file(buf, handle, "VFS")
+
+        # Rows are retained for retry (not silently lost)...
+        self.assertEqual(list(buf), ["r1", "r2", "r3"])
+        # ...and NOT counted as written (manifest must not over-report).
+        self.assertEqual(self.wm.rows_written.get("VFS", 0), 0)
+
+    def test_requeued_rows_are_written_on_a_later_successful_flush(self):
+        import io as _io
+        import errno
+        from collections import deque
+        buf = deque(["r1", "r2", "r3"])
+
+        # First flush fails — rows go back on the buffer, nothing counted.
+        self.wm._write_buffer_to_file(
+            buf, self._FailingHandle(OSError(errno.ENOSPC, "No space")), "VFS")
+        self.assertEqual(list(buf), ["r1", "r2", "r3"])
+
+        # Second flush to a working handle persists them, in original order.
+        good = _io.StringIO()
+        self.wm._write_buffer_to_file(buf, good, "VFS")
+        self.assertEqual(good.getvalue(), "r1\nr2\nr3\n")
+        self.assertEqual(self.wm.rows_written.get("VFS", 0), 3)
+        self.assertEqual(len(buf), 0)
+
+    def test_successful_write_counts_exactly_once(self):
+        import io as _io
+        from collections import deque
+        buf = deque([f"row{i}" for i in range(5)])
+        good = _io.StringIO()
+        self.wm._write_buffer_to_file(buf, good, "Cache")
+        self.assertEqual(self.wm.rows_written.get("Cache"), 5)
+        self.assertEqual(good.getvalue().count("\n"), 5)
+
+    def test_persistent_failure_is_bounded_and_loss_is_recorded(self):
+        import errno
+        from collections import deque
+        # Tiny cap so the test is cheap; mimics a persistently full disk.
+        self.wm._max_buffered_rows_on_error = 10
+        handle = self._FailingHandle(OSError(errno.EDQUOT, "quota"))
+        buf = deque()
+        for i in range(25):
+            buf.append(f"row{i}")
+            self.wm._write_buffer_to_file(buf, handle, "VFS")
+
+        # Memory is bounded at the cap (no unbounded growth / OOM)...
+        self.assertLessEqual(len(buf), 10)
+        # ...the dropped rows are recorded honestly (not silently swallowed)...
+        self.assertGreater(self.wm.write_dropped.get("VFS", 0), 0)
+        # ...and dropped rows are NOT also counted as written.
+        self.assertEqual(self.wm.rows_written.get("VFS", 0), 0)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Bug (CRITICAL — silent data loss + dishonest manifest)

`WriteManager._write_buffer_to_file` popped the **entire** stream buffer into a `StringIO` and bumped `rows_written` **before** `file_handle.write()`:

```python
while buffer:
    event = buffer.popleft(); string_buffer.write(event + '\n'); n += 1
self.rows_written[buffer_name] += n      # counted BEFORE the write
file_handle.write(complete_data)         # if this raises...
...
except Exception as e:
    logger("error", ...)                 # ...rows are already gone
```

If the write/flush raised — **ENOSPC, EDQUOT (which the gpu1 quota-limited traces actually hit — 38 events in one run), or a handle closed by the shutdown race** — every popped row was permanently lost **and** the manifest still counted them as persisted. Unlike perf-buffer loss (recorded in `lost_events`), this loss was completely invisible.

### Proof (before fix)
```
EDQUOT injected → buffer drained 3→0 rows, 0 bytes on disk, manifest rows_written={'VFS': 3}
```

## Fix
- Drain into a local batch, **write+flush first**, advance `rows_written` only on success.
- On failure, **re-queue** the un-persisted rows at the front so the next flush / shutdown `force_flush` retries them.
- **Bound** retained rows (`_max_buffered_rows_on_error = 500k`) so a persistently full/over-quota disk can't OOM the tracer; rows dropped past the cap are recorded in a new `write_dropped` manifest counter — honest loss, never silent.

### After fix
```
EDQUOT injected → buffer retains 3 rows, rows_written={}  (retried on next flush)
```

## Tests
+4 regression tests (no-loss + no-over-count on EDQUOT/ENOSPC, retry on later success, count-exactly-once, bounded-memory + recorded loss under persistent failure). Full suite: **106 passed** (was 102).

🤖 Generated with [Claude Code](https://claude.com/claude-code)