### PR TITLE
fix: idempotent shutdown + stop poll thread before closing handles (HIGH)

### DIFF
--- a/src/tracer/IOTracer.py
+++ b/src/tracer/IOTracer.py
@@ -20,6 +20,7 @@ import shutil
 import signal
 import os
 import ctypes
+import threading
 import json
 import platform
 import socket
@@ -156,6 +157,14 @@ class IOTracer:
         self.system_snapper     = SystemSnapper(self.writer)
         self.flag_mapper        = FlagMapper()
         self.running            = True
+        # Shutdown is driven by _cleanup, which can be entered more than once —
+        # the SIGINT/SIGTERM handler, a second signal, and the timed path all
+        # call it. This non-reentrant lock makes it run exactly once; a
+        # re-entrant or concurrent call returns immediately instead of flushing
+        # and detaching probes twice on already-closed handles.
+        self._cleanup_lock      = threading.Lock()
+        self._cleanup_done      = False
+        self._poll_thread       = None
         self.verbose            = verbose
         self.duration           = duration
         self.anonymous          = anonymous
@@ -1156,16 +1165,41 @@ class IOTracer:
         self.writer.append_fs_log(output)
 
     def _cleanup(self, signum, frame):
-        self.running = False
-        self.probe_tracker.detach_kprobes()
+        # Run exactly once. _cleanup is reached from the SIGINT/SIGTERM handler,
+        # a possible second signal (double Ctrl-C, or SIGINT then SIGTERM), and
+        # the timed path's direct call — a non-blocking acquire makes every
+        # entry after the first return immediately, so we never detach probes or
+        # flush+close handles twice.
+        if not self._cleanup_lock.acquire(blocking=False):
+            return
+        try:
+            if self._cleanup_done:
+                return
+            self._cleanup_done = True
+            self.running = False
 
-        def _flush():
-            self.fs_snapper.stop_snapper()
-            self.process_snapper.stop_snapper()
-            self.writer.write_to_disk()
-            self.writer.close_handles()
+            # Stop and JOIN the poll thread before touching handles. Previously
+            # cleanup detached probes and closed the writer handles while the
+            # poll thread was still running (polling_active was only cleared
+            # later, in trace()'s finally), so a perf-buffer callback could write
+            # to a handle being closed. Joining first guarantees no callback runs
+            # during the flush/close below.
+            if self.polling_thread is not None:
+                self.polling_thread.polling_active = False
+            if self._poll_thread is not None:
+                self._poll_thread.join(timeout=2.0)
 
-        run_with_spinner("Flushing trace data", _flush)
+            self.probe_tracker.detach_kprobes()
+
+            def _flush():
+                self.fs_snapper.stop_snapper()
+                self.process_snapper.stop_snapper()
+                self.writer.write_to_disk()
+                self.writer.close_handles()
+
+            run_with_spinner("Flushing trace data", _flush)
+        finally:
+            self._cleanup_lock.release()
 
     def _block_stats(self, collapse_zero: bool = True):
         """Read the per-CPU ``block_stats`` map → {issued, completed, missed, stale}.
@@ -1424,9 +1458,11 @@ class IOTracer:
         else:
             logger("info", "Tracing indefinitely. Ctrl + C to stop.")
 
-        # Start the polling thread for perf buffer
+        # Start the polling thread for perf buffer. Keep the Thread handle so
+        # _cleanup can join it before flushing/closing handles (otherwise a
+        # callback could still write to a handle being torn down).
         self.polling_thread = PollingThread(self.b, True)
-        self.polling_thread.create_thread()
+        self._poll_thread = self.polling_thread.create_thread()
 
         try:
             if self.duration is not None:
@@ -1462,9 +1498,13 @@ class IOTracer:
         except Exception as e:
             logger("error", f"Main loop error: {e}")
         finally:
-            self.polling_thread.polling_active = False
-            time.sleep(0.2)
-            
+            # Funnel every exit path (timed, Ctrl-C via handler, KeyboardInterrupt
+            # before the handler was installed, or an unexpected error) through
+            # the one idempotent cleanup, so probes are always detached and
+            # buffers flushed exactly once — the KeyboardInterrupt/error paths
+            # used to skip detach + flush entirely. A no-op if cleanup already ran.
+            self._cleanup(None, None)
+
             if self.verbose:
                 actual_duration = time.time() - start
                 logger("info", f"Trace completed after {actual_duration:.2f} seconds")

--- a/tests/test_cleanup_shutdown.py
+++ b/tests/test_cleanup_shutdown.py
@@ -1,0 +1,157 @@
+"""
+Regression tests for IOTracer._cleanup shutdown correctness.
+
+Two bugs are guarded here:
+  1. _cleanup was not idempotent — a second signal (double Ctrl-C, SIGINT then
+     SIGTERM) or the timed path's direct call ran detach_kprobes + flush + close
+     twice on already-closed handles.
+  2. _cleanup detached probes and closed the writer handles while the perf-buffer
+     poll thread was still running, so a callback could write to a handle being
+     torn down. The poll thread must be stopped and joined BEFORE close_handles.
+
+These import IOTracer (which pulls in bcc); the module is skipped where bcc is
+unavailable so it never breaks a minimal CI collection.
+"""
+
+import os
+import sys
+import types
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# WriterManager -> ObjectStorageManager imports `requests`; stub it if absent.
+if "requests" not in sys.modules:
+    try:
+        import requests  # noqa: F401
+    except ModuleNotFoundError:
+        sys.modules["requests"] = types.ModuleType("requests")
+
+# IOTracer does `from bcc import BPF`. The real bcc/BPF only loads under the
+# system (root) python; these tests exercise the pure-Python _cleanup logic via
+# object.__new__ and never touch BPF, so stub a BPF symbol when it's missing so
+# the module imports anywhere (venv / minimal CI) without root or eBPF.
+try:
+    from bcc import BPF  # noqa: F401
+except Exception:
+    _bcc = sys.modules.get("bcc") or types.ModuleType("bcc")
+    if not hasattr(_bcc, "BPF"):
+        _bcc.BPF = type("BPF", (), {})
+    sys.modules["bcc"] = _bcc
+
+try:
+    from src.tracer.IOTracer import IOTracer
+    import src.tracer.IOTracer as iotracer_mod
+    HAS_BCC = True
+except Exception:
+    HAS_BCC = False
+
+
+class _Recorder:
+    """Collects an ordered log of lifecycle calls across the fakes."""
+
+    def __init__(self):
+        self.calls = []
+
+
+class _FakePoll:
+    def __init__(self, rec):
+        self.rec = rec
+        self.polling_active = True
+
+
+class _FakePollThread:
+    def __init__(self, rec, poll):
+        self.rec = rec
+        self.poll = poll
+
+    def join(self, timeout=None):
+        # Record that the poll loop was asked to stop before we joined it.
+        self.rec.calls.append(("poll_active", self.poll.polling_active))
+        self.rec.calls.append("join")
+
+
+class _FakeProbe:
+    def __init__(self, rec):
+        self.rec = rec
+
+    def detach_kprobes(self):
+        self.rec.calls.append("detach")
+
+
+class _FakeSnapper:
+    def __init__(self, rec, name):
+        self.rec = rec
+        self.name = name
+
+    def stop_snapper(self):
+        self.rec.calls.append(f"stop_{self.name}")
+
+
+class _FakeWriter:
+    def __init__(self, rec):
+        self.rec = rec
+
+    def write_to_disk(self):
+        self.rec.calls.append("write_to_disk")
+
+    def close_handles(self):
+        self.rec.calls.append("close_handles")
+
+
+@unittest.skipUnless(HAS_BCC, "bcc not importable in this environment")
+class CleanupShutdownTests(unittest.TestCase):
+    def _make_tracer(self):
+        import threading
+        t = object.__new__(IOTracer)  # bypass __init__ (no BPF/root needed)
+        rec = _Recorder()
+        t._cleanup_lock = threading.Lock()
+        t._cleanup_done = False
+        t.running = True
+        t.verbose = False
+        poll = _FakePoll(rec)
+        t.polling_thread = poll
+        t._poll_thread = _FakePollThread(rec, poll)
+        t.probe_tracker = _FakeProbe(rec)
+        t.fs_snapper = _FakeSnapper(rec, "fs")
+        t.process_snapper = _FakeSnapper(rec, "proc")
+        t.writer = _FakeWriter(rec)
+        return t, rec
+
+    def setUp(self):
+        # Run the flush callback inline (no spinner thread / animation in tests).
+        self._orig_spinner = iotracer_mod.run_with_spinner
+        iotracer_mod.run_with_spinner = lambda label, fn, *a, **k: fn()
+
+    def tearDown(self):
+        iotracer_mod.run_with_spinner = self._orig_spinner
+
+    def test_cleanup_runs_exactly_once(self):
+        t, rec = self._make_tracer()
+        t._cleanup(None, None)
+        first = list(rec.calls)
+        # Second + third entries (double signal / timed path) must be no-ops.
+        t._cleanup(None, None)
+        t._cleanup(None, None)
+        self.assertEqual(rec.calls, first)
+        self.assertEqual(rec.calls.count("detach"), 1)
+        self.assertEqual(rec.calls.count("write_to_disk"), 1)
+        self.assertEqual(rec.calls.count("close_handles"), 1)
+        self.assertTrue(t._cleanup_done)
+        self.assertFalse(t.running)
+
+    def test_poll_thread_stopped_and_joined_before_handles_close(self):
+        t, rec = self._make_tracer()
+        t._cleanup(None, None)
+        # The poll loop flag was cleared before the join...
+        self.assertIn(("poll_active", False), rec.calls)
+        # ...and the join happened before close_handles (no callback can run
+        # against a handle being torn down).
+        self.assertLess(rec.calls.index("join"), rec.calls.index("close_handles"))
+        # detach precedes the buffer flush + close, too.
+        self.assertLess(rec.calls.index("detach"), rec.calls.index("write_to_disk"))
+        self.assertLess(rec.calls.index("write_to_disk"), rec.calls.index("close_handles"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Bug (HIGH — shutdown race + non-reentrant cleanup)

`_cleanup` (installed as the SIGINT/SIGTERM handler, also called by the timed path) had two defects:

1. **Race:** it detached probes and `close_handles()`-ed the writer **while the perf-buffer poll thread was still running** — `polling_active` was only cleared later, in `trace()`'s `finally` — so a callback could write to a handle being torn down. `create_thread()`'s returned Thread was discarded, so the poll thread couldn't even be joined.
2. **Not idempotent:** a second signal (double Ctrl-C, or SIGINT then SIGTERM) or the timed path's direct call ran `detach + flush + close` again on already-closed handles. The `KeyboardInterrupt` / error paths conversely **skipped `_cleanup` entirely**, so probes were never detached.

## Fix
- Retain the poll `Thread` handle.
- Guard `_cleanup` with a non-blocking lock + done flag → runs **exactly once**; re-entrant/duplicate calls return immediately.
- Inside it, **stop and JOIN the poll thread before** detaching probes and flushing/closing handles, so no callback can run against a handle being closed.
- Route `trace()`'s `finally` through the same idempotent `_cleanup`, so every exit path (timed, signal handler, KeyboardInterrupt, error) detaches + flushes exactly once.

## Verification
- New `tests/test_cleanup_shutdown.py`: asserts cleanup runs once (detach/write/close each called exactly once on repeated calls) and that the poll thread is stopped + joined **before** `close_handles` (and `detach` → `write_to_disk` → `close_handles` ordering). Guarded to skip where `bcc` is unavailable.
- Live SIGINT run on gpu1: clean shutdown — `Cleanup complete. Exited successfully.`, exit 0, **zero** closed-handle errors / tracebacks, valid 23 MB trace produced.
- Full suite: **104 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)