### PR TITLE
fix: size perf buffers per-stream so high-volume streams stop dropping events (HIGH)

### DIFF
--- a/src/tracer/IOTracer.py
+++ b/src/tracer/IOTracer.py
@@ -200,6 +200,21 @@ class IOTracer:
             sys.exit(1)
         self.page_cnt = page_cnt
 
+        # Per-stream perf-buffer sizing (pages per CPU; a perf buffer requires a
+        # power-of-two page count). A flat page_cnt=8 (32 KB/CPU) overflowed on
+        # the high-volume page-cache and VFS streams — a short bursty workload
+        # dropped ~64% of cache events and ~27% of fs events *in the kernel*
+        # because the single poll thread could not drain the tiny buffers fast
+        # enough. Give the hot streams much larger kernel buffers so they absorb
+        # bursts and drain during lulls; keep the low-rate streams (block,
+        # network) modest to bound memory. (page_cnt is rounded up to a power of
+        # two so an odd --page-cnt override stays valid.)
+        base = 1 << max(0, self.page_cnt - 1).bit_length()
+        self._page_cnt_cache = max(base, 256)   # ~1 MB/CPU   — hottest stream
+        self._page_cnt_fs    = max(base, 128)   # ~512 KB/CPU — VFS + io_uring
+        self._page_cnt_block = max(base, 64)    # ~256 KB/CPU
+        self._page_cnt_net   = max(base, 32)    # ~128 KB/CPU — low event rate
+
         if duration is not None and duration <= 0:
             logger("error", f"Invalid duration: {duration}. Duration must be a positive integer.")
             sys.exit(1)
@@ -1344,19 +1359,19 @@ class IOTracer:
         # Open perf buffers for each event type
         self.b["events"].open_perf_buffer(
             self._print_event,
-            page_cnt=self.page_cnt,
+            page_cnt=self._page_cnt_fs,
             lost_cb=self._make_lost_cb("fs")
         )
 
         self.b["events_dual"].open_perf_buffer(
             self._print_event_dual,
-            page_cnt=self.page_cnt,
+            page_cnt=self._page_cnt_fs,
             lost_cb=self._make_lost_cb("fs")
         )
 
         self.b["bl_events"].open_perf_buffer(
             self._print_event_block,
-            page_cnt=self.page_cnt,
+            page_cnt=self._page_cnt_block,
             lost_cb=self._make_lost_cb("block")
         )
 
@@ -1366,7 +1381,7 @@ class IOTracer:
         if self.trace_cache:
             self.b["cache_events"].open_perf_buffer(
                 self._print_event_cache,
-                page_cnt=self.page_cnt,
+                page_cnt=self._page_cnt_cache,
                 lost_cb=self._make_lost_cb("cache")
             )
 
@@ -1382,7 +1397,7 @@ class IOTracer:
                 try:
                     self.b[buf_name].open_perf_buffer(
                         callback,
-                        page_cnt=self.page_cnt,
+                        page_cnt=self._page_cnt_net,
                         lost_cb=self._make_lost_cb(stream)
                     )
                 except KeyError:
@@ -1404,7 +1419,7 @@ class IOTracer:
         try:
             self.b["io_uring_events"].open_perf_buffer(
                 self._print_event_io_uring,
-                page_cnt=self.page_cnt,
+                page_cnt=self._page_cnt_fs,
                 lost_cb=self._make_lost_cb("fs")
             )
         except KeyError:


### PR DESCRIPTION
## Bug (HIGH — severe in-kernel event loss)

Every perf buffer was opened with a flat `page_cnt=8` (32 KB/CPU). On the high-volume **page-cache** and **VFS** streams the single poll thread cannot drain a 32 KB buffer fast enough, so the kernel overwrites unconsumed events. A short live capture lost **393,921 cache events (64%)** and **14,822 fs events (27%)** — recorded in the manifest's `lost_events`.

## Fix
Size each kernel buffer by its event rate (pages/CPU, rounded up to a power of two):

| stream | pages | ~bytes/CPU |
|--------|-------|-----------|
| cache  | 256   | ~1 MB |
| fs / VFS + io_uring | 128 | ~512 KB |
| block  | 64    | ~256 KB |
| network | 32   | ~128 KB |

Low-rate streams stay modest to bound memory; the hot streams now absorb bursts and drain during lulls.

## Verification — live A/B on gpu1 (64 cores), identical workloads

**Realistic bursty workload** (40 files, mixed direct/cached I/O + fsync + metadata churn):

| | cache loss | fs loss |
|--|--|--|
| baseline `page_cnt=8` | 64% | 27% |
| **this PR** | **0%** | **0%** |

**Pathological sustained workload** (`drop_caches` + 6 passes over 300 files ≈ **1M cache events/s**):

| | cache loss |
|--|--|
| baseline `page_cnt=8` | 93.1% (57.8M lost) |
| **this PR** | 63.5% |

Bigger buffers fully eliminate loss for realistic bursty load. Under a truly *sustained* 1M-events/s flood the residual loss is the **single-threaded consumer** (inline `format_csv_row` per event) — not buffer size; moving event formatting off the poll thread is the follow-up for that regime. Full test suite: 102 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)