### PR TITLE
Add userspace hot-path profiler for the tracer

### DIFF
--- a/docs/PROFILING.md
+++ b/docs/PROFILING.md
@@ -1,0 +1,161 @@
+# Tracer Profiling
+
+This document describes how to profile the IO Tracer's userspace hot path and
+records the findings from a baseline run.
+
+## Why profile userspace?
+
+The live tracer needs root, BCC/eBPF, and a real kernel, so it can't be run on
+an ordinary dev box or in CI. But the throughput ceiling that matters in
+practice is set in **userspace**: a single poll thread (`PollingThread`) drains
+the per-CPU kernel perf buffers and runs a Python callback
+(`IOTracer._print_event` and friends) for every event. If that callback can't
+keep up, the kernel buffers overflow and events are *dropped* (the
+`lost_events` counter in `manifest.json`). Every microsecond shaved off
+per-event processing directly raises the event rate the tracer can sustain
+before it starts losing data.
+
+So the thing worth profiling is the per-event Python path:
+
+```
+poll thread
+  └─ _print_event(cpu, data, size)          # one call per VFS event
+       ├─ b["events"].event(data)           # ctypes decode (owned by BCC)
+       ├─ flag_mapper.format_vfs_flags(...)  # flag decoding
+       ├─ flag_mapper.format_fs_type(...)
+       ├─ _event_walltime(...)               # ns → datetime
+       ├─ _read_cmdline_cached(...)          # cached /proc read
+       ├─ format_csv_row(... 22 fields ...)  # CSV row build
+       └─ writer.append_fs_log(row)          # deque append + maybe flush/compress
+```
+
+## The harness
+
+[`scripts/profile_tracer.py`](../scripts/profile_tracer.py) drives the real
+callbacks with synthetic events and measures them under `cProfile`. It stubs
+out `bcc` (so the module imports without a kernel), constructs an `IOTracer`
+via `__new__` with only the attributes the callbacks need, and wires up the
+real `FlagMapper`, `PathResolver`, and `WriteManager` (upload disabled, output
+to a temp dir). Events are fed straight into `_print_event` /
+`_print_event_cache` / `_print_event_block`, so every per-event function the
+live tracer runs is exercised and attributed.
+
+**What it measures:** all per-event Python processing, plus `WriteManager`
+buffering, rotation, and zstd/gzip compression of the rotated files.
+
+**What it does not measure:** the kernel BPF programs themselves, the
+perf-buffer ctypes decode (`event(data)`, which lives inside BCC), and real
+network latency to the upload backend. The synthetic event mix is
+read/write-heavy with a small working set of pids/inodes/files, which models a
+busy host where the cmdline and inode→path caches stay warm.
+
+### Running it
+
+```bash
+# Accurate throughput (cProfile off) for each stream:
+python3 scripts/profile_tracer.py --stream fs    -n 300000 --bench
+python3 scripts/profile_tracer.py --stream cache -n 300000 --bench
+python3 scripts/profile_tracer.py --stream block -n 300000 --bench
+
+# Per-function breakdown (cProfile on):
+python3 scripts/profile_tracer.py --stream fs -n 200000 --sort tottime --top 25
+
+# Isolate per-event cost from flush/compress:
+python3 scripts/profile_tracer.py --stream fs -n 300000 --bench --no-compress
+
+# Dump raw stats for snakeviz / pstats:
+python3 scripts/profile_tracer.py --dump /tmp/fs.pstats
+```
+
+`--bench` disables `cProfile` (which inflates per-call cost ~5×) so the
+events/s number is representative; the per-function table needs `cProfile` on.
+
+## Baseline results
+
+Measured on the CI/dev container (CPython, `cProfile` off for throughput, on
+for the breakdown). Absolute rates are machine-relative — the **relative**
+breakdown is the durable signal.
+
+### Throughput by stream
+
+| Stream | Throughput   | Per-event | Notes                                  |
+|--------|--------------|-----------|----------------------------------------|
+| fs     | ~67k ev/s    | ~14.9 µs  | compress on (rotates + zstd)           |
+| fs     | ~78k ev/s    | ~12.8 µs  | `--no-compress` (pure per-event)       |
+| cache  | ~145k ev/s   | ~6.9 µs   | smallest row, fewest flag lookups      |
+| block  | ~129k ev/s   | ~7.8 µs   | rwbs/dev decode                        |
+
+The fs/VFS stream is roughly **2× more expensive per event** than cache or
+block, because it builds the widest CSV row (22 columns) and does the most flag
+decoding. It is also the highest-volume stream on most hosts, so it dominates
+total userspace cost.
+
+### Where the fs per-event time goes (`tottime`, 200k events)
+
+```
+ncalls   tottime  function
+200000    2.18s   utils.format_csv_row              # 22-field CSV build
+200000    2.05s   IOTracer._print_event             # the callback body itself
+200000    1.30s   FlagMapper.format_fs_flags        # open-flag decode
+4.8M      0.38s   list.append
+200000    0.30s   WriterManager.append_fs_log       # deque append + flush check
+200000    0.17s   FlagMapper.format_fs_type
+200000    0.14s   IOTracer._ns_to_walltime          # ns → datetime
+400000    0.14s   str.join
+200000    0.12s   IOTracer._format_dev
+200000    0.11s   {built-in fromtimestamp}
+```
+
+Three leaves account for the bulk of attributable time:
+`format_csv_row` (~27%), the `_print_event` body (~25%), and
+`format_fs_flags` (~16%).
+
+## Findings & optimization opportunities
+
+These are recorded for follow-up. They are **not applied here** — this change
+is profiling only, and several touch the trace output format, which deserves
+its own review. Impact figures are measured against the baseline above.
+
+1. **`format_fs_flags` loops the full flag table even when `flags == 0`.**
+   On a read/write/close-heavy mix the overwhelmingly common argument is
+   `flags == 0`, yet the function still iterates all 19 entries of
+   `flag_fs_map` and runs per-entry list-membership scans
+   (`name in [...]`, `"O_DSYNC" in result`). A short-circuit —
+   `if flags == 0: return "O_RDONLY"` — is exactly equivalent (access mode 0 =
+   `O_RDONLY`, no other bits set) and is **~25× faster on that path**
+   (2460 ns → 96 ns per call, microbenchmarked). Since `format_fs_flags` is
+   ~16% of fs `tottime`, this alone is a meaningful win. The general path could
+   also precompute the non-access flag list once instead of re-filtering the
+   dict per call.
+
+2. **`format_csv_row` is the single biggest leaf.** It is already hand-rolled
+   to avoid the stdlib `csv` overhead, but per field it does a type check and a
+   special-character scan. Most of the 22 fields per row are empty strings or
+   ints. Options worth measuring: skip the special-char scan for fields known
+   never to contain `,"\n\r` (op name, numeric columns), or assemble the row
+   from a pre-sized list. This is the highest-volume function in the tracer, so
+   even a small per-field saving compounds.
+
+3. **A `datetime` is built and stringified per event.** `_event_walltime` →
+   `_ns_to_walltime` calls `datetime.fromtimestamp(...)` and the result is then
+   `str()`-formatted inside `format_csv_row` (~0.4s cumulative / 200k events).
+   The raw monotonic-ns value is *already* emitted as the row's last column, so
+   the human-readable timestamp is partially redundant. Consider formatting the
+   wall-clock string directly from integer ns (avoiding the `datetime` object),
+   or making the formatted timestamp optional.
+
+4. **Repeated `getattr(event, "x", 0)` / `hasattr(event, "x")` guards.**
+   `_print_event` does ~6 `getattr`/`hasattr` probes per event (1.2M `getattr`
+   + 0.6M `hasattr` calls for 200k events) to tolerate optional struct fields.
+   Since the struct layout is fixed once the BPF program is compiled, these
+   could be resolved once at startup (e.g. capture the field set from
+   `event._fields_`) rather than per event.
+
+5. **`format_fs_type` does `dict.get` with an f-string default per call.** The
+   `f"FS(0x{int(magic):x})"` default is built eagerly even on the common cache
+   hit. A two-step lookup (check membership, format only on miss) avoids the
+   per-event f-string allocation.
+
+None of these change *what* is traced — only how fast each event is turned into
+a CSV row. Item 1 is the cleanest first step: large, isolated, and behavior
+preserving.

--- a/scripts/profile_tracer.py
+++ b/scripts/profile_tracer.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""
+Userspace hot-path profiler for the IO Tracer.
+
+The live tracer needs root + BCC/eBPF + a real kernel, so it cannot be profiled
+on an ordinary dev box or in CI. But the part of the tracer that the project
+actually controls — and that decides how many events per second a single poll
+thread can drain before the kernel perf buffers overflow and drop events — is
+the *userspace per-event processing*: the perf-buffer callbacks
+(``_print_event`` and friends), the flag/CSV formatting they call, and the
+``WriteManager`` buffering/rotation/compression behind them.
+
+This harness drives that exact code with synthetic events and measures it under
+``cProfile``. It feeds events straight into the real callback methods, so every
+function the live tracer runs per event (minus the ctypes perf-struct decode,
+which BCC owns) is exercised and attributed.
+
+What it does NOT measure: the kernel BPF programs, the perf-buffer ctypes
+decode (``self.b["events"].event(data)``), and real disk/network I/O latency to
+the upload backend. Those are noted in the report but are outside userspace.
+
+Usage:
+    python3 scripts/profile_tracer.py                 # default 500k events
+    python3 scripts/profile_tracer.py -n 1000000      # event count
+    python3 scripts/profile_tracer.py --no-compress   # skip writer flush/compress
+    python3 scripts/profile_tracer.py --sort tottime --top 30
+    python3 scripts/profile_tracer.py --stream cache   # profile the cache callback
+
+It runs entirely in-process with no root, BCC, or network access.
+"""
+
+import argparse
+import cProfile
+import io
+import os
+import pstats
+import sys
+import tempfile
+import time
+
+# Make ``src`` importable when run from the repo root or scripts/.
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+def _install_fake_bcc():
+    """Stub out ``bcc`` so IOTracer imports without a kernel.
+
+    IOTracer does ``from bcc import BPF`` at module import time. We never call
+    BPF in the harness (we construct IOTracer via ``__new__`` and feed events
+    directly), so a placeholder class is enough to satisfy the import.
+    """
+    if "bcc" in sys.modules:
+        return
+    import types
+
+    mod = types.ModuleType("bcc")
+
+    class BPF:  # noqa: N801 - mirror the real name
+        def __init__(self, *a, **k):
+            raise RuntimeError("fake bcc.BPF must not be instantiated in the profiler")
+
+    mod.BPF = BPF
+    sys.modules["bcc"] = mod
+
+
+_install_fake_bcc()
+
+from src.tracer.FlagMapper import FlagMapper          # noqa: E402
+from src.tracer.IOTracer import IOTracer              # noqa: E402
+from src.tracer.PathResolver import PathResolver      # noqa: E402
+from src.tracer.WriterManager import WriteManager     # noqa: E402
+
+
+class FakeEvent:
+    """A stand-in for a decoded BPF perf event.
+
+    Holds every attribute the callbacks read. ``filename``/``comm`` are bytes
+    to match the real ctypes ``char[]`` fields the callbacks ``.decode()``.
+    """
+
+    __slots__ = (
+        "pid", "tid", "ppid", "op", "filename", "comm", "inode", "size",
+        "offset", "flags", "address", "fd", "dirfd", "mmap_prot", "mmap_flags",
+        "ret_val", "latency_ns", "dev", "cgroup_id", "fs_magic", "ts",
+        "old_addr", "old_size",
+        # dual-path (rename/link/symlink)
+        "filename_old", "filename_new", "inode_old", "inode_new",
+        # cache
+        "type", "index", "cpu_id", "dev_id", "count",
+        # block
+        "sector", "bio_size", "queue_time_ns", "cmd_flags", "op_code", "req_id",
+    )
+
+    def __init__(self, **kw):
+        for s in self.__slots__:
+            setattr(self, s, 0)
+        self.filename = b""
+        self.comm = b""
+        self.filename_old = b""
+        self.filename_new = b""
+        for k, v in kw.items():
+            setattr(self, k, v)
+
+
+class _Decoder:
+    """Mimics ``self.b["events"]``: ``.event(data)`` returns the data as-is."""
+
+    @staticmethod
+    def event(data):
+        return data
+
+
+class _FakeBPF(dict):
+    """``self.b`` lookup table; every stream decodes to the passed FakeEvent."""
+
+    def __init__(self):
+        super().__init__()
+        dec = _Decoder()
+        for name in ("events", "events_dual", "cache_events", "bl_events",
+                     "io_uring_events", "net_conn_events", "net_sockopt_events",
+                     "net_drop_events"):
+            self[name] = dec
+
+
+# Op codes -> names come from FlagMapper.op_fs_types; build the reverse map so
+# the synthetic mix uses real codes the callbacks will decode.
+def _op_code(flag_mapper, name):
+    for code, n in flag_mapper.op_fs_types.items():
+        if n == name:
+            return code
+    raise KeyError(name)
+
+
+def build_tracer(output_dir, compress):
+    """Construct an IOTracer with only the attributes the callbacks need.
+
+    Bypasses ``__init__`` (which loads BPF and tests the upload connection) and
+    wires up the real collaborators: FlagMapper, PathResolver, and a real
+    WriteManager (automatic_upload off) writing into a temp dir.
+    """
+    t = IOTracer.__new__(IOTracer)
+    t.verbose = False
+    t.anonymous = False
+    t.trace_cache = True
+    t.trace_network = True
+    t._self_pid = -1  # never matches our synthetic pids
+    t._mono_to_real_offset_ns = time.time_ns() - time.monotonic_ns()
+    t.flag_mapper = FlagMapper()
+    t.path_resolver = PathResolver()
+    t.mmap_regions = {}
+    t.cmdline_cache = {}
+    t._event_count = 0
+    t._maintenance_interval = 50000
+    t._cmdline_cache_max = 100000
+    t._lost_counts = {}
+
+    # A real WriteManager so buffering, rotation and (optionally) compression
+    # are measured. No upload manager needed when automatic_upload is False.
+    t.writer = WriteManager(output_dir, upload_manager=None, automatic_upload=False)
+    if not compress:
+        # Neutralise compression/rotation so we isolate per-event processing +
+        # buffer appends from the periodic flush+compress cost.
+        t.writer.compress_log = lambda *a, **k: None
+        t.writer.vfs_max_events = 10 ** 12
+        t.writer.block_max_events = 10 ** 12
+        t.writer.cache_max_events = 10 ** 12
+    t.b = _FakeBPF()
+    return t
+
+
+def make_fs_events(flag_mapper, n, self_pid):
+    """A realistic VFS event mix: open/close plus read/write-heavy traffic.
+
+    Uses a small working set of pids/inodes/files so the cmdline and
+    inode->path caches warm up the way they do on a real host (most events come
+    from a handful of busy processes touching a handful of hot files).
+    """
+    READ = _op_code(flag_mapper, "READ")
+    WRITE = _op_code(flag_mapper, "WRITE")
+    OPEN = _op_code(flag_mapper, "OPEN")
+    CLOSE = _op_code(flag_mapper, "CLOSE")
+    # Weighted op stream: reads and writes dominate real I/O traces.
+    pattern = ([OPEN] + [READ] * 12 + [WRITE] * 5 + [CLOSE])
+    pids = [1001, 1002, 1003, 2007, 4242]
+    files = [
+        b"/var/lib/app/data.db",
+        b"/home/user/project/main.log",
+        b"/usr/lib/x86_64-linux-gnu/libc.so.6",
+        b"/tmp/scratch/cache.idx",
+    ]
+    base_ts = time.monotonic_ns()
+    events = []
+    for i in range(n):
+        op = pattern[i % len(pattern)]
+        pid = pids[i % len(pids)]
+        fname = files[i % len(files)] if op in (OPEN, CLOSE) else b""
+        inode = 100000 + (i % 4)
+        ev = FakeEvent(
+            pid=pid, tid=pid + 7, ppid=1, op=op,
+            filename=(fname if op == OPEN else b""),
+            comm=b"app-worker",
+            inode=inode,
+            size=4096 if op in (READ, WRITE) else 0,
+            offset=(i * 4096) & 0xFFFFFFF,
+            flags=0o2 if op == OPEN else 0,
+            fd=7 if op == OPEN else 0,
+            ret_val=4096 if op in (READ, WRITE) else 0,
+            latency_ns=15000 if op in (READ, WRITE) else 0,
+            dev=(8 << 20) | 1,
+            cgroup_id=0xABCD,
+            fs_magic=0xEF53,
+            ts=base_ts + i * 1000,
+        )
+        # Pre-seed the inode->path cache for read/write so the OPEN path that
+        # populated it on the real host is reflected here too.
+        events.append(ev)
+    # Warm the inode cache the way OPEN events would, so READ/WRITE rows resolve.
+    return events
+
+
+def make_cache_events(n, self_pid):
+    base_ts = time.monotonic_ns()
+    out = []
+    for i in range(n):
+        out.append(FakeEvent(
+            pid=1001 + (i % 5), comm=b"app-worker", type=i % 10,
+            inode=100000 + (i % 8), index=i & 0xFFFF, size=4096,
+            cpu_id=i % 8, dev_id=(8 << 20) | 1, count=1,
+            ts=base_ts + i * 500,
+        ))
+    return out
+
+
+def make_block_events(n, self_pid):
+    base_ts = time.monotonic_ns()
+    out = []
+    for i in range(n):
+        out.append(FakeEvent(
+            pid=1001 + (i % 5), tid=2001 + (i % 5), ppid=1,
+            comm=b"app-worker", op=b"R" if i % 2 else b"W",
+            inode=0, size=0, latency_ns=120000, cpu_id=i % 8,
+            dev=(8 << 20) | 1, ts=base_ts + i * 800,
+        ))
+        # block callback reads .sector/.bio_size/.queue_time_ns/.cmd_flags/
+        # .op_code/.req_id via attributes; add them.
+        out[-1].sector = i * 8  # type: ignore[attr-defined]
+        out[-1].bio_size = 4096  # type: ignore[attr-defined]
+        out[-1].queue_time_ns = 3000  # type: ignore[attr-defined]
+        out[-1].cmd_flags = 0  # type: ignore[attr-defined]
+        out[-1].op_code = 0  # type: ignore[attr-defined]
+        out[-1].req_id = i  # type: ignore[attr-defined]
+    return out
+
+
+def run_stream(tracer, stream, events):
+    if stream == "fs":
+        cb = tracer._print_event
+    elif stream == "cache":
+        cb = tracer._print_event_cache
+    elif stream == "block":
+        cb = tracer._print_event_block
+    else:
+        raise ValueError(stream)
+    for ev in events:
+        cb(0, ev, 0)
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Profile the IO Tracer userspace hot path")
+    ap.add_argument("-n", "--num-events", type=int, default=500_000,
+                    help="number of synthetic events to push (default: 500000)")
+    ap.add_argument("--stream", choices=["fs", "cache", "block"], default="fs",
+                    help="which callback to profile (default: fs)")
+    ap.add_argument("--no-compress", action="store_true",
+                    help="disable writer flush/rotate/compress (isolate per-event cost)")
+    ap.add_argument("--sort", default="cumulative",
+                    choices=["cumulative", "tottime", "ncalls"],
+                    help="pstats sort key (default: cumulative)")
+    ap.add_argument("--top", type=int, default=25, help="rows of pstats to show")
+    ap.add_argument("--dump", default=None, help="write raw .pstats to this path")
+    ap.add_argument("--bench", action="store_true",
+                    help="measure throughput WITHOUT cProfile overhead (accurate "
+                         "events/s) and skip the per-function table")
+    args = ap.parse_args()
+
+    output_dir = tempfile.mkdtemp(prefix="iotrc_prof_")
+    compress = not args.no_compress
+    tracer = build_tracer(output_dir, compress)
+
+    fm = tracer.flag_mapper
+    if args.stream == "fs":
+        events = make_fs_events(fm, args.num_events, tracer._self_pid)
+        # Warm the inode cache so READ/WRITE resolve a path (mirrors OPEN).
+        for ino, path in {
+            100000: "/var/lib/app/data.db",
+            100001: "/home/user/project/main.log",
+            100002: "/usr/lib/x86_64-linux-gnu/libc.so.6",
+            100003: "/tmp/scratch/cache.idx",
+        }.items():
+            tracer.path_resolver.inode_to_path[ino] = path
+    elif args.stream == "cache":
+        events = make_cache_events(args.num_events, tracer._self_pid)
+    else:
+        events = make_block_events(args.num_events, tracer._self_pid)
+
+    print(f"Profiling stream={args.stream} events={args.num_events:,} "
+          f"compress={'on' if compress else 'off'} output={output_dir}")
+
+    pr = None
+    if args.bench:
+        # cProfile inflates per-call cost ~5-10x; for an accurate throughput
+        # number, time the same workload with the profiler off.
+        wall0 = time.perf_counter()
+        run_stream(tracer, args.stream, events)
+        wall1 = time.perf_counter()
+    else:
+        pr = cProfile.Profile()
+        wall0 = time.perf_counter()
+        pr.enable()
+        run_stream(tracer, args.stream, events)
+        pr.disable()
+        wall1 = time.perf_counter()
+
+    # Flush remaining buffers (counts the final flush + compress in the timing
+    # summary below, but not inside the per-event cProfile window).
+    try:
+        tracer.writer.write_to_disk()
+        tracer.writer.close_handles()
+    except Exception:
+        pass
+
+    elapsed = wall1 - wall0
+    rate = args.num_events / elapsed if elapsed else 0.0
+    print()
+    print(f"=== Summary ({args.stream}) ===")
+    print(f"events processed : {args.num_events:,}")
+    print(f"wall time        : {elapsed:.3f} s")
+    print(f"throughput       : {rate:,.0f} events/s")
+    print(f"per-event cost   : {elapsed / args.num_events * 1e6:.3f} us/event")
+    if pr is None:
+        print("(measured with cProfile OFF — throughput is representative)")
+        return
+    print("(measured with cProfile ON — throughput is depressed; use --bench "
+          "for an accurate rate)")
+    print()
+
+    s = io.StringIO()
+    ps = pstats.Stats(pr, stream=s).strip_dirs()
+    sort_key = {"cumulative": "cumulative", "tottime": "tottime", "ncalls": "ncalls"}[args.sort]
+    ps.sort_stats(sort_key).print_stats(args.top)
+    print(s.getvalue())
+
+    if args.dump:
+        pstats.Stats(pr).dump_stats(args.dump)
+        print(f"raw stats written to {args.dump}")
+
+    # Clean up the temp trace tree.
+    try:
+        import shutil
+        shutil.rmtree(output_dir, ignore_errors=True)
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/profile_tracer.py
+++ b/scripts/profile_tracer.py
@@ -34,6 +34,7 @@ import cProfile
 import io
 import os
 import pstats
+import shutil
 import sys
 import tempfile
 import time
@@ -237,20 +238,17 @@ def make_block_events(n, self_pid):
     base_ts = time.monotonic_ns()
     out = []
     for i in range(n):
+        # The block callback also reads sector/bio_size/queue_time_ns/cmd_flags/
+        # op_code/req_id; pass them straight to the constructor (all are in
+        # FakeEvent.__slots__).
         out.append(FakeEvent(
             pid=1001 + (i % 5), tid=2001 + (i % 5), ppid=1,
             comm=b"app-worker", op=b"R" if i % 2 else b"W",
             inode=0, size=0, latency_ns=120000, cpu_id=i % 8,
             dev=(8 << 20) | 1, ts=base_ts + i * 800,
+            sector=i * 8, bio_size=4096, queue_time_ns=3000,
+            cmd_flags=0, op_code=0, req_id=i,
         ))
-        # block callback reads .sector/.bio_size/.queue_time_ns/.cmd_flags/
-        # .op_code/.req_id via attributes; add them.
-        out[-1].sector = i * 8  # type: ignore[attr-defined]
-        out[-1].bio_size = 4096  # type: ignore[attr-defined]
-        out[-1].queue_time_ns = 3000  # type: ignore[attr-defined]
-        out[-1].cmd_flags = 0  # type: ignore[attr-defined]
-        out[-1].op_code = 0  # type: ignore[attr-defined]
-        out[-1].req_id = i  # type: ignore[attr-defined]
     return out
 
 
@@ -308,60 +306,58 @@ def main():
     print(f"Profiling stream={args.stream} events={args.num_events:,} "
           f"compress={'on' if compress else 'off'} output={output_dir}")
 
-    pr = None
-    if args.bench:
-        # cProfile inflates per-call cost ~5-10x; for an accurate throughput
-        # number, time the same workload with the profiler off.
-        wall0 = time.perf_counter()
-        run_stream(tracer, args.stream, events)
-        wall1 = time.perf_counter()
-    else:
-        pr = cProfile.Profile()
-        wall0 = time.perf_counter()
-        pr.enable()
-        run_stream(tracer, args.stream, events)
-        pr.disable()
-        wall1 = time.perf_counter()
-
-    # Flush remaining buffers (counts the final flush + compress in the timing
-    # summary below, but not inside the per-event cProfile window).
+    # Everything below runs inside try/finally so the temp trace tree is always
+    # removed — including the early return in --bench mode and any exception.
     try:
-        tracer.writer.write_to_disk()
-        tracer.writer.close_handles()
-    except Exception:
-        pass
+        pr = None
+        if args.bench:
+            # cProfile inflates per-call cost ~5-10x; for an accurate throughput
+            # number, time the same workload with the profiler off.
+            wall0 = time.perf_counter()
+            run_stream(tracer, args.stream, events)
+            wall1 = time.perf_counter()
+        else:
+            pr = cProfile.Profile()
+            wall0 = time.perf_counter()
+            pr.enable()
+            run_stream(tracer, args.stream, events)
+            pr.disable()
+            wall1 = time.perf_counter()
 
-    elapsed = wall1 - wall0
-    rate = args.num_events / elapsed if elapsed else 0.0
-    print()
-    print(f"=== Summary ({args.stream}) ===")
-    print(f"events processed : {args.num_events:,}")
-    print(f"wall time        : {elapsed:.3f} s")
-    print(f"throughput       : {rate:,.0f} events/s")
-    print(f"per-event cost   : {elapsed / args.num_events * 1e6:.3f} us/event")
-    if pr is None:
-        print("(measured with cProfile OFF — throughput is representative)")
-        return
-    print("(measured with cProfile ON — throughput is depressed; use --bench "
-          "for an accurate rate)")
-    print()
+        # Flush remaining buffers (counts the final flush + compress in the
+        # timing summary below, but not inside the per-event cProfile window).
+        try:
+            tracer.writer.write_to_disk()
+            tracer.writer.close_handles()
+        except Exception:
+            pass
 
-    s = io.StringIO()
-    ps = pstats.Stats(pr, stream=s).strip_dirs()
-    sort_key = {"cumulative": "cumulative", "tottime": "tottime", "ncalls": "ncalls"}[args.sort]
-    ps.sort_stats(sort_key).print_stats(args.top)
-    print(s.getvalue())
+        elapsed = wall1 - wall0
+        rate = args.num_events / elapsed if elapsed else 0.0
+        print()
+        print(f"=== Summary ({args.stream}) ===")
+        print(f"events processed : {args.num_events:,}")
+        print(f"wall time        : {elapsed:.3f} s")
+        print(f"throughput       : {rate:,.0f} events/s")
+        print(f"per-event cost   : {elapsed / args.num_events * 1e6:.3f} us/event")
+        if pr is None:
+            print("(measured with cProfile OFF — throughput is representative)")
+            return
+        print("(measured with cProfile ON — throughput is depressed; use --bench "
+              "for an accurate rate)")
+        print()
 
-    if args.dump:
-        pstats.Stats(pr).dump_stats(args.dump)
-        print(f"raw stats written to {args.dump}")
+        s = io.StringIO()
+        ps = pstats.Stats(pr, stream=s).strip_dirs()
+        sort_key = {"cumulative": "cumulative", "tottime": "tottime", "ncalls": "ncalls"}[args.sort]
+        ps.sort_stats(sort_key).print_stats(args.top)
+        print(s.getvalue())
 
-    # Clean up the temp trace tree.
-    try:
-        import shutil
+        if args.dump:
+            pstats.Stats(pr).dump_stats(args.dump)
+            print(f"raw stats written to {args.dump}")
+    finally:
         shutil.rmtree(output_dir, ignore_errors=True)
-    except Exception:
-        pass
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What & why

The live tracer needs root + BCC/eBPF + a real kernel, so it can't be profiled on a dev box or in CI. But the throughput ceiling that actually causes **dropped events** is set in **userspace**: a single poll thread (`PollingThread`) drains the per-CPU kernel perf buffers and runs a Python callback (`IOTracer._print_event` and friends) for every event. If that callback can't keep up, the kernel buffers overflow and events are lost (the `lost_events` counter in `manifest.json`). So the thing worth profiling is the per-event Python path.

This PR adds a way to profile exactly that, plus a baseline report.

## Changes

- **`scripts/profile_tracer.py`** — drives the real per-event callbacks (`_print_event`, `_print_event_cache`, `_print_event_block`) and the real `WriteManager` with synthetic events under `cProfile`. It stubs out `bcc`, constructs an `IOTracer` via `__new__` with only the attributes the callbacks need, and wires up the real `FlagMapper` / `PathResolver` / `WriteManager` (upload off, temp output). Runs entirely in-process — no root, BCC, or network.
  - `--bench` reports accurate throughput (cProfile off); default mode prints a per-function breakdown.
  - `--stream {fs,cache,block}`, `-n`, `--no-compress`, `--sort`, `--top`, `--dump`.
- **`docs/PROFILING.md`** — methodology, baseline results, and findings.

## Baseline findings

| Stream | Throughput | Per-event |
|--------|-----------|-----------|
| fs     | ~67k ev/s | ~14.9 µs  |
| cache  | ~145k ev/s| ~6.9 µs   |
| block  | ~129k ev/s| ~7.8 µs   |

The fs/VFS stream is ~2× the per-event cost of cache/block (widest CSV row, most flag decoding) and is also the highest-volume stream, so it dominates. Top fs hotspots by `tottime`: `format_csv_row` (~27%), the `_print_event` body (~25%), and `format_fs_flags` (~16%).

`format_fs_flags` loops the full 19-entry flag table even for the overwhelmingly common `flags == 0` case; a short-circuit (`if flags == 0: return "O_RDONLY"`) is **~25× faster** on that path (microbenchmarked 2460 ns → 96 ns). This and other opportunities are documented in `docs/PROFILING.md` as follow-ups.

## Scope / safety

- **No tracer behavior is changed** — this is profiling tooling + docs only. Optimizations are recorded as follow-ups (several touch the trace output format and deserve their own review).
- Existing test suite: **112 passed**.

## How to run

```bash
python3 scripts/profile_tracer.py --stream fs -n 300000 --bench
python3 scripts/profile_tracer.py --stream fs -n 200000 --sort tottime --top 25
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YCiKXPmPnGcnvSF3NqDeHG)_