### PR TITLE
fix: flush buffers before writing the manifest so rows_written is accurate (MED)

### DIFF
--- a/src/tracer/IOTracer.py
+++ b/src/tracer/IOTracer.py
@@ -1470,6 +1470,17 @@ class IOTracer:
                 logger("info", f"Trace completed after {actual_duration:.2f} seconds")
 
             self._log_block_diagnostics()
+            # Flush every remaining buffered row to disk BEFORE writing the
+            # manifest, so its rows_written counts them. Previously the manifest
+            # was finalised here but the final flush happened later in
+            # force_flush(), so the last rotated rows reached disk *uncounted* —
+            # rows_written under-reported the trace (e.g. fs/nw streams short by a
+            # few dozen rows). The poll thread is already stopped (polling_active
+            # cleared above) and snapshots are halted, so no new rows arrive.
+            try:
+                self.writer.write_to_disk()
+            except Exception as e:
+                logger("warning", f"Final pre-manifest flush failed: {e}")
             # Finalise the manifest with stop time + final diagnostics. Guarded
             # so a manifest failure never blocks shutdown/flush.
             try:


### PR DESCRIPTION
## Bug (MED — manifest under-reports rows persisted)

The session manifest is finalised in `trace()`'s `finally` block ([IOTracer.py](src/tracer/IOTracer.py)), but the **final buffer flush happens afterward**, inside `force_flush()` (which starts with `write_to_disk()`). Any rows still buffered when the manifest is written — the last rotated rows of each continuous stream — reach disk **uncounted**, so `diagnostics.rows_written` under-reports the trace.

Measured against actual on-disk rows on a live capture:

| stream | manifest | on-disk |
|--------|---------:|--------:|
| fs | 39,615 | 39,642 (**+27**) |
| nw_sockopt | 530 | 566 (**+36**) |
| nw_conn | 1,319 | 1,323 (**+4**) |

## Fix
Flush the writer (`write_to_disk()`) **before** finalising the manifest. The poll thread is already stopped and snapshots halted at this point, so no new rows arrive; `force_flush()`'s own `write_to_disk()` then has nothing left and just compresses. One-line reorder, no upload-path change.

## Verification — live gpu1 capture, manifest vs on-disk row counts

| stream | manifest | on-disk | match |
|--------|---------:|--------:|:--:|
| fs | 21,046 | 21,046 | ✅ |
| cache | 166,519 | 166,519 | ✅ |
| block | 1,819 | 1,819 | ✅ |
| nw_conn | 907 | 907 | ✅ |
| nw_sockopt | 228 | 228 | ✅ |
| nw_drop | 8 | 8 | ✅ |
| filesystem_snapshot | 971,520 | 971,520 | ✅ |

All continuous streams now match exactly (they diverged before). Suite: **102 passed**.

> Note: the `process` *snapshot* stream can still differ by a small delta (8 here) — a **separate, pre-existing** snapshot-flush timing issue (reproduced on `main`: 941 vs 944), independent of this manifest-ordering fix and out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)