### PR TITLE
fix: don't crash cleanup when a signal arrives during startup (regression from #80)

### DIFF
--- a/src/tracer/IOTracer.py
+++ b/src/tracer/IOTracer.py
@@ -178,6 +178,11 @@ class IOTracer:
         # and detaching probes twice on already-closed handles.
         self._cleanup_lock      = threading.Lock()
         self._cleanup_done      = False
+        # Both must exist before trace() assigns them: the SIGINT/SIGTERM handler
+        # (_cleanup) is installed partway through trace() startup but references
+        # self.polling_thread, which trace() only sets once probes are attached.
+        # A signal in that window must not raise AttributeError and abort cleanup.
+        self.polling_thread     = None
         self._poll_thread       = None
         self.verbose            = verbose
         self.duration           = duration
@@ -1181,10 +1186,15 @@ class IOTracer:
             # later, in trace()'s finally), so a perf-buffer callback could write
             # to a handle being closed. Joining first guarantees no callback runs
             # during the flush/close below.
-            if self.polling_thread is not None:
-                self.polling_thread.polling_active = False
-            if self._poll_thread is not None:
-                self._poll_thread.join(timeout=2.0)
+            # getattr-guarded so a signal that fires before trace() has assigned
+            # these (the startup window) can never raise AttributeError and abort
+            # cleanup mid-way (which would leave _cleanup_done=True and block retry).
+            polling_thread = getattr(self, "polling_thread", None)
+            if polling_thread is not None:
+                polling_thread.polling_active = False
+            poll_thread = getattr(self, "_poll_thread", None)
+            if poll_thread is not None:
+                poll_thread.join(timeout=2.0)
 
             self.probe_tracker.detach_kprobes()
 

--- a/tests/test_cleanup_shutdown.py
+++ b/tests/test_cleanup_shutdown.py
@@ -152,6 +152,22 @@ class CleanupShutdownTests(unittest.TestCase):
         self.assertLess(rec.calls.index("detach"), rec.calls.index("write_to_disk"))
         self.assertLess(rec.calls.index("write_to_disk"), rec.calls.index("close_handles"))
 
+    def test_cleanup_safe_when_signal_arrives_during_startup(self):
+        # Regression: the SIGINT/SIGTERM handler (_cleanup) is installed partway
+        # through trace() startup, before self.polling_thread is assigned. A
+        # signal in that window must NOT raise AttributeError — which would abort
+        # cleanup with _cleanup_done already True, leaving probes attached and
+        # buffers unflushed. _cleanup must tolerate polling_thread / _poll_thread
+        # being absent (or None) and still detach + flush.
+        t, rec = self._make_tracer()
+        del t.polling_thread          # simulate the pre-assignment startup state
+        del t._poll_thread
+        t._cleanup(2, None)           # must not raise
+        self.assertIn("detach", rec.calls)
+        self.assertIn("write_to_disk", rec.calls)
+        self.assertIn("close_handles", rec.calls)
+        self.assertTrue(t._cleanup_done)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Bug (regression introduced by #80 — Ctrl-C during startup crashes, no clean shutdown)

#80 made `_cleanup` reference `self.polling_thread`, but `__init__` only initialises `self._poll_thread`. `self.polling_thread` is first assigned later in `trace()` (line ~1451) — **after** the SIGINT/SIGTERM handler is installed (line ~1362) and after the slow probe-attach + `capture_spec_snapshot()`. A signal in that startup window invokes `_cleanup`, which hits:

```
AttributeError: 'IOTracer' object has no attribute 'polling_thread'
```

…and aborts cleanup **after** setting `_cleanup_done = True`. The idempotency guard then blocks any retry, so: probes stay attached, buffers are never flushed, and the user sees a traceback instead of a clean exit.

### Deterministic repro (before fix)
```
>>> t._cleanup(2, None)
AttributeError: 'IOTracer' object has no attribute 'polling_thread'
_cleanup_done is now: True   # retry permanently blocked
```

## Fix
- Initialise `self.polling_thread = None` in `__init__` (next to `self._poll_thread = None`).
- Read both via `getattr(..., None)` in `_cleanup` as belt-and-suspenders, so an early signal can never raise.

### After fix
```
PASS: _cleanup completed without AttributeError
```

## Verification
- Deterministic repro now passes.
- New regression test `test_cleanup_safe_when_signal_arrives_during_startup` (deletes the attributes to simulate the startup state, asserts `_cleanup` detaches + flushes without raising).
- Full suite: **111 passed**.

Found by a post-merge multi-agent audit of `main` after #78–#84 landed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)