### PR TITLE
feat: integrate new Cloudflare Worker API with per-upload telemetry

### DIFF
--- a/src/tracer/IOTracer.py
+++ b/src/tracer/IOTracer.py
@@ -54,6 +54,9 @@ _NON_IO_SIZE_OPS = frozenset({
 })
 
 
+_ACTIVITY_THRESHOLD = 100  # block I/O events/sec to qualify as "active"
+
+
 class IOTracer:
     """
     Main class for tracing Linux I/O operations.
@@ -166,6 +169,8 @@ class IOTracer:
 
 
         self.writer             = WriteManager(output_dir, self.upload_manager, automatic_upload)
+        if self.automatic_upload:
+            self.upload_manager.on_upload_success = self._post_telemetry_delta
         self.fs_snapper         = FilesystemSnapper(self.writer, anonymous)
         self.process_snapper    = ProcessSnapper(self.writer, anonymous)
         self.system_snapper     = SystemSnapper(self.writer)
@@ -219,6 +224,14 @@ class IOTracer:
         self._event_count           = 0
         self._maintenance_interval  = 50000  # events between cache sweeps
         self._cmdline_cache_max     = 100000  # hard cap on cmdline cache entries
+        self._disk_event_counter: int = 0
+        self._counter_lock          = threading.Lock()
+        self.active_duration_s: int = 0
+        self._activity_stop         = threading.Event()
+        self._activity_t: threading.Thread | None = None
+        self._last_posted_active_s: int = 0
+        self._last_posted_rows: dict[str, int] = {}
+        self._telemetry_lock        = threading.Lock()
 
         if cache_sample_rate > 1:
             self.writer.set_cache_sampling(cache_sample_rate)
@@ -271,6 +284,37 @@ class IOTracer:
             logger("error", f"failed to initialize BPF: {e}")
             print("Your device are incompatible with this version of IO Tracer. Please notify us at io-tracer@googlegroups.com")
             sys.exit(1)
+
+    def _increment_disk_counter(self) -> None:
+        with self._counter_lock:
+            self._disk_event_counter += 1
+
+    def _activity_detector(self) -> None:
+        while not self._activity_stop.wait(timeout=1.0):
+            with self._counter_lock:
+                count = self._disk_event_counter
+                self._disk_event_counter = 0
+            if count > _ACTIVITY_THRESHOLD:
+                self.active_duration_s += 1
+
+    def _post_telemetry_delta(self) -> None:
+        with self._telemetry_lock:
+            duration_delta = self.active_duration_s - self._last_posted_active_s
+            self._last_posted_active_s = self.active_duration_s
+
+            current_rows = dict(self.writer.rows_written)
+            events_delta = {
+                k.lower().replace(" ", "_"): current_rows.get(k, 0) - self._last_posted_rows.get(k, 0)
+                for k in current_rows
+                if current_rows.get(k, 0) > self._last_posted_rows.get(k, 0)
+            }
+            self._last_posted_rows = current_rows
+
+        self.upload_manager.post_telemetry(
+            duration_s=duration_delta,
+            events=events_delta,
+            operating_system="Linux",
+        )
 
     def _should_filter_process(self, comm: str) -> bool:
         """Helper to filter out I/O unrelated system processes."""
@@ -985,6 +1029,7 @@ class IOTracer:
         pid = event.pid
         if pid == self._self_pid:
             return
+        self._increment_disk_counter()
         timestamp = self._event_walltime(event)
         tid = event.tid
         comm = event.comm.decode('utf-8', errors='replace')
@@ -1179,6 +1224,7 @@ class IOTracer:
                 return
             self._cleanup_done = True
             self.running = False
+            self._activity_stop.set()
 
             # Stop and JOIN the poll thread before touching handles. Previously
             # cleanup detached probes and closed the writer handles while the
@@ -1369,6 +1415,10 @@ class IOTracer:
         if self.automatic_upload:
             self.upload_manager.start_worker()
 
+        self._activity_stop.clear()
+        self._activity_t = threading.Thread(target=self._activity_detector, daemon=True)
+        self._activity_t.start()
+
         signal.signal(signal.SIGINT, self._cleanup)
         signal.signal(signal.SIGTERM, self._cleanup)
 
@@ -1528,6 +1578,15 @@ class IOTracer:
 
             print()
             logger("info", "Trace stopped")
+
+            if self._activity_t is not None:
+                self._activity_t.join(timeout=2.0)
+
+            if self.automatic_upload:
+                try:
+                    self._post_telemetry_delta()
+                except Exception as e:
+                    logger("warn", f"Telemetry post failed (non-fatal): {e}")
 
             run_with_spinner("Compressing trace output", self.writer.force_flush)
 

--- a/src/tracer/ObjectStorageManager.py
+++ b/src/tracer/ObjectStorageManager.py
@@ -20,6 +20,7 @@ import mimetypes
 import os
 import threading
 import time
+from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
 from queue import Queue, Empty
@@ -66,7 +67,7 @@ class ObjectStorageManager:
         self._t: list[threading.Thread] = []
         self.backend_url = "https://io-tracer-worker.1a1a11a.workers.dev"
         # self.app_version = get_current_tag()
-        self.machine_id = capture_machine_id()
+        self.machine_id = capture_machine_id().upper()
         self.current_datetime = datetime.now()
         self.file_queue: Queue[str] = Queue()
         self.successful_upload = 0
@@ -78,6 +79,7 @@ class ObjectStorageManager:
         # clean_queue()/stop_worker() from ever draining the queue.
         self._attempts: dict[str, int] = {}
         self.MAX_UPLOAD_ATTEMPTS = 5
+        self.on_upload_success: Callable[[], None] | None = None
 
 
     def test_connection(self) -> bool:
@@ -88,7 +90,11 @@ class ObjectStorageManager:
             bool: True if connection successful, False otherwise
         """
         def _check():
-            r = requests.get(f"{self.backend_url}/connection-test.txt", timeout=5)
+            payload = {
+                "computer_id": self.machine_id,
+                "operating_system": "Linux",
+            }
+            r = requests.post(f"{self.backend_url}/telemetry", json=payload, timeout=5)
             if not r.ok:
                 raise Exception("can't connect")
             return True
@@ -115,9 +121,10 @@ class ObjectStorageManager:
         Raises:
             RuntimeError: If the request fails
         """
-        r = requests.post(
-            f"{self.backend_url}/{self.trace_bucket}/"
-            f"{self.machine_id.upper()}/"
+        r = requests.get(
+            f"{self.backend_url}/presigned-url/"
+            f"{self.trace_bucket}/"
+            f"{self.machine_id}/"
             f"{self.current_datetime.strftime('%Y%m%d_%H%M%S_%f')[:-3]}/"
             f"{file_type}/"
             f"{filename}",
@@ -163,10 +170,42 @@ class ObjectStorageManager:
         if r.ok:
             os.remove(file_path)
             self.successful_upload += 1
-            unlock_reward()  
+            unlock_reward()
             logger("info", f"Files Uploaded: {self.successful_upload}", True)
+            if self.on_upload_success is not None:
+                try:
+                    self.on_upload_success()
+                except Exception:
+                    pass  # telemetry failure must never break the upload path
         else:
             raise RuntimeError(f"Upload failed: {r.status_code} {r.text}")
+
+    def post_telemetry(
+        self,
+        duration_s: int,
+        events: dict[str, int],
+        operating_system: str | None = None,
+    ):
+        """
+        Post session telemetry to the backend.
+
+        Args:
+            duration_s: Active trace duration in seconds (delta, not cumulative)
+            events: Per-stream row counts, e.g. {"fs": 1500, "block": 200}
+            operating_system: Platform string (e.g. platform.platform())
+
+        Raises:
+            RuntimeError: If the request fails
+        """
+        payload: dict = {"computer_id": self.machine_id}
+        if operating_system:
+            payload["operating_system"] = operating_system
+        payload["duration_s"] = duration_s
+        payload["events"] = events
+        r = requests.post(f"{self.backend_url}/telemetry", json=payload, timeout=10)
+        if not r.ok:
+            raise RuntimeError(f"Telemetry post failed: {r.status_code} {r.text}")
+        logger("info", f"Telemetry sent: {payload}")
 
     def append_object(self, file_path: str):
         """


### PR DESCRIPTION
## Summary

- **New Worker API**: migrates `ObjectStorageManager` to the updated Cloudflare Worker schema — `GET /presigned-url/[filepath]` for presigned URLs and `POST /telemetry` for both connection testing and telemetry reporting; drops the dead `GET /connection-test.txt` endpoint
- **Active duration tracking**: adds a 1-second background loop that increments `active_duration_s` only when block I/O exceeds 100 events/sec (matching the reference C# implementation), so idle time is excluded from the reported duration
- **Per-upload telemetry**: after every successful file upload, `_post_telemetry_delta()` sends a delta of `active_duration_s` and `rows_written` to `/telemetry`; a final flush at shutdown catches any remaining delta; event type keys are normalized to `lowercase_with_underscores`

## Test plan

- [ ] Run a short trace with `--automatic-upload` and confirm every "Telemetry sent:" log line appears after each file upload
- [ ] Verify `events` keys in the payload are lowercase with underscores (e.g. `filesystem_snapshot`, `process_state`)
- [ ] Verify `duration_s` appears in every payload (0 when no active block I/O seconds)
- [ ] Run `python3 -m unittest discover -s tests` — all existing tests pass (they use `FakeUploadManager` and don't hit the network)
- [ ] Confirm D1 database accumulates correct cumulative counts across multiple uploads without double-counting

🤖 Generated with [Claude Code](https://claude.com/claude-code)