### PR TITLE
fix: make the created_files counter increment atomic (LOW)

### DIFF
--- a/src/tracer/WriterManager.py
+++ b/src/tracer/WriterManager.py
@@ -76,6 +76,11 @@ class WriteManager:
         self.current_datetime = datetime.now()
 
         self.created_files = 0
+        # created_files is bumped from several threads (perf-callback compress,
+        # periodic-flush compress, and the snapshot thread's part upload). A
+        # plain += is a non-atomic read-modify-write, so concurrent rotations
+        # could lose increments and undercount this telemetry — guard it.
+        self._created_files_lock = threading.Lock()
         # Total rows written to disk per stream (keyed by buffer label), for the
         # session manifest — lets a consumer spot a stream whose probes attached
         # but produced no events.
@@ -736,8 +741,8 @@ class WriteManager:
                     num_parts = len(self.fs_snapshot_parts_pending_upload)
                     if num_parts > 0:
                         # Count each part individually to match upload counter
-                        self.created_files += num_parts
-                        logger('info', f"Files Created: {str(self.created_files)} (filesystem snapshot with {num_parts} parts)", True)
+                        total_created = self._bump_created_files(num_parts)
+                        logger('info', f"Files Created: {str(total_created)} (filesystem snapshot with {num_parts} parts)", True)
                     for part_file in self.fs_snapshot_parts_pending_upload:
                         if os.path.exists(part_file):
                             self.upload_manager.append_object(part_file)
@@ -1096,6 +1101,15 @@ class WriteManager:
         # in the window between a stream's drain and the clear — silently losing
         # events on every periodic flush. The drain is the only emptying needed.
 
+    def _bump_created_files(self, n: int = 1) -> int:
+        """Atomically add ``n`` to the created-files counter and return the new
+        total. Called from multiple threads (perf-callback / periodic-flush
+        compression and the snapshot upload), where a bare ``+=`` could lose
+        increments to a read-modify-write race."""
+        with self._created_files_lock:
+            self.created_files += n
+            return self.created_files
+
     def compress_log(self, input_file: str):
         """
         Compress a log file and optionally upload it.
@@ -1120,8 +1134,8 @@ class WriteManager:
             upload_target = compressed if compressed is not None else src
 
             if self.automatic_upload:
-                self.created_files += 1
-                logger('info', f"Files Created: {str(self.created_files)}", True)
+                total_created = self._bump_created_files()
+                logger('info', f"Files Created: {str(total_created)}", True)
                 # Upload each log individually, preserving its subdirectory
                 # (fs, block, cache, process, ...) on the backend.
                 self.upload_manager.append_object(upload_target)
@@ -1160,8 +1174,8 @@ class WriteManager:
                     tar.add(src, arcname=os.path.basename(src))
 
             if self.automatic_upload:
-                self.created_files += 1
-                logger("info", f"Files Created: {self.created_files}", True)
+                total_created = self._bump_created_files()
+                logger("info", f"Files Created: {total_created}", True)
                 self.upload_manager.append_object(dst)
 
             shutil.rmtree(src)

--- a/tests/test_writer_upload.py
+++ b/tests/test_writer_upload.py
@@ -548,5 +548,53 @@ class WriteBufferErrorHandlingTests(unittest.TestCase):
         self.assertEqual(self.wm.rows_written.get("VFS", 0), 0)
 
 
+class CreatedFilesCounterTests(unittest.TestCase):
+    """created_files is bumped from several threads (compress on the
+    perf-callback and periodic-flush threads, plus snapshot part uploads). The
+    bump must be atomic so concurrent rotations don't lose increments via a
+    read-modify-write race."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.output_dir = os.path.join(self.tmp, "trace")
+        self.upload = FakeUploadManager()
+        self.wm = SilentWriteManager(
+            output_dir=self.output_dir,
+            upload_manager=self.upload,
+            automatic_upload=True,
+        )
+
+    def tearDown(self):
+        import shutil
+        try:
+            self.wm.close_handles()
+        except Exception:
+            pass
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    def test_concurrent_bumps_lose_no_increments(self):
+        import threading
+        threads_n, per_thread = 16, 2000
+        barrier = threading.Barrier(threads_n)
+
+        def worker():
+            barrier.wait()  # maximise contention by releasing all at once
+            for _ in range(per_thread):
+                self.wm._bump_created_files()
+
+        threads = [threading.Thread(target=worker) for _ in range(threads_n)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertEqual(self.wm.created_files, threads_n * per_thread)
+
+    def test_bump_returns_new_total_and_supports_n(self):
+        self.assertEqual(self.wm._bump_created_files(), 1)
+        self.assertEqual(self.wm._bump_created_files(5), 6)
+        self.assertEqual(self.wm.created_files, 6)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Bug (LOW — telemetry undercount under concurrency)

`created_files` is bumped from several threads — log compression on the perf-callback and periodic-flush threads, plus the snapshot thread's part upload:

```python
self.created_files += num_parts   # snapshot thread
self.created_files += 1           # compress_log (poll / periodic threads)
self.created_files += 1           # compress_dir
```

A bare `+=` is a non-atomic read-modify-write (LOAD/ADD/STORE), so concurrent rotations can interleave and lose increments, undercounting the "Files Created" telemetry.

## Fix
Route every bump through a lock-guarded `_bump_created_files(n)` helper that returns the new total (so the log line stays consistent too).

## Verification
New regression test: **16 threads × 2000 concurrent bumps** (released together via a barrier for maximum contention) must total exactly **32000** with no lost updates. Full suite: **104 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)