### PR TITLE
fix: don't leave a stray header-only process shard each rotation (LOW)

### DIFF
--- a/src/tracer/WriterManager.py
+++ b/src/tracer/WriterManager.py
@@ -739,7 +739,14 @@ class WriteManager:
                 self._process_handle.close()
                 rotated = self.output_process_file
                 self.output_process_file = f"{self.output_dir}/process/process_{self.current_datetime.strftime('%Y%m%d_%H%M%S_%f')[:-3]}.csv"
-                self._process_handle = self._open_log_file(self.output_process_file, 'process')
+                # Reopen LAZILY (on the next append) rather than eagerly: an eager
+                # _open_log_file here writes a schema header into the new file
+                # immediately, so the LAST snapshot before shutdown left a
+                # header-only, 0-data-row file that force_flush still compressed +
+                # uploaded (a stray part; a bogus 2nd header to a concatenating
+                # reader). With None, the file is created only when there is a row
+                # to write, and force_flush's compress_log skips the missing path.
+                self._process_handle = None
                 self._reset_flush_timer()
 
                 # Mark process snapshot as complete

--- a/tests/test_writer_upload.py
+++ b/tests/test_writer_upload.py
@@ -547,6 +547,49 @@ class WriteBufferErrorHandlingTests(unittest.TestCase):
         self.assertEqual(self.wm.rows_written.get("VFS", 0), 0)
 
 
+class ProcessRotationTests(unittest.TestCase):
+    """flush_process_state_only must not leave a stray header-only file: it
+    reopens the next process file LAZILY, so the last snapshot before shutdown
+    doesn't produce a 0-data-row part that force_flush still compresses+uploads."""
+
+    def setUp(self):
+        self.tmp = tempfile.mkdtemp()
+        self.output_dir = os.path.join(self.tmp, "trace")
+        self.upload = FakeUploadManager()
+        self.wm = SilentWriteManager(
+            output_dir=self.output_dir,
+            upload_manager=self.upload,
+            automatic_upload=True,
+        )
+
+    def tearDown(self):
+        import shutil
+        try:
+            self.wm.close_handles()
+        except Exception:
+            pass
+        shutil.rmtree(self.tmp, ignore_errors=True)
+
+    @unittest.skipUnless(HAS_ZSTD or True, "")
+    def test_flush_does_not_leave_header_only_part(self):
+        for i in range(5):
+            self.wm.append_process_log(f"2026-01-01,{i},proc{i},,1,1,0,0,0,0,running,1")
+        self.wm.flush_process_state_only()
+
+        # The full file was rotated + uploaded; the NEXT process file is reopened
+        # lazily, so it must NOT exist on disk yet (no eager header write).
+        self.assertFalse(os.path.exists(self.wm.output_process_file),
+                         "next process file should be created lazily, not eagerly with a header")
+        uploads_after_flush = len(self.upload.uploaded)
+        self.assertEqual(uploads_after_flush, 1)
+
+        # Simulate shutdown compressing the (still un-written) current file:
+        # compress_log must skip the missing path, so NO stray empty part uploads.
+        self.wm.compress_log(self.wm.output_process_file)
+        self.assertEqual(len(self.upload.uploaded), uploads_after_flush,
+                         "force_flush must not upload a header-only/missing process part")
+
+
 class CreatedFilesCounterTests(unittest.TestCase):
     """created_files is bumped from several threads (compress on the
     perf-callback and periodic-flush threads, plus snapshot part uploads). The


### PR DESCRIPTION
## Bug (LOW — stray header-only part, confirmed empirically)

`flush_process_state_only()` rotated **eagerly**: after writing the process buffer to the current file and closing it, it set a new `output_process_file` and immediately reopened it via `_open_log_file`, which writes a schema header into the new empty file. On the **last** snapshot before shutdown that file stayed header-only (0 data rows), and `force_flush` still `compress_log`'d + uploaded it — a stray part, counted toward `created_files`, and a bogus second header to any reader concatenating the process parts.

Confirmed in a live capture: `process/` had two files, the second decompressing to exactly the header with 0 data rows.

## Fix
Reopen **lazily** (`self._process_handle = None`): the next file is created only when there's a row to write (append / `write_to_disk` already open on demand), and `force_flush`'s `compress_log` skips the missing path. This matches the empty-file skip the continuous streams already get via `_rotate_stream`.

## Verification
- New regression test `test_flush_does_not_leave_header_only_part` (asserts the next file isn't created eagerly and no empty part is uploaded).
- Live capture: exactly one process shard with data, **no** header-only part; clean shutdown.
- Suite: **111 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)