### PR TITLE
Dump OS information when the BPF prober can't compile or run

### DIFF
--- a/docs/COMPATIBILITY_FIXES.md
+++ b/docs/COMPATIBILITY_FIXES.md
@@ -39,3 +39,45 @@ When combined, the initial burst quickly saturates the 1024 limit.
 ### The Solution
 * **RLIMIT_NOFILE Bump**: We added a booster function `maximize_fd_limit()` at the start of `iotrc.py`. By importing `resource`, the script now dynamically bypasses the default 1024 soft limit and escalates the `RLIMIT_NOFILE` to up to `1,048,576` at runtime before starting any tracing allocations.
 * **psutil Context Guarding**: We improved file descriptor cleanup inside `ProcessSampler.py`. The `psutil.process_iter` iterations are now safely enclosed in protective `try/except` blocks to handle processes that disappear mid-iteration, safely closing their descriptors instead of leaking them into memory.
+
+## 4. OS Information Dump on Compile / Run Failure
+
+### The Problem
+When the BPF prober could not compile (e.g. a kernel-version mismatch the
+`#if` guards didn't cover) or failed to load/attach on an unexpected kernel,
+the tracer exited with a generic *"Your device is incompatible … please notify
+us"* message. The user had nothing concrete to send, and the maintainers had
+nothing to act on — diagnosing the incompatibility meant a slow back-and-forth
+asking for the kernel version, BTF availability, toolchain versions, and so on.
+
+### The Solution
+On any compile/load failure (`IOTracer.__init__`) or probe-attach failure
+(`IOTracer.trace()`), the tracer now calls
+`SystemSnapper.dump_failure_diagnostics()`, which collects **as much of the OS /
+kernel / toolchain environment as possible** and writes it to a local file
+named `io-tracer-os-info_<timestamp>.json` (in the current directory, falling
+back to the system temp dir). A short summary is also printed to the console.
+
+Collection is *best effort* — every probe is individually guarded, so a missing
+`/proc` entry or absent tool is recorded as an error rather than aborting the
+dump. The captured data includes:
+
+* **The triggering error** and its full traceback, plus the exact `cflags` and
+  BPF source path that were attempted.
+* **Kernel**: `uname` fields, `/proc/version`, `/proc/cmdline` (surfaces
+  BPF-blocking boot params such as `lockdown=`; secret-looking `key=value`
+  tokens are redacted), and the libc version.
+* **BTF**: whether `/sys/kernel/btf/vmlinux` is present (required by BCC/CO-RE).
+* **Kernel config**: a curated set of BPF-relevant `CONFIG_*` values read from
+  `/proc/config.gz` or `/boot/config-<release>` (`CONFIG_BPF_SYSCALL`,
+  `CONFIG_DEBUG_INFO_BTF`, `CONFIG_KPROBES`, …).
+* **Toolchain**: Python, `bcc`, `clang`/`llc`, `gcc`, and `ld` versions (`clang`
+  is what BCC shells out to when compiling the prober).
+* **Kernel headers**: presence of `/lib/modules/<release>/build` and
+  `/usr/src/linux-headers-<release>` (BCC's fallback when BTF is absent).
+* **tracefs**: whether debugfs/tracefs is mounted and whether the
+  `block_rq_complete` tracepoint exposes `cmd_flags` (the field `-DHAS_CMD_FLAGS`
+  keys off).
+* **System specs**: OS/distribution, CPU, and memory. The IP-geolocation
+  country lookup is intentionally skipped on this path so a slow/unreachable
+  network can't delay or block the dump.

--- a/src/tracer/IOTracer.py
+++ b/src/tracer/IOTracer.py
@@ -289,7 +289,7 @@ class IOTracer:
             run_with_spinner("Loading BPF program", _init_bpf)
         except Exception as e:
             logger("error", f"failed to initialize BPF: {e}")
-            print("Your device are incompatible with this version of IO Tracer.")
+            print("Your device is incompatible with this version of IO Tracer.")
             # Dump as much OS/kernel/toolchain information as possible so the
             # incompatibility can actually be diagnosed (rather than emailing us
             # a bare "it doesn't work"). Never let the dump mask the real error.
@@ -1446,7 +1446,7 @@ class IOTracer:
             # kernel). That is still a "failed to run" — dump the environment so
             # the attach failure can be diagnosed, then exit.
             logger("error", f"failed to attach kernel probes: {e}")
-            print("Your device are incompatible with this version of IO Tracer.")
+            print("Your device is incompatible with this version of IO Tracer.")
             self._dump_failure_diagnostics(e, "Kernel probe attachment failed")
             sys.exit(1)
         if self.automatic_upload:

--- a/src/tracer/IOTracer.py
+++ b/src/tracer/IOTracer.py
@@ -263,6 +263,10 @@ class IOTracer:
         self.b: BPF
         self.probe_tracker: KernelProbeTracker
 
+        # Remember the BPF source path and the cflags actually used, so a
+        # compile/load failure can report exactly what was attempted.
+        self.bpf_file = bpf_file
+        self._attempted_cflags: list[str] = []
         try:
             def _init_bpf():
                 cflags = ["-Wno-duplicate-decl-specifier", "-Wno-macro-redefined", "-mllvm", "-bpf-stack-size=4096"]
@@ -276,14 +280,37 @@ class IOTracer:
                 # so gating at compile time keeps overhead at zero when off.
                 if self.trace_network:
                     cflags.append("-DENABLE_NETWORK")
+                # Record the cflags before compiling so the diagnostics dump can
+                # report them even when the BPF() call itself raises.
+                self._attempted_cflags = cflags
                 self.b = BPF(src_file=bpf_file.encode(), cflags=cflags)
                 self.probe_tracker = KernelProbeTracker(self.b, developer_mode, trace_cache=self.trace_cache)
 
             run_with_spinner("Loading BPF program", _init_bpf)
         except Exception as e:
             logger("error", f"failed to initialize BPF: {e}")
-            print("Your device are incompatible with this version of IO Tracer. Please notify us at io-tracer@googlegroups.com")
+            print("Your device are incompatible with this version of IO Tracer.")
+            # Dump as much OS/kernel/toolchain information as possible so the
+            # incompatibility can actually be diagnosed (rather than emailing us
+            # a bare "it doesn't work"). Never let the dump mask the real error.
+            self._dump_failure_diagnostics(e, "BPF program failed to compile or load")
             sys.exit(1)
+
+    def _dump_failure_diagnostics(self, error: BaseException, context: str) -> None:
+        """Best-effort OS-information dump for a compile/run failure.
+
+        Wrapped so a failure inside the diagnostics path never replaces the
+        original error with a confusing secondary traceback.
+        """
+        try:
+            self.system_snapper.dump_failure_diagnostics(
+                error=error,
+                attempted_cflags=getattr(self, "_attempted_cflags", None),
+                bpf_file=getattr(self, "bpf_file", None),
+                context=context,
+            )
+        except Exception as diag_err:  # noqa: BLE001 - diagnostics are best effort
+            logger("warning", f"Could not collect OS diagnostics: {diag_err}")
 
     def _increment_disk_counter(self) -> None:
         with self._counter_lock:
@@ -1411,7 +1438,17 @@ class IOTracer:
         The trace runs indefinitely if no duration is specified,
         or for the specified number of seconds otherwise.
         """
-        run_with_spinner("Attaching kernel probes", self.probe_tracker.attach_probes)
+        try:
+            run_with_spinner("Attaching kernel probes", self.probe_tracker.attach_probes)
+        except Exception as e:
+            # The program compiled and loaded but a probe would not attach (e.g.
+            # a kernel symbol the verifier accepted is missing/renamed on this
+            # kernel). That is still a "failed to run" — dump the environment so
+            # the attach failure can be diagnosed, then exit.
+            logger("error", f"failed to attach kernel probes: {e}")
+            print("Your device are incompatible with this version of IO Tracer.")
+            self._dump_failure_diagnostics(e, "Kernel probe attachment failed")
+            sys.exit(1)
         if self.automatic_upload:
             self.upload_manager.start_worker()
 

--- a/src/tracer/snappers/SystemSnapper.py
+++ b/src/tracer/snappers/SystemSnapper.py
@@ -31,6 +31,39 @@ import platform
 import shutil
 import requests
 import json
+import os
+import sys
+import gzip
+import tempfile
+import traceback
+from datetime import datetime
+
+
+# Kernel config options that decide whether the BPF prober can compile, load
+# (pass the verifier), and attach its kprobes/tracepoints. When the tracer
+# cannot compile or fails to run, these are the first things a maintainer needs
+# to see — e.g. a kernel built without CONFIG_DEBUG_INFO_BTF can't supply the
+# BTF that BCC/CO-RE relies on, and CONFIG_BPF_SYSCALL=n disables BPF outright.
+_BPF_KERNEL_CONFIG_KEYS = (
+    "CONFIG_BPF",
+    "CONFIG_BPF_SYSCALL",
+    "CONFIG_BPF_JIT",
+    "CONFIG_HAVE_EBPF_JIT",
+    "CONFIG_BPF_EVENTS",
+    "CONFIG_DEBUG_INFO",
+    "CONFIG_DEBUG_INFO_BTF",
+    "CONFIG_DEBUG_INFO_BTF_MODULES",
+    "CONFIG_KPROBES",
+    "CONFIG_KPROBE_EVENTS",
+    "CONFIG_UPROBES",
+    "CONFIG_FTRACE",
+    "CONFIG_FUNCTION_TRACER",
+    "CONFIG_TRACEPOINTS",
+    "CONFIG_PERF_EVENTS",
+    "CONFIG_HAVE_KPROBES",
+    "CONFIG_NET_CLS_BPF",
+    "CONFIG_CGROUP_BPF",
+)
 
 
 # ARM "CPU implementer" hex codes (from /proc/cpuinfo) → vendor name. Used only
@@ -325,14 +358,32 @@ class SystemSnapper:
         self.wm.direct_write("network_info.json", json.dumps(network_info, indent=2))
 
         # OS Info
+        os_info = self.get_os_info(include_country=True)
+        self.wm.direct_write("os_info.json", json.dumps(os_info, indent=2))
+
+    def get_os_info(self, include_country: bool = True) -> dict:
+        """
+        Collect operating system information.
+
+        Args:
+            include_country: When True, perform an IP-geolocation lookup for the
+                country code. Set False to skip the network call — e.g. when
+                dumping diagnostics on a build/run failure, where a slow or
+                unreachable network must not delay or block the dump.
+
+        Returns:
+            dict: OS name/release/version/machine/hostname, plus a Linux
+                distribution sub-dict (best effort) and, optionally, country.
+        """
         os_info = {
             "system": platform.system(),
             "release": platform.release(),
             "version": platform.version(),
             "machine": platform.machine(),
             "hostname": platform.node(),
-            "country": self.get_country_code()
         }
+        if include_country:
+            os_info["country"] = self.get_country_code()
         # Add distribution info for Linux
         if platform.system() == "Linux":
             try:
@@ -358,4 +409,404 @@ class SystemSnapper:
                         }
                 except Exception:
                     pass
-        self.wm.direct_write("os_info.json", json.dumps(os_info, indent=2))
+        return os_info
+
+    # ------------------------------------------------------------------ #
+    # Failure diagnostics
+    #
+    # When the BPF prober cannot compile or the tracer fails to run, the
+    # tooling previously exited with a generic "your device is incompatible"
+    # message and nothing for a maintainer to act on. The methods below collect
+    # as much of the OS / kernel / toolchain environment as possible — every
+    # probe is individually guarded so one failure never aborts the rest — and
+    # write it to a local file the user can attach when reporting the problem.
+    # ------------------------------------------------------------------ #
+
+    @staticmethod
+    def _safe(fn, default=None):
+        """Run a collector, returning its value or a ``{"_error": ...}`` marker.
+
+        Keeps the diagnostics dump "best effort": a single probe that raises
+        (missing /proc entry, permission error, absent tool) is recorded as an
+        error instead of aborting the whole collection.
+        """
+        try:
+            return fn()
+        except Exception as e:  # noqa: BLE001 - diagnostics must never raise
+            return {"_error": f"{type(e).__name__}: {e}"} if default is None else default
+
+    @staticmethod
+    def _read_text_file(path: str, max_bytes: int = 64 * 1024) -> str | None:
+        """Read a (small) text file, returning ``None`` if it can't be read."""
+        try:
+            with open(path, "r", errors="replace") as f:
+                return f.read(max_bytes).strip()
+        except OSError:
+            return None
+
+    @staticmethod
+    def _tool_version(cmd: list[str]) -> str | None:
+        """Return the first line of ``cmd``'s output, or ``None`` if it fails.
+
+        Used to capture compiler/linker versions (clang is what BCC shells out
+        to when compiling the prober). Bounded by a short timeout so a missing
+        or hung tool can't stall the diagnostics dump — this runs right before
+        the process exits, and there are several of these calls in series, so
+        the timeout is deliberately small to cap the worst-case exit latency.
+        """
+        try:
+            out = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=2
+            )
+        except (OSError, subprocess.SubprocessError):
+            return None
+        text = (out.stdout or out.stderr or "").strip()
+        return text.splitlines()[0] if text else None
+
+    # Substrings that mark a kernel-cmdline ``key=value`` token as carrying a
+    # secret whose value should be redacted before it lands in the dump. The
+    # cmdline itself is kept because it can reveal BPF-blocking settings
+    # (lockdown=, lsm=, …) that are genuinely useful for diagnosis.
+    _CMDLINE_SECRET_KEY_HINTS = ("secret", "token", "password", "passwd", "cred")
+
+    @classmethod
+    def _sanitize_cmdline(cls, cmdline: str | None) -> str | None:
+        """Redact secret-looking ``key=value`` tokens from a kernel cmdline.
+
+        Keeps every diagnostically useful parameter (lockdown, lsm, console, …)
+        but replaces the *value* of any token whose key looks like a secret
+        (e.g. a provisioning token occasionally passed at boot) with
+        ``<redacted>``, so the dump the user is asked to share doesn't leak it.
+        """
+        if not cmdline:
+            return cmdline
+        out = []
+        for token in cmdline.split():
+            key, sep, _ = token.partition("=")
+            if sep and any(h in key.lower() for h in cls._CMDLINE_SECRET_KEY_HINTS):
+                out.append(f"{key}=<redacted>")
+            else:
+                out.append(token)
+        return " ".join(out)
+
+    def get_kernel_info(self) -> dict:
+        """uname fields plus the raw kernel version/cmdline strings."""
+        uname = os.uname()
+        return {
+            "sysname": uname.sysname,
+            "nodename": uname.nodename,
+            "release": uname.release,
+            "version": uname.version,
+            "machine": uname.machine,
+            "platform": platform.platform(),
+            "proc_version": self._read_text_file("/proc/version"),
+            # Boot cmdline can reveal BPF-blocking settings (e.g. lockdown=);
+            # secret-looking tokens are redacted before it's recorded.
+            "proc_cmdline": self._sanitize_cmdline(self._read_text_file("/proc/cmdline")),
+            "libc": " ".join(platform.libc_ver()).strip() or None,
+        }
+
+    def get_btf_info(self) -> dict:
+        """Whether the kernel ships BTF — required for BCC/CO-RE on modern setups."""
+        btf_path = "/sys/kernel/btf/vmlinux"
+        present = os.path.exists(btf_path)
+        size = None
+        if present:
+            try:
+                size = os.path.getsize(btf_path)
+            except OSError:
+                size = None
+        return {"vmlinux_btf_present": present, "vmlinux_btf_bytes": size}
+
+    def get_kernel_config(self) -> dict:
+        """Curated BPF-relevant ``CONFIG_*`` values from the running kernel.
+
+        Reads ``/proc/config.gz`` (gzip) when present, otherwise
+        ``/boot/config-<release>``. Returns the source it used plus a value
+        ("y"/"m"/"n"/...) for each key in :data:`_BPF_KERNEL_CONFIG_KEYS`;
+        keys absent from the config are reported as ``None``.
+        """
+        release = os.uname().release
+        raw = None
+        source = None
+        try:
+            if os.path.exists("/proc/config.gz"):
+                with gzip.open("/proc/config.gz", "rt", errors="replace") as f:
+                    raw = f.read()
+                source = "/proc/config.gz"
+            else:
+                boot_cfg = f"/boot/config-{release}"
+                text = self._read_text_file(boot_cfg, max_bytes=2 * 1024 * 1024)
+                if text is not None:
+                    raw = text
+                    source = boot_cfg
+        except OSError:
+            raw = None
+
+        if raw is None:
+            return {"source": None, "note": "kernel config not available", "values": {}}
+
+        values: dict[str, str | None] = {k: None for k in _BPF_KERNEL_CONFIG_KEYS}
+        wanted = set(_BPF_KERNEL_CONFIG_KEYS)
+        for line in raw.splitlines():
+            line = line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, _, value = line.partition("=")
+            if key in wanted:
+                values[key] = value
+        return {"source": source, "values": values}
+
+    def get_toolchain_info(self) -> dict:
+        """Versions of the userspace pieces involved in building/loading BPF."""
+        bcc_version = None
+        try:
+            import importlib.metadata as _md
+            try:
+                bcc_version = _md.version("bcc")
+            except _md.PackageNotFoundError:
+                bcc_version = None
+        except Exception:  # noqa: BLE001 - metadata lookup is best effort
+            bcc_version = None
+        if bcc_version is None:
+            try:
+                import bcc as _bcc
+                bcc_version = getattr(_bcc, "__version__", None)
+            except Exception:  # noqa: BLE001 - bcc may be the thing that's broken
+                bcc_version = None
+        return {
+            "python_version": platform.python_version(),
+            "python_implementation": platform.python_implementation(),
+            "python_executable": sys.executable,
+            "bcc_version": bcc_version,
+            "clang_version": self._tool_version(["clang", "--version"]),
+            "llc_version": self._tool_version(["llc", "--version"]),
+            "gcc_version": self._tool_version(["gcc", "--version"]),
+            "ld_version": self._tool_version(["ld", "--version"]),
+        }
+
+    def get_kernel_headers_info(self) -> dict:
+        """Whether matching kernel headers/build tree are present (BCC fallback)."""
+        release = os.uname().release
+        build_link = f"/lib/modules/{release}/build"
+        headers_dir = f"/usr/src/linux-headers-{release}"
+        build_target = None
+        if os.path.islink(build_link):
+            try:
+                build_target = os.readlink(build_link)
+            except OSError:
+                build_target = None
+        return {
+            "modules_build_path": build_link,
+            "modules_build_present": os.path.exists(build_link),
+            "modules_build_symlink_target": build_target,
+            "usr_src_headers_path": headers_dir,
+            "usr_src_headers_present": os.path.exists(headers_dir),
+        }
+
+    def get_tracefs_info(self) -> dict:
+        """debugfs/tracefs availability and the cmd_flags tracepoint probe.
+
+        ``block_rq_complete``'s ``cmd_flags`` field is what IOTracer keys
+        ``-DHAS_CMD_FLAGS`` off, so its presence (or absence) here mirrors a
+        compile-time branch and is useful when a build fails.
+        """
+        debug_tracing = "/sys/kernel/debug/tracing"
+        tracefs = "/sys/kernel/tracing"
+        tp_format = f"{debug_tracing}/events/block/block_rq_complete/format"
+        has_cmd_flags = None
+        if os.path.exists(tp_format):
+            fmt = self._read_text_file(tp_format)
+            has_cmd_flags = ("cmd_flags" in fmt) if fmt is not None else None
+        return {
+            "debugfs_tracing_mounted": os.path.isdir(debug_tracing),
+            "tracefs_mounted": os.path.isdir(tracefs),
+            "block_rq_complete_has_cmd_flags": has_cmd_flags,
+        }
+
+    def get_cpu_info(self) -> dict:
+        """CPU brand and core counts (no frequency probe — kept dependency-light)."""
+        return {
+            "brand": self.get_cpu_brand(),
+            "cores_logical": psutil.cpu_count(logical=True),
+            "cores_physical": psutil.cpu_count(logical=False),
+        }
+
+    def get_memory_info(self) -> dict:
+        """Total/available RAM, for context on a verifier/OOM-style failure."""
+        mem = psutil.virtual_memory()
+        return {
+            "total_bytes": mem.total,
+            "available_bytes": mem.available,
+            "total_gb": round(mem.total / (1024**3), 2),
+            "available_gb": round(mem.available / (1024**3), 2),
+        }
+
+    def collect_diagnostics(
+        self,
+        error: BaseException | None = None,
+        attempted_cflags: list[str] | None = None,
+        bpf_file: str | None = None,
+        context: str | None = None,
+    ) -> dict:
+        """
+        Gather as much OS / kernel / toolchain context as possible.
+
+        Built to be robust on exactly the broken hosts it is meant to diagnose:
+        every section is collected through :meth:`_safe`, so a probe that raises
+        is recorded as an error rather than aborting the dump. The result is
+        plain JSON-serializable data.
+
+        Args:
+            error: The exception that triggered the dump (compile/load/attach
+                failure), recorded with its traceback.
+            attempted_cflags: The cflags BCC was invoked with, if known.
+            bpf_file: Path to the BPF C source that failed to build.
+            context: Short human description of what failed.
+
+        Returns:
+            dict: Structured diagnostics (see the on-disk file for the layout).
+        """
+        diagnostics: dict = {
+            "io_tracer_diagnostics": {
+                "generated_at": datetime.now().isoformat(),
+                "context": context or "BPF program could not compile or the tracer failed to run",
+                "note": (
+                    "Collected automatically because the IO Tracer could not "
+                    "compile or load its eBPF program on this host. Share this "
+                    "file with the maintainers so they can diagnose the "
+                    "incompatibility."
+                ),
+            },
+        }
+
+        if error is not None:
+            diagnostics["error"] = {
+                "type": type(error).__name__,
+                "message": str(error),
+                "traceback": "".join(
+                    traceback.format_exception(type(error), error, error.__traceback__)
+                ).strip(),
+            }
+
+        diagnostics["attempt"] = {
+            "bpf_source": bpf_file,
+            "cflags": list(attempted_cflags) if attempted_cflags is not None else None,
+            "euid": self._safe(os.geteuid, default=None),
+        }
+
+        diagnostics["bpf_environment"] = {
+            "kernel": self._safe(self.get_kernel_info),
+            "btf": self._safe(self.get_btf_info),
+            "kernel_config": self._safe(self.get_kernel_config),
+            "toolchain": self._safe(self.get_toolchain_info),
+            "kernel_headers": self._safe(self.get_kernel_headers_info),
+            "tracefs": self._safe(self.get_tracefs_info),
+        }
+
+        diagnostics["system"] = {
+            "os": self._safe(lambda: self.get_os_info(include_country=False)),
+            "cpu": self._safe(self.get_cpu_info),
+            "memory": self._safe(self.get_memory_info),
+        }
+
+        return diagnostics
+
+    def dump_failure_diagnostics(
+        self,
+        error: BaseException | None = None,
+        attempted_cflags: list[str] | None = None,
+        bpf_file: str | None = None,
+        context: str | None = None,
+        dest_dir: str | None = None,
+    ) -> str | None:
+        """
+        Collect diagnostics, write them to a local JSON file, and print a summary.
+
+        Never raises: this runs on the failure path (right before the process
+        exits), so any error here is swallowed rather than masking the original
+        BPF failure. The file is written to ``dest_dir`` if given, else the
+        current working directory, else the system temp dir — the first that is
+        writable wins.
+
+        Returns:
+            str | None: Path to the diagnostics file, or ``None`` if it could
+            not be written anywhere (the summary is still printed).
+        """
+        try:
+            diagnostics = self.collect_diagnostics(
+                error=error,
+                attempted_cflags=attempted_cflags,
+                bpf_file=bpf_file,
+                context=context,
+            )
+        except Exception as e:  # noqa: BLE001 - diagnostics must never raise
+            diagnostics = {"_collect_error": f"{type(e).__name__}: {e}"}
+
+        # default=str so anything unexpectedly non-serializable still dumps.
+        try:
+            text = json.dumps(diagnostics, indent=2, default=str)
+        except Exception:  # noqa: BLE001
+            text = repr(diagnostics)
+
+        filename = f"io-tracer-os-info_{datetime.now().strftime('%Y%m%d_%H%M%S')}.json"
+        path = None
+        candidates = [dest_dir, os.getcwd(), tempfile.gettempdir()]
+        for directory in candidates:
+            if not directory:
+                continue
+            try:
+                candidate = os.path.join(directory, filename)
+                with open(candidate, "w") as f:
+                    f.write(text)
+                path = candidate
+                break
+            except OSError:
+                continue
+
+        self._print_diagnostics_summary(diagnostics, path)
+        return path
+
+    @staticmethod
+    def _print_diagnostics_summary(diagnostics: dict, path: str | None) -> None:
+        """Print a short, human-readable highlight of the collected diagnostics."""
+        def _get(d, *keys):
+            for k in keys:
+                if not isinstance(d, dict):
+                    return None
+                d = d.get(k)
+            return d
+
+        print("\n--- IO Tracer OS information (build/run failure) ---")
+        kernel = _get(diagnostics, "bpf_environment", "kernel") or {}
+        os_sec = _get(diagnostics, "system", "os") or {}
+        distro = os_sec.get("distribution") if isinstance(os_sec, dict) else None
+        btf = _get(diagnostics, "bpf_environment", "btf") or {}
+        tool = _get(diagnostics, "bpf_environment", "toolchain") or {}
+        err = diagnostics.get("error") or {}
+
+        def _line(label, value):
+            if value not in (None, "", {}):
+                print(f"  {label}: {value}")
+
+        _line("Kernel", kernel.get("release"))
+        if isinstance(distro, dict):
+            name = " ".join(
+                str(v) for v in (distro.get("name"), distro.get("version")) if v
+            ).strip()
+            _line("Distribution", name or None)
+        _line("Architecture", kernel.get("machine"))
+        _line("BTF (vmlinux)", "present" if btf.get("vmlinux_btf_present") else "MISSING")
+        _line("clang", tool.get("clang_version"))
+        _line("bcc", tool.get("bcc_version"))
+        if err:
+            _line("Error", f"{err.get('type')}: {err.get('message')}")
+
+        if path:
+            print(f"\n  Full diagnostics written to: {path}")
+        else:
+            print("\n  (could not write the diagnostics file to disk)")
+        print(
+            "  Please send this information to io-tracer@googlegroups.com so we "
+            "can help.\n"
+        )

--- a/src/tracer/snappers/SystemSnapper.py
+++ b/src/tracer/snappers/SystemSnapper.py
@@ -396,7 +396,7 @@ class SystemSnapper:
             except ImportError:
                 # Fallback if distro package not available
                 try:
-                    with open("/etc/os-release") as f:
+                    with open("/etc/os-release", encoding="utf-8") as f:
                         os_release = {}
                         for line in f:
                             if "=" in line:
@@ -439,7 +439,7 @@ class SystemSnapper:
     def _read_text_file(path: str, max_bytes: int = 64 * 1024) -> str | None:
         """Read a (small) text file, returning ``None`` if it can't be read."""
         try:
-            with open(path, "r", errors="replace") as f:
+            with open(path, "r", encoding="utf-8", errors="replace") as f:
                 return f.read(max_bytes).strip()
         except OSError:
             return None
@@ -471,20 +471,37 @@ class SystemSnapper:
 
     @classmethod
     def _sanitize_cmdline(cls, cmdline: str | None) -> str | None:
-        """Redact secret-looking ``key=value`` tokens from a kernel cmdline.
+        """Redact secret-looking tokens from a kernel cmdline.
 
         Keeps every diagnostically useful parameter (lockdown, lsm, console, …)
-        but replaces the *value* of any token whose key looks like a secret
-        (e.g. a provisioning token occasionally passed at boot) with
-        ``<redacted>``, so the dump the user is asked to share doesn't leak it.
+        but redacts secrets (e.g. a provisioning token occasionally passed at
+        boot) so the dump the user is asked to share doesn't leak them. Handles
+        both forms:
+
+        * ``key=value`` — the value is redacted when ``key`` looks like a secret.
+        * ``--flag value`` — when a bare flag looks like a secret, the following
+          whitespace-separated token is redacted (unless it is itself a flag),
+          covering the space-separated args that can follow ``--`` on the line.
         """
         if not cmdline:
             return cmdline
+        hints = cls._CMDLINE_SECRET_KEY_HINTS
         out = []
+        expect_value = False
         for token in cmdline.split():
+            if expect_value:
+                expect_value = False
+                # The previous token was a bare secret flag; this is its value
+                # unless it's another flag (in which case the flag had no value).
+                if not token.startswith("-"):
+                    out.append("<redacted>")
+                    continue
             key, sep, _ = token.partition("=")
-            if sep and any(h in key.lower() for h in cls._CMDLINE_SECRET_KEY_HINTS):
+            if sep and any(h in key.lower() for h in hints):
                 out.append(f"{key}=<redacted>")
+            elif not sep and any(h in token.lower() for h in hints):
+                out.append(token)
+                expect_value = True
             else:
                 out.append(token)
         return " ".join(out)
@@ -531,7 +548,7 @@ class SystemSnapper:
         source = None
         try:
             if os.path.exists("/proc/config.gz"):
-                with gzip.open("/proc/config.gz", "rt", errors="replace") as f:
+                with gzip.open("/proc/config.gz", "rt", encoding="utf-8", errors="replace") as f:
                     raw = f.read()
                 source = "/proc/config.gz"
             else:
@@ -757,7 +774,7 @@ class SystemSnapper:
                 continue
             try:
                 candidate = os.path.join(directory, filename)
-                with open(candidate, "w") as f:
+                with open(candidate, "w", encoding="utf-8") as f:
                     f.write(text)
                 path = candidate
                 break

--- a/tests/test_os_info.py
+++ b/tests/test_os_info.py
@@ -1,0 +1,173 @@
+"""
+Unit tests for the OS-information / failure-diagnostics dump.
+
+When the eBPF prober cannot compile or the tracer fails to run, SystemSnapper
+collects as much of the OS / kernel / toolchain environment as possible and
+writes it to a local JSON file the user can share with the maintainers. These
+tests exercise that collection directly — no bcc, no root, no real BPF.
+
+Importing SystemSnapper transitively pulls in WriterManager ->
+ObjectStorageManager (which imports ``requests``) and SystemSnapper itself
+imports ``psutil``. Minimal CI environments install neither, so stub them
+before import (mirrors the other tests' handling of ``requests``). The
+diagnostics code only calls ``psutil`` inside individually-guarded sections, so
+a bare stub is enough for the import to succeed.
+"""
+
+import json
+import os
+import sys
+import tempfile
+import types
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+for _mod in ("requests", "psutil"):
+    if _mod not in sys.modules:
+        try:
+            __import__(_mod)
+        except ModuleNotFoundError:
+            sys.modules[_mod] = types.ModuleType(_mod)
+
+from src.tracer.snappers.SystemSnapper import SystemSnapper
+
+
+class _FakeWriteManager:
+    """Minimal stand-in; the diagnostics path never touches the writer."""
+
+
+def _make_snapper():
+    return SystemSnapper(writer_manager=_FakeWriteManager())
+
+
+class GetOsInfoTests(unittest.TestCase):
+    def test_core_fields_present(self):
+        info = _make_snapper().get_os_info(include_country=False)
+        for key in ("system", "release", "version", "machine", "hostname"):
+            self.assertIn(key, info)
+
+    def test_country_skipped_when_disabled(self):
+        # include_country=False must not perform the network geolocation call.
+        info = _make_snapper().get_os_info(include_country=False)
+        self.assertNotIn("country", info)
+
+
+class CollectDiagnosticsTests(unittest.TestCase):
+    def _collect_with_error(self):
+        snapper = _make_snapper()
+        try:
+            raise RuntimeError("verifier rejected program")
+        except RuntimeError as e:
+            return snapper.collect_diagnostics(
+                error=e,
+                attempted_cflags=["-Wno-macro-redefined", "-DHAS_CMD_FLAGS"],
+                bpf_file="/path/to/prober.c",
+                context="unit test failure",
+            )
+
+    def test_top_level_structure(self):
+        diag = self._collect_with_error()
+        for key in ("io_tracer_diagnostics", "error", "attempt",
+                    "bpf_environment", "system"):
+            self.assertIn(key, diag)
+
+    def test_error_captured_with_traceback(self):
+        diag = self._collect_with_error()
+        self.assertEqual(diag["error"]["type"], "RuntimeError")
+        self.assertEqual(diag["error"]["message"], "verifier rejected program")
+        self.assertIn("RuntimeError", diag["error"]["traceback"])
+        self.assertIn("verifier rejected program", diag["error"]["traceback"])
+
+    def test_attempt_records_inputs(self):
+        diag = self._collect_with_error()
+        self.assertEqual(diag["attempt"]["bpf_source"], "/path/to/prober.c")
+        self.assertEqual(
+            diag["attempt"]["cflags"],
+            ["-Wno-macro-redefined", "-DHAS_CMD_FLAGS"],
+        )
+
+    def test_bpf_environment_sections(self):
+        diag = self._collect_with_error()
+        for key in ("kernel", "btf", "kernel_config", "toolchain",
+                    "kernel_headers", "tracefs"):
+            self.assertIn(key, diag["bpf_environment"])
+
+    def test_system_sections_have_no_country(self):
+        diag = self._collect_with_error()
+        for key in ("os", "cpu", "memory"):
+            self.assertIn(key, diag["system"])
+        os_section = diag["system"]["os"]
+        if isinstance(os_section, dict):
+            self.assertNotIn("country", os_section)
+
+    def test_result_is_json_serializable(self):
+        diag = self._collect_with_error()
+        # Must round-trip cleanly — it is written as JSON on the failure path.
+        json.loads(json.dumps(diag))
+
+    def test_works_without_error_argument(self):
+        diag = _make_snapper().collect_diagnostics()
+        self.assertNotIn("error", diag)
+        self.assertIn("bpf_environment", diag)
+
+
+class SanitizeCmdlineTests(unittest.TestCase):
+    def test_redacts_secret_tokens_keeps_the_rest(self):
+        cmdline = (
+            "BOOT_IMAGE=/vmlinuz root=UUID=abc ro lockdown=integrity "
+            "provisioning_token=SUPERSECRET ds_secret=hunter2 quiet"
+        )
+        out = SystemSnapper._sanitize_cmdline(cmdline)
+        # Diagnostically useful params are preserved verbatim.
+        self.assertIn("lockdown=integrity", out)
+        self.assertIn("root=UUID=abc", out)
+        self.assertIn("ro", out)
+        self.assertIn("quiet", out)
+        # Secret-looking values are redacted, key kept for context.
+        self.assertIn("provisioning_token=<redacted>", out)
+        self.assertIn("ds_secret=<redacted>", out)
+        self.assertNotIn("SUPERSECRET", out)
+        self.assertNotIn("hunter2", out)
+
+    def test_handles_empty_and_none(self):
+        self.assertIsNone(SystemSnapper._sanitize_cmdline(None))
+        self.assertEqual(SystemSnapper._sanitize_cmdline(""), "")
+
+
+class DumpFailureDiagnosticsTests(unittest.TestCase):
+    def test_writes_valid_json_file(self):
+        snapper = _make_snapper()
+        with tempfile.TemporaryDirectory() as tmp:
+            try:
+                raise OSError("Failed to load BPF program")
+            except OSError as e:
+                path = snapper.dump_failure_diagnostics(
+                    error=e,
+                    attempted_cflags=["-mllvm", "-bpf-stack-size=4096"],
+                    bpf_file="/path/to/prober.c",
+                    context="BPF program failed to compile or load",
+                    dest_dir=tmp,
+                )
+
+            self.assertIsNotNone(path)
+            self.assertTrue(os.path.isfile(path))
+            self.assertEqual(os.path.dirname(path), tmp)
+            self.assertTrue(os.path.basename(path).startswith("io-tracer-os-info_"))
+
+            with open(path) as f:
+                loaded = json.load(f)
+            self.assertEqual(loaded["error"]["message"], "Failed to load BPF program")
+            self.assertEqual(loaded["attempt"]["bpf_source"], "/path/to/prober.c")
+
+    def test_never_raises_and_returns_path(self):
+        # Even with no inputs at all, the dump must succeed and produce a file.
+        snapper = _make_snapper()
+        with tempfile.TemporaryDirectory() as tmp:
+            path = snapper.dump_failure_diagnostics(dest_dir=tmp)
+            self.assertIsNotNone(path)
+            self.assertTrue(os.path.isfile(path))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_os_info.py
+++ b/tests/test_os_info.py
@@ -130,6 +130,30 @@ class SanitizeCmdlineTests(unittest.TestCase):
         self.assertNotIn("SUPERSECRET", out)
         self.assertNotIn("hunter2", out)
 
+    def test_redacts_space_separated_secret_values(self):
+        # Secrets passed as a separate token after a flag (common after `--`).
+        out = SystemSnapper._sanitize_cmdline(
+            "-- --addr 0.0.0.0:2024 --password hunter2 --verbose"
+        )
+        self.assertIn("--addr 0.0.0.0:2024", out)
+        self.assertIn("--password <redacted>", out)
+        self.assertNotIn("hunter2", out)
+        self.assertIn("--verbose", out)
+
+    def test_secret_flag_followed_by_flag_is_not_redacted(self):
+        # A secret-looking flag immediately followed by another flag has no
+        # value to redact — the following flag must be preserved.
+        out = SystemSnapper._sanitize_cmdline("--token --verbose quiet")
+        self.assertEqual(out, "--token --verbose quiet")
+
+    def test_does_not_overredact_benign_cmdline(self):
+        # The real boot cmdline observed in this environment has no secrets.
+        cmd = (
+            "console=ttyS0 reboot=k panic=1 nomodule random.trust_cpu=1 "
+            "ipv6.disable=1 -- --firecracker-init --addr 0.0.0.0:2024"
+        )
+        self.assertEqual(SystemSnapper._sanitize_cmdline(cmd), cmd)
+
     def test_handles_empty_and_none(self):
         self.assertIsNone(SystemSnapper._sanitize_cmdline(None))
         self.assertEqual(SystemSnapper._sanitize_cmdline(""), "")


### PR DESCRIPTION
## Summary

When the eBPF prober fails to **compile/load** or its probes fail to **attach**, the tracer previously exited with a generic *"Your device is incompatible … please notify us"* message and **nothing for a maintainer to act on**. Diagnosing the incompatibility meant a slow back-and-forth asking for the kernel version, BTF availability, toolchain versions, and so on.

This change makes the tracer **dump as much OS / kernel / toolchain information as possible** on those failure paths, write it to a local JSON file, and print a short summary — so the user has something concrete to share and the maintainers can diagnose the problem in one round.

## What it does

On a compile/load failure (`IOTracer.__init__`) or a probe-attach failure (`IOTracer.trace()`), the tracer calls `SystemSnapper.dump_failure_diagnostics()`, which:

- Collects diagnostics through individually-guarded probes (best effort — a missing `/proc` entry or absent tool is recorded, never aborts the dump).
- Writes them to `io-tracer-os-info_<timestamp>.json` (current dir, falling back to the system temp dir).
- Prints a console summary ending with the maintainer contact.

### Captured data
- **Triggering error** + full traceback, plus the exact `cflags` and BPF source path that were attempted.
- **Kernel**: `uname` fields, `/proc/version`, `/proc/cmdline` (surfaces BPF-blocking boot params such as `lockdown=`), libc version.
- **BTF**: whether `/sys/kernel/btf/vmlinux` is present (required by BCC/CO-RE).
- **Kernel config**: curated BPF-relevant `CONFIG_*` values from `/proc/config.gz` or `/boot/config-<release>` (`CONFIG_BPF_SYSCALL`, `CONFIG_DEBUG_INFO_BTF`, `CONFIG_KPROBES`, …).
- **Toolchain**: Python, `bcc`, `clang`/`llc`, `gcc`, `ld` versions (`clang` is what BCC shells out to).
- **Kernel headers**: presence of `/lib/modules/<release>/build` and `/usr/src/linux-headers-<release>`.
- **tracefs**: debugfs/tracefs mount state and whether `block_rq_complete` exposes `cmd_flags` (the field `-DHAS_CMD_FLAGS` keys off).
- **System specs**: OS/distribution, CPU, memory.

## Privacy & robustness
- The IP-geolocation **country lookup is skipped** on this path so a slow/unreachable network can't stall the dump.
- **Network interface (IP/MAC) info is not included**, and secret-looking `key=value` tokens in `/proc/cmdline` are **redacted**.
- Tool-version probes use a short **2s timeout** to bound worst-case exit latency.
- The dump **never raises** — any error inside it is swallowed so it can't mask the original BPF failure.
- The file is written **locally only** (not auto-uploaded).

## Changes
- `src/tracer/snappers/SystemSnapper.py`: extract `get_os_info()`; add `collect_diagnostics()`, `dump_failure_diagnostics()`, and the per-section collectors.
- `src/tracer/IOTracer.py`: dump diagnostics on BPF init failure and probe-attach failure.
- `tests/test_os_info.py`: new pure-Python unit tests (stub `psutil`/`requests`, no bcc/root needed).
- `docs/COMPATIBILITY_FIXES.md`: document the new behavior.

## Testing
- `python3 -m unittest discover -s tests` → **129 passed, 13 skipped** (the skipped ones require bcc/root).
- New `test_os_info.py` covers the OS-info extraction, full diagnostics structure + JSON-serializability, error/traceback capture, the cmdline secret redaction, and the on-disk dump file.
- An adversarial multi-dimension review (correctness / CI-dependency safety / robustness-privacy) found no correctness or CI-breaking issues; the two confirmed robustness/privacy findings (exit latency and `/proc/cmdline` exposure) are addressed by the 2s timeout and the cmdline redaction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V8BAVoLMNgr29AwZTvYXZj

---
_Generated by [Claude Code](https://claude.ai/code/session_01V8BAVoLMNgr29AwZTvYXZj)_